### PR TITLE
 [USH-926] : Resolve Mobile Menu Close and Share Button Issues

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/fragments/deployment-details/deployment-details.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/fragments/deployment-details/deployment-details.component.html
@@ -4,8 +4,9 @@
   </span>
   <mzima-client-button
     *ngIf="!isDesktop"
-    fill="outline"
-    color="custom"
+    fill="solid"
+    color="secondary"
+    border="thin"
     [iconOnly]="true"
     class="menu__head__close"
     (buttonClick)="toggleBurgerMenu(false)"

--- a/apps/web-mzima-client/src/app/shared/components/fragments/menu-list-non-links/menu-list-non-links.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/fragments/menu-list-non-links/menu-list-non-links.component.scss
@@ -135,7 +135,7 @@
     overflow-y: auto;
     overflow-x: hidden;
     scroll-behavior: smooth;
-    height: calc(100% - 220px);
+    height: calc(90% - 220px);
     -webkit-overflow-scrolling: touch;
 
     @include breakpoint-max($tablet) {

--- a/apps/web-mzima-client/src/app/shared/components/fragments/share-and-donate/share-and-donate.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/fragments/share-and-donate/share-and-donate.component.html
@@ -16,10 +16,12 @@
 <div class="menu__footer" *ngIf="!isDesktop">
   <app-donation-button class="menu__footer__button" *ngIf="isDonateAvailable"></app-donation-button>
   <mzima-client-button
-    fill="outline"
-    color="custom"
     (buttonClick)="openShare()"
+    color="secondary"
     class="menu__footer__button"
+    [data-qa]="'share'"
+    fill="solid"
+    border="thick"
   >
     {{ 'app.share' | translate }}
     <mat-icon icon svgIcon="share"></mat-icon>

--- a/libs/mzima-ui/src/lib/button/button.component.html
+++ b/libs/mzima-ui/src/lib/button/button.component.html
@@ -15,6 +15,8 @@
     fill +
     ' mzima-button--' +
     size +
+    ' mzima-button--' +
+    border +
     (expand ? ' mzima-button--block' : '') +
     (rounded ? ' mzima-button--rounded' : '') +
     (isActive ? ' mzima-button--active' : '') +

--- a/libs/mzima-ui/src/lib/button/button.component.scss
+++ b/libs/mzima-ui/src/lib/button/button.component.scss
@@ -261,6 +261,17 @@ $laptop: 1439px;
     --disabled-background-color: var(--button-disabled-background);
   }
 
+  //border
+  &--thin {
+    border: 0.2px solid var(--border-color);
+  }
+  &--thick {
+    border: 1px solid var(--border-color);
+  }
+  &--none {
+    border: none;
+  }
+
   &__content {
     display: flex;
     position: relative;

--- a/libs/mzima-ui/src/lib/button/button.component.ts
+++ b/libs/mzima-ui/src/lib/button/button.component.ts
@@ -19,6 +19,7 @@ export class ButtonComponent {
   @Input() public ariaLabel: string;
   @Input() public dataQa: string;
   @Input() public type: 'button' | 'submit' = 'button';
+  @Input() public border: 'none' | 'thin' | 'thick';
   @Input() public size: 'small' | 'medium' | 'big' = 'medium';
   @Input() public fill: 'solid' | 'outline' | 'clear' = 'solid';
   @Input() public color:


### PR DESCRIPTION
## Summary
This pull request addresses the issue [USH-926](https://github.com/ushahidi/platform-client-mzima/issues/636), resolving concerns related to the mobile menu's Close and Share buttons.

### Tasks
 - [x] Restored the color and border of the Close button.
 - [x] Restored the color and border of the Share button.
 - [x] Ensured visibility of the Share button.

### Solution
Upon investigation, I found conflicting fill and color values for the Share and Close buttons in the mobile menu. To align with the design provided in the attached screenshot under the issue, I updated these values accordingly. Additionally, I introduced a border attribute and a button style in the ButtonComponent to provide flexibility for adding or removing borders.

To address the issue of the Share button being hidden, I discovered that the menu button had a height of 100%, preventing the Share button from being visible. Consequently, I adjusted the height to ensure proper visibility of the Share button.

### Files Changes
- share-and-donate.component.html
- deployment-details.component.html
- button.component.ts
- button.component.css
- button.component.html
- menu-list-non-link.component.css

### Tests
This fix was tested on different mobile devices and browsers, ensuring the Close and Share buttons work seamlessly without introducing any new issues. The design and functionality align with the specified requirements, providing a smooth user experience

## video
A ideov demonstrating the current state of the resolved issues can be viewed [here]

https://github.com/ushahidi/platform-client-mzima/assets/76694292/7d4c734c-8731-4a01-bb9c-22a287ac5c7f

@Ifycode @tuxpiper @AmTryingMyBest  please could you review this PR when you are chanced, thank you


