### PR TITLE
Ush 1123 - unstructured posts didn't return in the correct order

### DIFF
--- a/apps/mobile-mzima-client/android/build.gradle
+++ b/apps/mobile-mzima-client/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath 'com.google.gms:google-services:4.3.15'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -41,6 +41,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
   public override params: GeoJsonFilter = {
     limit: 20,
     page: 1,
+    include_unstructured_posts: true,
     // created_before_by_id: '',
   };
   private readonly getPostsSubject = new Subject<{

--- a/libs/sdk/src/lib/models/posts.interface.ts
+++ b/libs/sdk/src/lib/models/posts.interface.ts
@@ -26,6 +26,7 @@ export interface GeoJsonFilter {
   offset?: number;
   order?: 'desc' | 'asc';
   order_unlocked_on_top?: boolean;
+  include_unstructured_posts?: boolean;
   orderby?: string;
   set?: string;
   reactToFilters?: boolean;

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -25,6 +25,7 @@ export class PostsService extends ResourceService<any> {
     set: '',
     order_unlocked_on_top: true,
     reactToFilters: true,
+    include_unstructured_posts: true,
     'source[]': [],
     'tags[]': [],
     'form[]': [],


### PR DESCRIPTION
Issue: The ticket describes unstructured posts being in the wrong order implying a problem with sorting. However the actual issue as shown in the video is that unstructured posts are excluded entirely.

Solution: This ticket changes the default behaviour to include unstructure posts in results.