### PR TITLE
Move short text field

### DIFF
--- a/e2e-testing/cypress/functions/PostFunctions.js
+++ b/e2e-testing/cypress/functions/PostFunctions.js
@@ -18,7 +18,7 @@ class PostFunctions {
       .find('input.mat-input-element')
       .type(this.postTitle);
     cy.get(PostLocators.descField).type(this.postDescription);
-    // cy.get(PostLocators.shtTextField).type('Automated Short text');
+    cy.get(PostLocators.shtTextField).type('Automated Short text');
     cy.get(PostLocators.lngTextField).type('This is an automated long text response');
     cy.contains('mat-label', 'Number (Decimal) Field')
       .siblings('mat-form-field')

--- a/e2e-testing/cypress/functions/PostFunctions.js
+++ b/e2e-testing/cypress/functions/PostFunctions.js
@@ -18,7 +18,7 @@ class PostFunctions {
       .find('input.mat-input-element')
       .type(this.postTitle);
     cy.get(PostLocators.descField).type(this.postDescription);
-    cy.get(PostLocators.shtTextField).type('Automated Short text');
+    // cy.get(PostLocators.shtTextField).type('Automated Short text');
     cy.get(PostLocators.lngTextField).type('This is an automated long text response');
     cy.contains('mat-label', 'Number (Decimal) Field')
       .siblings('mat-form-field')

--- a/e2e-testing/cypress/functions/PostFunctions.js
+++ b/e2e-testing/cypress/functions/PostFunctions.js
@@ -18,7 +18,7 @@ class PostFunctions {
       .find('input.mat-input-element')
       .type(this.postTitle);
     cy.get(PostLocators.descField).type(this.postDescription);
-    cy.get(PostLocators.shtTextField).type('Automated Short text');
+
     cy.get(PostLocators.lngTextField).type('This is an automated long text response');
     cy.contains('mat-label', 'Number (Decimal) Field')
       .siblings('mat-form-field')

--- a/e2e-testing/cypress/functions/PostFunctions.js
+++ b/e2e-testing/cypress/functions/PostFunctions.js
@@ -18,8 +18,8 @@ class PostFunctions {
       .find('input.mat-input-element')
       .type(this.postTitle);
     cy.get(PostLocators.descField).type(this.postDescription);
-    cy.get(PostLocators.lngTextField).type('This is an automated long text response');
     cy.get(PostLocators.shtTextField).type('Automated Short text');
+    cy.get(PostLocators.lngTextField).type('This is an automated long text response');
     cy.contains('mat-label', 'Number (Decimal) Field')
       .siblings('mat-form-field')
       .find('input.mat-input-element')

--- a/e2e-testing/cypress/locators/PostLocators.js
+++ b/e2e-testing/cypress/locators/PostLocators.js
@@ -6,8 +6,8 @@ const PostLocators = {
   /* Input fields */
   titleField: '[data-qa="title"]',
   descField: '[data-qa="description"]',
-  lngTextField: '[data-qa="long-text field"]',
   shtTextField: '[data-qa="short-text field"]',
+  lngTextField: '[data-qa="long-text field"]',
   decimalField: '[data-qa="number-decimal field"]',
   intField: '[data-qa="number-integer field"]',
   dateField: '[data-qa="date-&-time-field"]',


### PR DESCRIPTION
The short text field response fails. Skipping it until we can figure out why, and a fix for it.