### PR TITLE
Ush 1107 - New deployment opening map with a zoom level of 0 which suppresses the map

### DIFF
--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -90,7 +90,7 @@ export class MapComponent extends MainViewComponent implements OnInit {
       mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
 
     this.leafletOptions = {
-      minZoom: 0,
+      minZoom: 1,
       maxZoom: 22,
       scrollWheelZoom: true,
       zoomControl: false,
@@ -161,7 +161,7 @@ export class MapComponent extends MainViewComponent implements OnInit {
     // Fix initial zoom flicker of map view's map when bounds exist in local storage
     const bounds = localStorage.getItem('bounds');
     if (bounds === null) {
-      this.map.setZoom(0);
+      this.map.setZoom(this.leafletOptions.zoom ?? this.leafletOptions.minZoom ?? 1);
     } else {
       const { fit, zoom, center } = JSON.parse(bounds as string);
       this.map.setMaxBounds(fit);

--- a/apps/web-mzima-client/src/app/settings/general/settings-map/settings-map.component.ts
+++ b/apps/web-mzima-client/src/app/settings/general/settings-map/settings-map.component.ts
@@ -34,7 +34,7 @@ export class SettingsMapComponent implements OnInit {
   mapConfig: MapConfigInterface;
   mapReady = false;
   maxZoom = 22; // affects the arrow on number input field for "Default zoom level"
-  minZoom = 0; // affects the arrow on number input field for "Default zoom level"
+  minZoom = 1; // affects the arrow on number input field for "Default zoom level"
   baseLayers = Object.values(mapHelper.getMapLayers().baselayers);
 
   public geocoderControl: any;


### PR DESCRIPTION
Issue: 

When a new deployment is opened for the first time, the map zoom level is set to 0. This effectively hides the map.

Fix:

I have changed the minimum zoom level from 0 to 1, which should prevent the map from disappearing. I have also modified a line that was forcing a zoom level of 0 when no bound was available, to use either the configured default zoom, or the min zoom (1) if default zoom is unavailable.