### PR TITLE
Adding select all option to sidebar-filters

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -140,9 +140,9 @@
                 fill="clear"
                 size="small"
                 class="filter-group__head__button"
-                (buttonClick)="clearFilter('form')"
+                (buttonClick)="toggleSidebarFilters('form')"
               >
-                {{ 'nav.clear' | translate }}
+                {{ (showAllButton('form') ? 'nav.select_all' : 'nav.clear') | translate }}
               </mzima-client-button>
             </div>
             <mat-selection-list
@@ -192,9 +192,9 @@
                 fill="clear"
                 size="small"
                 class="filter-group__head__button"
-                (buttonClick)="clearFilter('source')"
+                (buttonClick)="toggleSidebarFilters('source')"
               >
-                {{ 'nav.clear' | translate }}
+                {{ (showAllButton('source') ? 'nav.select_all' : 'nav.clear') | translate }}
               </mzima-client-button>
             </div>
             <mat-selection-list name="source" class="selection-list" formControlName="source">
@@ -256,9 +256,9 @@
               fill="clear"
               size="small"
               class="filter-group__head__button"
-              (buttonClick)="clearFilter('form')"
+              (buttonClick)="toggleSidebarFilters('form')"
             >
-              {{ 'nav.clear' | translate }}
+              {{ (showAllButton('form') ? 'nav.select_all' : 'nav.clear') | translate }}
             </mzima-client-button>
           </div>
         </app-filter-control>
@@ -278,9 +278,9 @@
               fill="clear"
               size="small"
               class="filter-group__head__button"
-              (buttonClick)="clearFilter('source')"
+              (buttonClick)="toggleSidebarFilters('source')"
             >
-              {{ 'nav.clear' | translate }}
+              {{ (showAllButton('source') ? 'nav.select_all' : 'nav.clear') | translate }}
             </mzima-client-button>
           </div>
         </app-filter-control>

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -714,11 +714,33 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
 
   public clearFilter(filterName: string): void {
     this.total = 0;
-    if (filterName === 'form' || filterName === 'source') {
-      this.form.controls[filterName].patchValue(['none']);
+    this.form.controls[filterName].patchValue('');
+  }
+
+  public showAllButton(filterName: string) {
+    return (
+      JSON.stringify(this.form.controls[filterName].getRawValue()) === JSON.stringify(['none'])
+    );
+  }
+
+  public toggleSidebarFilters(filterName: string): void {
+    let newValue;
+    if (this.showAllButton(filterName)) {
+      if (filterName === 'form') {
+        newValue = this.surveyList.map((survey: any) => {
+          return survey.id;
+        });
+      }
+      if (filterName === 'source') {
+        newValue = this.sources.map((source: any) => {
+          return source.value;
+        });
+      }
     } else {
-      this.form.controls[filterName].patchValue('');
+      this.total = 0;
+      newValue = ['none'];
     }
+    this.form.controls[filterName].patchValue(newValue);
   }
 
   public searchPosts(): void {


### PR DESCRIPTION
Adding an option to toggle between "Clear" and "Select All" for the filters in the sidebar.

To test:
Applies to the filters "Surveys" and "Source" in the sidebar, both in map-view and data-view (desktop and mobile).
Initially, all checkboxes are selected, when clicking "Clear", all filters are cleared and the button change text to "Select all". When clicking "Select all", all filters are selected and the button change text to "Clear" again.

Designs (slightly adjusted in this PR to conform with what is currently used in platform for all filters): https://linear.app/ushahidi/issue/USH-1026/add-select-all-fe