### PR TITLE
chore: add sentry environment configuration

### DIFF
--- a/apps/mobile-mzima-client/src/app/core/intefaces/env.interface.ts
+++ b/apps/mobile-mzima-client/src/app/core/intefaces/env.interface.ts
@@ -10,5 +10,6 @@ export interface EnvConfigInterface {
   export_polling_interval: number;
   gtm_key: string;
   sentry_dsn: string;
+  sentry_environment?: string;
   sentry_debug_mode: boolean;
 }

--- a/apps/mobile-mzima-client/src/env.json
+++ b/apps/mobile-mzima-client/src/env.json
@@ -10,5 +10,6 @@
   "export_polling_interval": 30000,
   "gtm_key": "GTM-TXQLHS5",
   "sentry_dsn": "",
+  "sentry_environment": "",
   "sentry_debug_mode": false
 }

--- a/apps/web-mzima-client/src/app/app.module.ts
+++ b/apps/web-mzima-client/src/app/app.module.ts
@@ -30,6 +30,7 @@ export function loadSentryFactory(envService: EnvService) {
       Sentry.init({
         dsn: envService.environment.sentry_dsn,
         debug: envService.environment.sentry_debug_mode,
+        environment: envService.environment.sentry_environment || 'default',
         integrations: [
           new BrowserTracing({
             tracePropagationTargets: [],

--- a/apps/web-mzima-client/src/app/core/interfaces/env.interface.ts
+++ b/apps/web-mzima-client/src/app/core/interfaces/env.interface.ts
@@ -10,5 +10,6 @@ export interface EnvConfigInterface {
   export_polling_interval: number;
   gtm_key: string;
   sentry_dsn: string;
+  sentry_environment?: string;
   sentry_debug_mode: boolean;
 }

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -10,5 +10,6 @@
   "export_polling_interval": 30000,
   "gtm_key": "GTM-TXQLHS5",
   "sentry_dsn": "",
+  "sentry_environment": "",
   "sentry_debug_mode": false
 }

--- a/docker/env.json.template
+++ b/docker/env.json.template
@@ -16,6 +16,7 @@
     "oauth_client_id": "{{ default .Env.OAUTH_CLIENT_ID "ushahidiui" }}",
     "oauth_client_secret": "{{ default .Env.OAUTH_CLIENT_SECRET "35e7f0bca957836d05ca0492211b0ac707671261" }}",
     "sentry_dsn": "{{ default .Env.SENTRY_DSN "" }}",
+    "sentry_environment": "{{ default .Env.SENTRY_ENVIRONMENT "" }}",
     "sentry_debug_mode": {{ default .Env.SENTRY_DEBUG_MODE "false" }},
     "export_polling_interval": {{ default .Env.EXPORT_POLLING_INTERVAL "30000" }},
     "gtm_key": "{{ default .Env.GTM_CONTAINER_ID "" }}"


### PR DESCRIPTION
This is a useful configuration bit to separate different environments in Sentry.

Did I add it properly?