### PR TITLE
Checking for manage-post permissions before showing sms-conversation

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
@@ -166,7 +166,12 @@
     <app-post-metadata *ngIf="post.id" [post]="post"></app-post-metadata>
   </ng-container>
 </div>
-<app-post-conversation *ngIf="post && post.source === 'SMS'" [post]="post"></app-post-conversation>
+<ng-container *ngIf="isManagePosts">
+  <app-post-conversation
+    *ngIf="post && post.source === 'SMS'"
+    [post]="post"
+  ></app-post-conversation>
+</ng-container>
 <ng-template #spinner>
   <app-spinner *ngIf="isPostLoading" class="spinner"></app-spinner>
   <p


### PR DESCRIPTION
This PR hides the conversation-window for users without manage-posts permissions.

In both data and map-view, look at a published post coming from sms. When logged out, the conversation-window should not be visible and the user can look at the post details, both in a modal in the map and in dataview. If logged in as an admin or user with manage-post-permissions, the conversations-window is visible.