### PR TITLE
[USH-1109] Make role name uneditable where attribute is protected

### DIFF
--- a/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.ts
+++ b/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.ts
@@ -54,7 +54,6 @@ export class RoleItemComponent implements OnInit {
       description: [''],
       permissions: [[], [Validators.required]],
       id: [null],
-      name: ['', [Validators.required]],
       protected: [false],
     });
   }
@@ -99,7 +98,6 @@ export class RoleItemComponent implements OnInit {
       id: role.id,
       display_name: role.display_name,
       description: role.description,
-      name: role.name,
       protected: role.protected,
       url: role.url,
       permissions: role.permissions,
@@ -119,7 +117,6 @@ export class RoleItemComponent implements OnInit {
     this.isFormOnSubmit = true;
     const roleBody = {
       id: this.form.value.id,
-      name: this.form.value.name,
       display_name: this.form.value.display_name,
       description: this.form.value.description,
       permissions: this.form.value.permissions,

--- a/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.ts
+++ b/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.ts
@@ -118,6 +118,7 @@ export class RoleItemComponent implements OnInit {
     const roleBody = {
       id: this.form.value.id,
       display_name: this.form.value.display_name,
+      name: this.form.value.display_name, // name: same value as display_name only on initial role add
       description: this.form.value.description,
       permissions: this.form.value.permissions,
       protected: this.form.value.protected,
@@ -133,6 +134,7 @@ export class RoleItemComponent implements OnInit {
         },
       });
     } else {
+      delete roleBody.name; // We don't want to change name property on edit/update
       this.rolesService.updateRole(this.role.id, this.form.value).subscribe({
         next: () => this.navigateToRoles(),
         error: ({ error }) => {

--- a/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.ts
+++ b/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.ts
@@ -115,17 +115,12 @@ export class RoleItemComponent implements OnInit {
 
   public save(): void {
     this.isFormOnSubmit = true;
-    const roleBody = {
-      id: this.form.value.id,
-      display_name: this.form.value.display_name,
-      name: this.form.value.display_name, // name: same value as display_name only on initial role add
-      description: this.form.value.description,
-      permissions: this.form.value.permissions,
-      protected: this.form.value.protected,
-    };
+
+    const roleBody = this.form.value;
 
     if (!this.isUpdate) {
       delete roleBody.id;
+      roleBody.name = roleBody.display_name; // name: same value as display_name only on initial role add
       this.rolesService.post(roleBody).subscribe({
         next: () => this.navigateToRoles(),
         error: ({ error }) => {
@@ -135,7 +130,7 @@ export class RoleItemComponent implements OnInit {
       });
     } else {
       roleBody.name = this.role.name; // Use role name from API - We don't want to change name property along with display_name on edit/update
-      this.rolesService.updateRole(this.role.id, this.form.value).subscribe({
+      this.rolesService.updateRole(this.role.id, roleBody).subscribe({
         next: () => this.navigateToRoles(),
         error: ({ error }) => {
           this.formErrors = error.errors.failed_validations;

--- a/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.ts
+++ b/apps/web-mzima-client/src/app/settings/roles/role-item/role-item.component.ts
@@ -134,7 +134,7 @@ export class RoleItemComponent implements OnInit {
         },
       });
     } else {
-      delete roleBody.name; // We don't want to change name property on edit/update
+      roleBody.name = this.role.name; // Use role name from API - We don't want to change name property along with display_name on edit/update
       this.rolesService.updateRole(this.role.id, this.form.value).subscribe({
         next: () => this.navigateToRoles(),
         error: ({ error }) => {


### PR DESCRIPTION
**Frontend fix (Details):** 
- On Edit/Update: Only the display_name now changes - for any role whether protected or not protected. name property does not change.
- On Add: Both display_name and name properties change.