### PR TITLE
USH-1122 "Unknown Form" survey type disappears when filters are cleared.

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -323,11 +323,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
     let fetchPostsWithoutFormId = false;
     if (Array.isArray(values.form)) {
       const index = values.form.findIndex((id: any) => id === 0);
-      if (index !== -1) {
-        // Remove the item with id 0
-        values.form.splice(index, 1);
-        fetchPostsWithoutFormId = true;
-      }
+      fetchPostsWithoutFormId = index !== -1;
     }
 
     const filters: any = {
@@ -675,13 +671,8 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
 
   public resetForm(filters: any = {}): void {
     // Check if this.surveyList contains an item with id 0
-    let fetchPostsWithoutFormId = false;
     const index = this.surveyList.findIndex((s) => s.id === 0);
-    if (index !== -1) {
-      // Remove the item with id 0
-      this.surveyList.splice(index, 1);
-      fetchPostsWithoutFormId = true;
-    }
+    const fetchPostsWithoutFormId = index !== -1;
 
     this.form.patchValue({
       query: '',


### PR DESCRIPTION
Bug: When user clicks on "clear filters", the survey type "Unknown Form" is removed from the bottom of the survey type list filter. 

This PR fixes this issue.

https://linear.app/ushahidi/issue/USH-1122/unknown-form-disappear-from-survey-list-after-click-on-clear-all