### PR TITLE
chore: add source maps in production builds

### DIFF
--- a/apps/web-mzima-client/project.json
+++ b/apps/web-mzima-client/project.json
@@ -68,6 +68,7 @@
               "with": "apps/web-mzima-client/src/environments/environment.prod.ts"
             }
           ],
+          "sourceMap": true,
           "outputHashing": "all"
         },
         "development": {
@@ -75,7 +76,12 @@
           "optimization": false,
           "vendorChunk": true,
           "extractLicenses": false,
-          "sourceMap": true,
+          "sourceMap": {
+            "scripts": true,
+            "styles": true,
+            "hidden": false,
+            "vendor": true
+          },
           "namedChunks": true
         }
       },


### PR DESCRIPTION
Enables source maps with our production (and staging) deployments, adds vendor source maps to development environments.