### PR TITLE
[USH-787] Map view: Translation dropdown is being covered by cross button in "Edit Post" modal

### DIFF
--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -308,7 +308,7 @@ export class MapComponent extends MainViewComponent implements OnInit {
   ): void {
     this.dialog.open(PostDetailsModalComponent, {
       width: '100%',
-      maxWidth: 576,
+      maxWidth: 626,
       data: { post, color, twitterId, editable },
       height: 'auto',
       maxHeight: '90vh',

--- a/apps/web-mzima-client/src/app/map/post-details-modal/post-details-modal.component.scss
+++ b/apps/web-mzima-client/src/app/map/post-details-modal/post-details-modal.component.scss
@@ -41,6 +41,14 @@
           bottom: -16px;
         }
       }
+
+      app-post-edit {
+        ::ng-deep {
+          .form-row {
+            margin-right: 40px;
+          }
+        }
+      }
     }
 
     .post-item-page {


### PR DESCRIPTION
[[USH-787] Map view: Translation dropdown is being covered by cross button in "Edit Post" modal](https://linear.app/ushahidi/issue/USH-787/map-view-translation-dropdown-is-being-covered-by-cross-button-in-edit)

@OlehSol9856, @tuxpiper , @AmTryingMyBest , @Ifycode  could you review this PR. 