### PR TITLE
Pulling the deployment name and adding it to the sender-field in the UI

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-conversation/post-conversation.component.html
+++ b/apps/web-mzima-client/src/app/post/post-conversation/post-conversation.component.html
@@ -6,7 +6,9 @@
     <div class="message {{ message.direction }}">
       <div class="message--{{ message.direction }}">
         <div class="message--header">
-          <span class="highlighted">{{ message.contact.contact }}</span>
+          <span class="highlighted">{{
+            message.direction === 'incoming' ? message.contact.contact : sender
+          }}</span>
           <span class="date">{{ message.created | dateAgo }}</span>
           <span class="highlighted">via {{ message.type }}</span>
         </div>

--- a/apps/web-mzima-client/src/app/post/post-conversation/post-conversation.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-conversation/post-conversation.component.ts
@@ -7,7 +7,9 @@ import {
   PostResult,
   PostPropertiesInterface,
 } from '@mzima-client/sdk';
+import { SessionService } from '@services';
 import { Observable, of, map } from 'rxjs';
+
 @Component({
   selector: 'app-post-conversation',
   templateUrl: './post-conversation.component.html',
@@ -21,11 +23,13 @@ export class PostConversationComponent implements OnInit {
   public currentPage: number = 1;
   public messageLimit: number = 5;
   public newMessage = new FormControl();
+  public sender: string;
 
-  constructor(private messagesService: MessagesService) {}
+  constructor(private messagesService: MessagesService, private sessionService: SessionService) {}
 
   ngOnInit(): void {
     this.getMessagesData();
+    this.getSender();
   }
 
   getMessagesData() {
@@ -43,6 +47,15 @@ export class PostConversationComponent implements OnInit {
         this.messagesTotal = results.meta.total | 0;
       });
   }
+
+  getSender() {
+    this.sessionService.deploymentInfo$.pipe().subscribe({
+      next: ({ title }) => {
+        this.sender = title;
+      },
+    });
+  }
+
   sortByDate(messages: Observable<MessageResult[]> | any) {
     return messages.pipe(
       map((data: any) => {


### PR DESCRIPTION
A small change after QA, adding the Deployment-name as the sender to the UI. Previously, the same number was visible both as sending and receiving number by mistake.