### PR TITLE
1070 hidden field indicator

### DIFF
--- a/apps/web-mzima-client/src/app/core/enums/icons.ts
+++ b/apps/web-mzima-client/src/app/core/enums/icons.ts
@@ -74,4 +74,5 @@ export enum Icons {
   infoCircle = 'info-circle',
   thumbUp = 'thumb-up',
   ellipses = 'ellipses',
+  https = 'https',
 }

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
@@ -70,6 +70,13 @@
             *ngFor="let field of task.fields | sortByField : 'priority' : 'asc'; let i = index"
           >
             <mat-label>
+              <mat-icon
+                aria-label="Field responses will be private"
+                *ngIf="field.response_private"
+                icon
+                svgIcon="https"
+                class="field__icon"
+              ></mat-icon>
               {{ field?.translations[activeLanguage]?.label || field?.label }}
               <span class="color-accent" *ngIf="field?.required">*</span>
             </mat-label>

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
@@ -61,6 +61,10 @@
     display: block;
     margin-bottom: 8px;
   }
+  .field__icon {
+    vertical-align: middle;
+    display: inline;
+  }
 }
 
 .tags {

--- a/apps/web-mzima-client/src/assets/icons/https.svg
+++ b/apps/web-mzima-client/src/assets/icons/https.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_3952_99703)">
+<path d="M18 8H17V6C17 3.24 14.76 1 12 1C9.24 1 7 3.24 7 6V8H6C4.9 8 4 8.9 4 10V20C4 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V10C20 8.9 19.1 8 18 8ZM12 17C10.9 17 10 16.1 10 15C10 13.9 10.9 13 12 13C13.1 13 14 13.9 14 15C14 16.1 13.1 17 12 17ZM9 8V6C9 4.34 10.34 3 12 3C13.66 3 15 4.34 15 6V8H9Z" fill="black"/>
+</g>
+<defs>
+<clipPath id="clip0_3952_99703">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
This PR adds a lock-icon to the labels in the survey-forms when a field is private.

Issue: https://linear.app/ushahidi/issue/USH-1070/no-indicator-for-what-fields-in-a-survey-that-are-private