### PR TITLE
[USH-967] README.md git checkout typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Further help: Visit the [Nx Documentation](https://nx.dev) to learn more
 Except you are requested to create your branch from another branch, always create your new branch from the `development` branch:
 
 ````
-git checkout develop
+git checkout development
 ````
 
 ````


### PR DESCRIPTION
Fixed a typo where readme.md file shows 'git develop' instead of 'git development'