### PR TITLE
[USH-959] Wrong Link Redirection when clicking the Documentation Link (Mzima Web Client)

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
@@ -38,7 +38,7 @@ export class SupportModalComponent extends BaseComponent {
         title: this.translate.instant('app.documentation.title'),
         description: this.translate.instant('app.documentation.description'),
         action: () => {
-          this.openUrl('https://docs.ushahidi.com/platform-user-manual/v/mzima');
+          this.openUrl('https://docs.ushahidi.com/ushahidi-platform-user-manual');
           this.closeModal();
         },
       },

--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
@@ -38,7 +38,7 @@ export class SupportModalComponent extends BaseComponent {
         title: this.translate.instant('app.documentation.title'),
         description: this.translate.instant('app.documentation.description'),
         action: () => {
-          this.openUrl('https://docs.ushahidi.com/platform-user-manual/v/mzima');
+          this.openUrl('https://docs.ushahidi.com/platform-user-manual');
           this.closeModal();
         },
       },

--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
@@ -38,7 +38,7 @@ export class SupportModalComponent extends BaseComponent {
         title: this.translate.instant('app.documentation.title'),
         description: this.translate.instant('app.documentation.description'),
         action: () => {
-          this.openUrl('https://docs.ushahidi.com/ushahidi-platform-user-manual');
+          this.openUrl('https://docs.ushahidi.com/platform-user-manual/v/mzima');
           this.closeModal();
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27613,7 +27613,7 @@
         "@nrwl/webpack": "16.0.2",
         "@nx/devkit": "16.0.2",
         "@nx/js": "16.0.2",
-        "autoprefixer": "10.4.5",
+        "autoprefixer": "^10.4.9",
         "babel-loader": "^9.1.2",
         "chalk": "^4.1.0",
         "chokidar": "^3.5.1",
@@ -29511,8 +29511,7 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+      "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
       "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
       "dev": true,
       "requires": {
@@ -37613,7 +37612,7 @@
         "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
         "@csstools/postcss-trigonometric-functions": "^1.0.2",
         "@csstools/postcss-unset-value": "^1.0.2",
-        "autoprefixer": "10.4.5",
+        "autoprefixer": "^10.4.8",
         "browserslist": "^4.21.3",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27613,7 +27613,7 @@
         "@nrwl/webpack": "16.0.2",
         "@nx/devkit": "16.0.2",
         "@nx/js": "16.0.2",
-        "autoprefixer": "^10.4.9",
+        "autoprefixer": "10.4.5",
         "babel-loader": "^9.1.2",
         "chalk": "^4.1.0",
         "chokidar": "^3.5.1",
@@ -29511,7 +29511,8 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
       "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
       "dev": true,
       "requires": {
@@ -37612,7 +37613,7 @@
         "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
         "@csstools/postcss-trigonometric-functions": "^1.0.2",
         "@csstools/postcss-unset-value": "^1.0.2",
-        "autoprefixer": "^10.4.8",
+        "autoprefixer": "10.4.5",
         "browserslist": "^4.21.3",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",


### PR DESCRIPTION
Replaced the link that directed to GitBook (previous) to the official Mzima Documentation (current)