### PR TITLE
[USH-918] Rename menu-list-non-links Angular component name to better reflect its purpose 

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/fragments/menu-modal-popups/menu-modal-popups.component.spec.ts
+++ b/apps/web-mzima-client/src/app/shared/components/fragments/menu-modal-popups/menu-modal-popups.component.spec.ts
@@ -1,16 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MenuListNonLinksComponent } from './menu-list-non-links.component';
+import { MenuModalPopupsComponent } from './menu-modal-popups.component';
 
-describe('MenuListNonLinksComponent', () => {
-  let component: MenuListNonLinksComponent;
-  let fixture: ComponentFixture<MenuListNonLinksComponent>;
+describe('MenuModalPopupsComponent', () => {
+  let component: MenuModalPopupsComponent;
+  let fixture: ComponentFixture<MenuModalPopupsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [MenuListNonLinksComponent],
+      declarations: [MenuModalPopupsComponent],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(MenuListNonLinksComponent);
+    fixture = TestBed.createComponent(MenuModalPopupsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });


### PR DESCRIPTION
This fix is to improve the solution for this issue #624 
Fix:
Edited the component names in the menu-modal-popups.component.spec.ts to match the updated names.