### PR TITLE
1098-Adding option to structure posts

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
@@ -1,4 +1,28 @@
-<div class="post-item-page">
+<div *ngIf="!formId" class="post-item-page">
+  <div class="page-content" *ngIf="surveys; else spinner">
+    <h1 class="survey-name">{{ 'post.unstructured.add_survey.title' | translate }}</h1>
+    <span class="info-message">
+      {{ 'post.unstructured.add_survey.info' | translate : { source: post.source } }}</span
+    >
+
+    <div class="form-row">
+      <mat-form-field appearance="outline">
+        <mat-select
+          [data-qa]="'select-survey-to-edit'"
+          disableOptionCentering
+          [(value)]="selectedSurvey"
+          placeholder="{{ 'survey.choose_survey' | translate }}"
+          (selectionChange)="formSelected()"
+        >
+          <mat-option *ngFor="let survey of surveys | async" [value]="survey">
+            {{ survey.name }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </div>
+</div>
+<div *ngIf="formId" class="post-item-page">
   <div class="page-content">
     <div class="translate-container">
       <h1 class="survey-name">{{ surveyName }}</h1>

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
@@ -190,3 +190,11 @@
     flex-direction: row;
   }
 }
+
+.info-message {
+  display: block;
+  background-color: var(--color-neutral-10);
+  border-radius: 4px;
+  padding: 20px;
+  margin-bottom: 20px;
+}

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -39,12 +39,13 @@ import {
   PostResult,
   MediaService,
   postHelpers,
+  SurveyItem,
 } from '@mzima-client/sdk';
 import { BaseComponent } from '../../base.component';
 import { preparingVideoUrl } from '../../core/helpers/validators';
 import { objectHelpers, formValidators, dateHelper } from '@helpers';
 import { PhotoRequired, PointValidator } from '../../core/validators';
-import { lastValueFrom } from 'rxjs';
+import { Observable, lastValueFrom, of } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { LanguageInterface } from '../../core/interfaces/language.interface';
 import { MatSelectChange } from '@angular/material/select';
@@ -66,7 +67,7 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
   public taskForm: FormGroup;
   public description: string;
   public title: string;
-  private formId?: number;
+  public formId?: number;
   public tasks: any[];
   public activeLanguage: string;
   private initialFormData: any;
@@ -96,6 +97,8 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
   maxImageSize: any;
   selectedLanguage: any;
   postLanguages: LanguageInterface[] = [];
+  selectedSurvey: SurveyItem;
+  public surveys: Observable<any>;
 
   constructor(
     protected override sessionService: SessionService,
@@ -133,7 +136,13 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
         this.postsService.lockPost(this.postId).subscribe();
         this.loadPostData(this.postId);
       }
+      if (!this.formId) {
+        this.surveysService.get().subscribe((result) => {
+          this.surveys = of(result.results);
+        });
+      }
     });
+
     this.translate.onLangChange.subscribe((newLang) => {
       this.activeLanguage = newLang.lang;
     });
@@ -143,7 +152,7 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['postInput'] && changes['postInput'].currentValue) {
-      this.post = this.postInput;
+      this.post = this.post ? this.post : this.postInput;
       this.formId = this.post.form_id;
       this.postId = this.post.id;
       this.loadSurveyData(this.formId!, this.post.post_content);
@@ -151,6 +160,13 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
   }
 
   loadData(): void {}
+
+  formSelected() {
+    this.formId = this.selectedSurvey.id;
+    this.post.form_id = this.selectedSurvey.id;
+    this.post.post_content = this.selectedSurvey.tasks;
+    this.loadSurveyData(this.formId, this.post.post_content);
+  }
 
   selectLanguageEmit(event: MatSelectChange) {
     this.activeLanguage = event.value.code;

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -152,7 +152,7 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['postInput'] && changes['postInput'].currentValue) {
-      this.post = this.post ? this.post : this.postInput;
+      this.post = this.postInput;
       this.formId = this.post.form_id;
       this.postId = this.post.id;
       this.loadSurveyData(this.formId!, this.post.post_content);

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -964,7 +964,7 @@
     },
     "unstructured": {
       "add_survey": {
-        "info": "<strong>This post hasn't yet been assigned to a survey within your deployment.</strong> That's because it was submitted via {{source}}, which doesn't provide a way for the author to add their post to a specific survey.",
+        "info": "This post hasn’t yet been assigned to a Survey within your Deployment. That’s because it was submitted via {{source}}, which doesn’t provide a way for the authors to add their post to a specific Survey. Assign this post to a Survey, using the form below.",
         "choose": "Which survey would you like to add this post to?",
         "title": "Add this post to a survey",
         "save_and_edit": "Add to survey & edit"


### PR DESCRIPTION
This PR makes it possible to structure posts from datasources in post-edit-view.

Designs and issue for reference: https://linear.app/ushahidi/issue/USH-1098/edit-unstructured-posts-not-working

To test: Click pen-icon in the header of a post coming from for example sms or twitter. Check both on mobile and desktop.

Note: The call to v3 is not related to structuring of posts, it is happening here: https://github.com/ushahidi/platform-client-mzima/blob/c37dd0f5c3fdfbf2929265256e1e1c363131ce3c/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts#L113