### PR TITLE
"Members" should be able to delete their own contact

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/account-settings-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/account-settings-modal.component.ts
@@ -254,13 +254,14 @@ export class AccountSettingsModalComponent implements OnInit {
   }
 
   public async deleteContact(id: number): Promise<void> {
+    const askSwitch = this.contacts.find((contact) => (contact.id = id))?.can_notify;
     const dialogRef = this.dialog.open(DeleteContactModalComponent, {
       width: '100%',
       maxWidth: 576,
       panelClass: ['modal', 'select-languages-modal'],
       data: {
         contactId: id,
-        contacts: this.contacts,
+        contacts: askSwitch ? this.contacts : [],
       },
     });
 

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.html
@@ -17,9 +17,17 @@
 
 <mat-dialog-content class="">
   <div class="form-row">
-    <div class="instructions">{{ 'user_profile.nav.delete_contact.instructions' | translate }}</div>
+    <div class="instructions">
+      {{ 'user_profile.nav.delete_contact.instructions' | translate }}
+      {{
+        (this.notificationSwitches.length > 0
+          ? 'user_profile.nav.delete_contact.switch_instructions'
+          : ''
+        ) | translate
+      }}
+    </div>
   </div>
-  <div class="form-row">
+  <div class="form-row" *ngIf="this.notificationSwitches.length > 0">
     <div class="contact-method" *ngFor="let contact of this.contacts; let i = index">
       <mat-slide-toggle [(ngModel)]="notificationSwitches[i]" [data-qa]="'contact-notify-toggle'">
         {{ contact.contact }}

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.html
@@ -19,6 +19,13 @@
   <div class="form-row">
     <div class="instructions">{{ 'user_profile.nav.delete_contact.instructions' | translate }}</div>
   </div>
+  <div class="form-row">
+    <div class="contact-method" *ngFor="let contact of this.contacts; let i = index">
+      <mat-slide-toggle [(ngModel)]="notificationSwitches[i]" [data-qa]="'contact-notify-toggle'">
+        {{ contact.contact }}
+      </mat-slide-toggle>
+    </div>
+  </div>
   <div class="form-row"></div>
 </mat-dialog-content>
 

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.html
@@ -1,33 +1,15 @@
-<mzima-client-button
-  tabindex="-1"
-  fill="outline"
-  [iconOnly]="true"
-  color="light-gray"
-  [data-qa]="'btn-close'"
-  class="modal__close-btn"
-  [mat-dialog-close]="false"
-  ariaLabel="{{ 'modal.button.close' | translate }}"
+<strong mat-dialog-title class="title" [data-qa]="'task-modal-title'"
+  >{{ 'user_profile.nav.delete_contact.title' | translate }}
+  {{ 'user_profile.nav.delete_contact.title_subject.' + this.data.contactType | translate }}</strong
 >
-  <mat-icon icon svgIcon="close"></mat-icon>
-</mzima-client-button>
 
-<strong mat-dialog-title class="title" [data-qa]="'task-modal-title'">{{
-  'user_profile.nav.delete_contact.title' | translate
-}}</strong>
-
-<mat-dialog-content class="">
+<mat-dialog-content class="delete-contact-modal">
   <div class="form-row">
     <div class="instructions">
       {{ 'user_profile.nav.delete_contact.instructions' | translate }}
-      {{
-        (this.notificationSwitches.length > 0
-          ? 'user_profile.nav.delete_contact.switch_instructions'
-          : ''
-        ) | translate
-      }}
     </div>
   </div>
-  <div class="form-row" *ngIf="this.notificationSwitches.length > 0">
+  <div class="form-row">
     <div class="contact-method" *ngFor="let contact of this.contacts; let i = index">
       <mat-slide-toggle [(ngModel)]="notificationSwitches[i]" [data-qa]="'contact-notify-toggle'">
         {{ contact.contact }}

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.html
@@ -1,0 +1,37 @@
+<mzima-client-button
+  tabindex="-1"
+  fill="outline"
+  [iconOnly]="true"
+  color="light-gray"
+  [data-qa]="'btn-close'"
+  class="modal__close-btn"
+  [mat-dialog-close]="false"
+  ariaLabel="{{ 'modal.button.close' | translate }}"
+>
+  <mat-icon icon svgIcon="close"></mat-icon>
+</mzima-client-button>
+
+<strong mat-dialog-title class="title" [data-qa]="'task-modal-title'">{{
+  'user_profile.nav.delete_contact.title' | translate
+}}</strong>
+
+<mat-dialog-content class="">
+  <div class="form-row">
+    <div class="instructions">{{ 'user_profile.nav.delete_contact.instructions' | translate }}</div>
+  </div>
+  <div class="form-row"></div>
+</mat-dialog-content>
+
+<div mat-dialog-actions align="end">
+  <mzima-client-button
+    fill="outline"
+    color="secondary"
+    (buttonClick)="cancel()"
+    [data-qa]="'survey-task-cancel'"
+  >
+    {{ 'user_profile.nav.delete_contact.button.cancel' | translate }}
+  </mzima-client-button>
+  <mzima-client-button type="submit" (buttonClick)="submit()" [data-qa]="'survey-task-add'">
+    {{ 'user_profile.nav.delete_contact.button.delete' | translate }}
+  </mzima-client-button>
+</div>

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.scss
@@ -1,0 +1,5 @@
+.delete-contact-modal {
+  .instructions {
+    font-size: 1.2rem;
+  }
+}

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.spec.ts
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteContactModalComponent } from './delete-contact-modal.component';
+
+describe('DeleteContactModalComponent', () => {
+  let component: DeleteContactModalComponent;
+  let fixture: ComponentFixture<DeleteContactModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DeleteContactModalComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeleteContactModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.ts
@@ -21,11 +21,13 @@ export class DeleteContactModalComponent {
     private matDialogRef: MatDialogRef<DeleteContactModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: DeleteContactModalData,
   ) {
-    // Create an array of can_notify booleans, excluding the contact to be deleted.
-    this.contacts = this.data.contacts.filter((contact) => contact.id != this.data.contactId);
-    this.contacts.forEach((contact) => {
-      this.notificationSwitches.push(contact.can_notify);
-    });
+    if (this.data.contacts) {
+      // Create an array of can_notify booleans, excluding the contact to be deleted.
+      this.contacts = this.data.contacts.filter((contact) => contact.id != this.data.contactId);
+      this.contacts.forEach((contact) => {
+        this.notificationSwitches.push(contact.can_notify);
+      });
+    }
   }
 
   cancel() {
@@ -33,7 +35,7 @@ export class DeleteContactModalComponent {
   }
 
   submit() {
-    // Empty contacts array and then fill with modified contacts for updating.
+    // Empty contacts array and then fill with only modified contacts for updating.
     this.contacts = [];
     this.data.contacts
       .filter((contact) => contact.id != this.data.contactId)

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.ts
@@ -1,5 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ContactsInterface } from '@mzima-client/sdk';
+
+export interface DeleteContactModalData {
+  contacts: ContactsInterface[];
+  contactId: number;
+}
 
 @Component({
   selector: 'app-delete-contact-modal',
@@ -7,13 +14,36 @@ import { MatDialogRef } from '@angular/material/dialog';
   styleUrls: ['./delete-contact-modal.component.scss'],
 })
 export class DeleteContactModalComponent {
-  constructor(private matDialogRef: MatDialogRef<DeleteContactModalComponent>) {}
+  public notificationSwitches: boolean[] = [];
+  public contacts: ContactsInterface[] = [];
+
+  constructor(
+    private matDialogRef: MatDialogRef<DeleteContactModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: DeleteContactModalData,
+  ) {
+    // Create an array of can_notify booleans, excluding the contact to be deleted.
+    this.contacts = this.data.contacts.filter((contact) => contact.id != this.data.contactId);
+    this.contacts.forEach((contact) => {
+      this.notificationSwitches.push(contact.can_notify);
+    });
+  }
 
   cancel() {
     this.matDialogRef.close();
   }
 
   submit() {
-    this.matDialogRef.close();
+    // Empty contacts array and then fill with modified contacts for updating.
+    this.contacts = [];
+    this.data.contacts
+      .filter((contact) => contact.id != this.data.contactId)
+      .forEach((contact, i) => {
+        if (contact.can_notify !== this.notificationSwitches[i]) {
+          contact.can_notify = this.notificationSwitches[i];
+          this.contacts.push(contact);
+        }
+      });
+
+    this.matDialogRef.close(this.contacts);
   }
 }

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.ts
@@ -6,6 +6,7 @@ import { ContactsInterface } from '@mzima-client/sdk';
 export interface DeleteContactModalData {
   contacts: ContactsInterface[];
   contactId: number;
+  contactType: string;
 }
 
 @Component({

--- a/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/account-settings-modal/delete-contact-modal/delete-contact-modal.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-delete-contact-modal',
+  templateUrl: './delete-contact-modal.component.html',
+  styleUrls: ['./delete-contact-modal.component.scss'],
+})
+export class DeleteContactModalComponent {
+  constructor(private matDialogRef: MatDialogRef<DeleteContactModalComponent>) {}
+
+  cancel() {
+    this.matDialogRef.close();
+  }
+
+  submit() {
+    this.matDialogRef.close();
+  }
+}

--- a/apps/web-mzima-client/src/app/shared/components/index.ts
+++ b/apps/web-mzima-client/src/app/shared/components/index.ts
@@ -32,3 +32,4 @@ export * from './page-not-found/page-not-found.component';
 export * from './share-modal/share-modal.component';
 export * from './onboarding/onboarding.component';
 export * from './notification/notification.component';
+export * from './account-settings-modal/delete-contact-modal/delete-contact-modal.component';

--- a/apps/web-mzima-client/src/app/shared/shared.module.ts
+++ b/apps/web-mzima-client/src/app/shared/shared.module.ts
@@ -51,6 +51,7 @@ import {
   ShareAndDonateComponent,
   AccountAndLogoutComponent,
 } from './components';
+import { DeleteContactModalComponent } from './components/account-settings-modal/delete-contact-modal/delete-contact-modal.component';
 import { AccessDeniedComponent } from './components/access-denied/access-denied.component';
 import { CollectionItemModule } from './components/collection-item/collection-item.module';
 import { FilterControlModule } from './components/filter-control/filter-control.module';
@@ -91,6 +92,7 @@ const components = [
   NotificationComponent,
   AccessDeniedComponent,
   SafePipe,
+  DeleteContactModalComponent,
 ];
 
 const modules = [

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -1641,7 +1641,7 @@
           "email" : "Email",
           "phone" : "Phone"
         },
-        "instructions" : "Deleting means that from now you will not be able to receive notifications on your phone number. But you can switch notifications to your email address below.",
+        "instructions" : "Deleting means that from now you will not be able to receive notifications on your phone number. But you can switch notifications to a contact method below.",
         "button" : {
           "delete" : "Delete",
           "cancel" : "Cancel"

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -1634,7 +1634,19 @@
     },
     "nav": {
       "account_settings": "Account settings",
-      "notifications_settings": "Notifications settings"
+      "notifications_settings": "Notifications settings",
+      "delete_contact" : {
+        "title" : "Delete your",
+        "title_subject" : {
+          "email" : "Email",
+          "phone" : "Phone"
+        },
+        "instructions" : "Deleting means that from now you will not be able to receive notifications on your phone number. But you can switch notifications to your email address below.",
+        "button" : {
+          "delete" : "Delete",
+          "cancel" : "Cancel"
+        }  
+      }
     }
   },
   "user_create": {

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -1641,7 +1641,8 @@
           "email" : "Email",
           "phone" : "Phone"
         },
-        "instructions" : "Deleting means that from now you will not be able to receive notifications on your phone number. But you can switch notifications to your email address below.",
+        "instructions" : "Deleting means that from now you will not be able to receive notifications on your phone number.",
+        "switch_instructions" : "But you can switch notifications to your email address below.",
         "button" : {
           "delete" : "Delete",
           "cancel" : "Cancel"

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -1641,8 +1641,7 @@
           "email" : "Email",
           "phone" : "Phone"
         },
-        "instructions" : "Deleting means that from now you will not be able to receive notifications on your phone number.",
-        "switch_instructions" : "But you can switch notifications to your email address below.",
+        "instructions" : "Deleting means that from now you will not be able to receive notifications on your phone number. But you can switch notifications to your email address below.",
         "button" : {
           "delete" : "Delete",
           "cancel" : "Cancel"


### PR DESCRIPTION
Creates the ability for users to switch contact methods if they try to delete a contact method that they receive notifications on. There is functionality in the designs which is out of scope for the ticket, and I have moved into a new ticket. (https://linear.app/ushahidi/issue/USH-1104/how-we-handle-notifications-should-be-revised-based-on-designs)

Associated Tickets: 
 
https://linear.app/ushahidi/issue/USH-941/update-delete-contacts
https://linear.app/ushahidi/issue/USH-888/members-should-be-able-to-delete-their-own-contact