### PR TITLE
USH-1158 - Date/Time widgets are not behaving independently.

### DIFF
--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
@@ -143,7 +143,7 @@
           <ng-container *ngIf="field.input === 'date'">
             <div class="form-control--section">
               <app-form-control
-                id="open-date"
+                [id]="'open-date'+i"
                 color="light"
                 [label]="field?.label"
                 [required]="field?.required"
@@ -165,7 +165,7 @@
                 </ng-container>
               </app-form-control>
 
-              <ion-modal class="date-modal" trigger="open-date">
+              <ion-modal class="date-modal" [trigger]="'open-date'+i">
                 <ng-template>
                   <ion-content>
                     <ion-datetime
@@ -185,7 +185,7 @@
           <ng-container *ngIf="field.input === 'datetime'">
             <div class="form-control--section">
               <app-form-control
-                id="open-datetime"
+                [id]="'open-datetime'+i"
                 color="light"
                 [label]="field?.label"
                 [required]="field?.required"
@@ -203,7 +203,7 @@
                 </ng-container>
               </app-form-control>
 
-              <ion-modal class="date-modal" trigger="open-datetime">
+              <ion-modal class="date-modal" [trigger]="'open-datetime'+i">
                 <ng-template>
                   <ion-content>
                     <ion-datetime


### PR DESCRIPTION
Issue: If a form had multiple date/time widgets, they were not behaving independently. Clicking one would open all, retaining the same value for each, etc.

This PR gives each date/time widget a unique id so they can be handled separately.

