### PR TITLE
Icon (mobile menu) and Search Placeholder Text In Toolbar Change

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/toolbar/toolbar.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/toolbar/toolbar.component.ts
@@ -103,7 +103,7 @@ export class ToolbarComponent implements OnInit {
       },
       {
         label: 'nav.help_support',
-        icon: 'auth',
+        icon: 'info',
         visible: true,
         action: () => this.openSupportModal(),
       },

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -565,7 +565,7 @@
     "restore_defaults": "Restore Defaults",
     "apply_filters": "Apply",
     "save_to_set": "Save to Set",
-    "search": "Search",
+    "search": "Search post by keyword",
     "date_range": "Date range",
     "who_its_visible_to": "Who it's visible to",
     "status": "Status",


### PR DESCRIPTION
Minor edit the support icon form 'auth' to 'info' in the mobile menu toolbar .

Edited the search placeholder text from Search to Search post by keyword. The change is only for English language.