### PR TITLE
E2e fix posts tests

### DIFF
--- a/e2e-testing/cypress/functions/PostsFunctions/PostFunctions.js
+++ b/e2e-testing/cypress/functions/PostsFunctions/PostFunctions.js
@@ -29,9 +29,10 @@ class PostFunctions {
     cy.get(PostLocators.intField).type(100);
 
     // click on date field to open pop up
-    cy.get(PostLocators.dateField).click(); //the first click opens the date picker
-    cy.get(PostLocators.dateField).click(); //the second click closes the date picker
+    // cy.get(PostLocators.dateField).click(); //the first click opens the date picker
+    // cy.get(PostLocators.dateField).click(); //the second click closes the date picker
     //add a check that the field is populated with the current day's date
+    //skipping this because it has no value as a test, will add date-specific checks
 
     // cy.get('.mat-button.mat-stroked-button').click(); // click on the checkmark button to select today's date
     //this works for date&time field, not date only field. date only field has no checkmark

--- a/e2e-testing/cypress/functions/PostsFunctions/PostFunctions.js
+++ b/e2e-testing/cypress/functions/PostsFunctions/PostFunctions.js
@@ -24,12 +24,12 @@ class PostFunctions {
     this.type_post_title(this.postTitle);
     this.type_post_description(this.postDescription);
     cy.get(PostLocators.lngTextField).type('This is an automated long text response');
-    cy.get(PostLocators.shtTextField).eq(1).type('Automated Short text');
-    cy.get(PostLocators.decimalField).eq(2).type(99.9);
-    cy.get(PostLocators.intField).eq(4).type(100);
+    cy.get(PostLocators.shtTextField).type('Automated Short text');
+    cy.get(PostLocators.decimalField).type(99.9);
+    cy.get(PostLocators.intField).type(100);
 
     // click on date field to open pop up
-    cy.get(PostLocators.dateField).eq(6).click();
+    cy.get(PostLocators.dateField).click();
     cy.get('.mat-button.mat-stroked-button').click(); // click on the checkmark button to select today's date
     cy.get(PostLocators.selectFieldBtn).click();
     cy.get(PostLocators.selectFieldOption1).click();
@@ -45,12 +45,10 @@ class PostFunctions {
 
   verify_created_post_exists() {
     cy.get(PostLocators.surveySelectionList)
-        .children(PostLocators.surveySelectItem)
-        .contains("Full Length Survey-with image-field- don't delete")
-        .click({force: true})
-    cy.get(PostLocators.postPreview)
-      .children(PostLocators.postItem)
-      .contains(this.postTitle);
+      .children(PostLocators.surveySelectItem)
+      .contains("Full Length Survey-with image-field- don't delete")
+      .click({ force: true });
+    cy.get(PostLocators.postPreview).children(PostLocators.postItem).contains(this.postTitle);
   }
 }
 

--- a/e2e-testing/cypress/functions/PostsFunctions/PostFunctions.js
+++ b/e2e-testing/cypress/functions/PostsFunctions/PostFunctions.js
@@ -29,8 +29,12 @@ class PostFunctions {
     cy.get(PostLocators.intField).type(100);
 
     // click on date field to open pop up
-    cy.get(PostLocators.dateField).click();
-    cy.get('.mat-button.mat-stroked-button').click(); // click on the checkmark button to select today's date
+    cy.get(PostLocators.dateField).click(); //the first click opens the date picker
+    cy.get(PostLocators.dateField).click(); //the second click closes the date picker
+    //add a check that the field is populated with the current day's date
+
+    // cy.get('.mat-button.mat-stroked-button').click(); // click on the checkmark button to select today's date
+    //this works for date&time field, not date only field. date only field has no checkmark
     cy.get(PostLocators.selectFieldBtn).click();
     cy.get(PostLocators.selectFieldOption1).click();
     cy.get(PostLocators.radioFieldOption2).click();

--- a/e2e-testing/cypress/locators/PostsLocators/PostLocators.js
+++ b/e2e-testing/cypress/locators/PostsLocators/PostLocators.js
@@ -10,13 +10,13 @@ const PostLocators = {
   confirmContent: '[data-qa="confirm-content"]',
 
   /* Input fields */
-  titleField: '[data-qa="null"]',
+  titleField: '[ng-reflect-data-qa="title"]',
   descField: '[data-qa="description"]',
-  shtTextField: '[data-qa="null"]',
+  shtTextField: '[ng-reflect-data-qa="short-text field"]',
   lngTextField: '[data-qa="long-text field"]',
-  decimalField: '[data-qa="null"]',
-  intField: '[data-qa="null"]',
-  dateField: '[data-qa="null"]',
+  decimalField: '[ng-reflect-data-qa="number-decimal field"]',
+  intField: '[ng-reflect-data-qa="number-integer field"]',
+  dateField: '[ng-reflect-data-qa="date-field"]',
   selectFieldBtn: '[data-qa="post-item-post-selectc5394e60-350d-4948-af81-6e8bf0502761"]',
   selectFieldOption1: '[data-qa="post-item-post-select-optionS1"]',
   radioFieldOption2: '[data-qa="radio-buttons-field-r2"]',


### PR DESCRIPTION
I made quite a few changes in this PR. 
- removed the data-qa="null" selectors and replaced them with a correct selector. I noticed that data-qa="" would end up with the null value, while ng-reflect-data-qa="" would have the correct value. Idk why this happens, but to clean things up in the future we may want to correct that so that all selectors are the same. 
But for now, this works correctly. :) 
 - i removed the step that interacted with the date field. I saw this didn't add value to the test as it was. To get value out of that check, we need to verify the content of the field. 