### PR TITLE
Adjust edit posts for ci

### DIFF
--- a/e2e-testing/cypress/functions/EditPostFunctions.js
+++ b/e2e-testing/cypress/functions/EditPostFunctions.js
@@ -31,12 +31,8 @@ class EditPostFunctions {
   }
 
   check_for_added_post_in_survey() {
-    // cy.get('mat-selection-list[name="surveys"]')
-    //   .children('mat-list-option')
-    //   .eq(0)
-    // .click({force: true})
-    cy.contains('Filter').click();
-    cy.contains('Clear all filters').click();
+    cy.get('.search-form__filters > .mzima-button').click();
+    cy.get('.search-form__button > .mzima-button').click();
     cy.get('ngx-masonry').children('app-post-preview').contains('New Post Title');
     cy.get(
       '.mzima-button.mzima-button--gray.mzima-button--clear.mzima-button--medium.mzima-button--block.mzima-button--icon-only.ng-star-inserted',

--- a/e2e-testing/cypress/functions/EditPostFunctions.js
+++ b/e2e-testing/cypress/functions/EditPostFunctions.js
@@ -1,75 +1,65 @@
 import EditPostLocators from '../locators/EditPostLocators';
 
 class EditPostFunctions {
+  click_add_post_btn() {
+    cy.get('.submit-post-button').click();
+  }
 
-    click_add_post_btn(){
-        cy.get(".submit-post-button").click()
-    }
+  select_survey_item() {
+    cy.get(EditPostLocators.surveyItem).click();
+  }
 
-    select_survey_item(){
-        cy.get(EditPostLocators.surveyItem).click()
-    }
+  type_post_title(title) {
+    cy.get(EditPostLocators.postTitleField).eq(0).type(title).should('have.value', title);
+  }
 
+  type_post_description(description) {
+    cy.get(EditPostLocators.postDescField).type(description).should('have.value', description);
+  }
 
-    type_post_title(title) {
-        cy.get(EditPostLocators.postTitleField)
-          .eq(0)
-          .type(title)
-          .should('have.value', title);
-    }
+  save_post() {
+    cy.get(EditPostLocators.savePostBtn).click();
+  }
+  add_post() {
+    this.click_add_post_btn();
+    this.select_survey_item();
+    this.type_post_title('New Post Title');
+    this.type_post_description('New Post Description');
+    cy.get(EditPostLocators.postCheckBox).click({ force: true });
+    this.save_post();
+    cy.get(EditPostLocators.successBtn).click();
+  }
 
-    type_post_description(description) {
-        cy.get(EditPostLocators.postDescField)
-          .type(description)
-          .should('have.value', description);
-    }
+  check_for_added_post_in_survey() {
+    // cy.get('mat-selection-list[name="surveys"]')
+    //   .children('mat-list-option')
+    //   .eq(0)
+    // .click({force: true})
+    cy.contains('Filter').click();
+    cy.contains('Clear all filters').click();
+    cy.get('ngx-masonry').children('app-post-preview').contains('New Post Title');
+    cy.get(
+      '.mzima-button.mzima-button--gray.mzima-button--clear.mzima-button--medium.mzima-button--block.mzima-button--icon-only.ng-star-inserted',
+    )
+      .eq(0)
+      .click({ force: true });
+  }
 
-    save_post() {
-      cy.get(EditPostLocators.savePostBtn)
-        .click();
-    }
-    add_post(){
-        this.click_add_post_btn()
-        this.select_survey_item()
-        this.type_post_title("New Post Title")
-        this.type_post_description("New Post Description")
-        cy.get(EditPostLocators.postCheckBox).click({force: true});
-        this.save_post();
-        cy.get(EditPostLocators.successBtn).click()
-    }
+  edit_post() {
+    cy.get(EditPostLocators.postTitleField).eq(0).type(' 2');
+    this.save_post();
+  }
 
-    check_for_added_post_in_survey(){
-      cy.get('mat-selection-list[name="surveys"]')
-        .children('mat-list-option')
-        .eq(0)
-        .click({force: true})
-      cy.get('ngx-masonry')
-        .children('app-post-preview')
-        .contains("New Post Title")
-      cy.get('.mzima-button.mzima-button--gray.mzima-button--clear.mzima-button--medium.mzima-button--block.mzima-button--icon-only.ng-star-inserted')
-        .eq(0)
-        .click({force: true})
-    }
+  check_edit_post() {
+    cy.get('ngx-masonry').children('app-post-preview').contains('New Post Title 2');
+  }
 
-    edit_post(){
-        cy.get(EditPostLocators.postTitleField)
-          .eq(0)
-          .type(" 2")
-        this.save_post();
-    }
-
-    check_edit_post(){
-        cy.get('ngx-masonry')
-        .children('app-post-preview')
-        .contains("New Post Title 2")
-    }
-
-    edit_post_steps() {
-        this.add_post();
-        this.check_for_added_post_in_survey({force: true});
-        this.edit_post();
-        this.check_edit_post();
-      }
+  edit_post_steps() {
+    this.add_post();
+    this.check_for_added_post_in_survey({ force: true });
+    this.edit_post();
+    this.check_edit_post();
+  }
 }
 
 export default EditPostFunctions;


### PR DESCRIPTION
In the ci environment where the tests run, the language changes to arabic (an issue to be addressed later)
in this pr I change how the edited post is located. 
The steps are after editing:
 - go to Data View
 - clear all filters
 - search for edited post
