### PR TITLE
Removing pen icon for bulk-actions

### DIFF
--- a/apps/mobile-mzima-client/src/app/profile/posts/posts.page.html
+++ b/apps/mobile-mzima-client/src/app/profile/posts/posts.page.html
@@ -4,9 +4,9 @@
     fill="clear"
     class="edit-button"
     (buttonClick)="editPosts()"
-    [color]="!isEditMode ? 'custom' : 'primary'"
+    color="custom"
   >
-    <app-icon *ngIf="!isEditMode" name="edit" slot="icon-only"></app-icon>
+    <ng-container *ngIf="!isEditMode">Bulk Actions</ng-container>
     <ng-container *ngIf="isEditMode">Done</ng-container>
   </app-button>
   <ng-container *ngIf="posts.length; else emptyBox">

--- a/apps/mobile-mzima-client/src/app/profile/posts/posts.page.scss
+++ b/apps/mobile-mzima-client/src/app/profile/posts/posts.page.scss
@@ -4,14 +4,7 @@
   margin-left: 16px;
   --button-padding-end: 24px;
   --button-padding-start: 24px;
-
-  @media (prefers-color-scheme: light) {
-    color: var(--ion-color-step-600);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--ion-color-step-800);
-  }
+  color: var(--color-primary-40);
 }
 
 .empty-box {


### PR DESCRIPTION
This PR removes the wrong icon used for Bulk Actions in "My posts" in the mobile app.

To test:
- In the mobile app, log in to your account
- Tap on "Profile"
- Tap on "My posts"
- The previous Pen-icon in the upper right corner says "Bulk Actions" (and "Done" after tapping "Bulk Actions")


Designs and issue:
https://linear.app/ushahidi/issue/USH-1021/replace-pencil-icon-on-my-posts-page-fe
