### PR TITLE
[USH-1109] Role name field uneditable for protected roles

### DIFF
--- a/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.html
+++ b/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.html
@@ -6,6 +6,7 @@
       <input
         matInput
         formControlName="display_name"
+        [readonly]="role.protected"
         (ngModelChange)="setName($event)"
         placeholder="{{ 'role.placeholder.name' | translate }}"
       />


### PR DESCRIPTION
**Frontend Only fix:** Prevent admin & member names from being editable, since they are both protected.