### PR TITLE
add alert role where there's an alert to improve accessibility

### DIFF
--- a/apps/web-mzima-client/src/app/settings/data-export/data-export.component.html
+++ b/apps/web-mzima-client/src/app/settings/data-export/data-export.component.html
@@ -9,7 +9,7 @@
   <mat-tab-group dynamicHeight disableRipple disablePagination animationDuration="0ms">
     <mat-tab [label]="'data_export.export' | translate" [data-qa]="'tab-export'">
       <ng-container *ngIf="hxlEnabled && !hxlApiKey">
-        <div class="alert">
+        <div class="alert" role="alert">
           <p>{{ 'data_export.hxl_apikey_alert_1' | translate }}</p>
           <p>
             {{ 'data_export.hxl_apikey_alert_2' | translate }}

--- a/apps/web-mzima-client/src/app/settings/surveys/survey-task/survey-task.component.html
+++ b/apps/web-mzima-client/src/app/settings/surveys/survey-task/survey-task.component.html
@@ -278,7 +278,7 @@
               </mat-option>
             </mat-select>
           </mat-form-field>
-          <div class="alert error" *ngIf="showLangError">
+          <div class="alert error" role="alert" *ngIf="showLangError">
             <mat-icon svgIcon="warning"></mat-icon>
             <p translate="translations.error_translation_exists"></p>
           </div>

--- a/xregexp.d.ts
+++ b/xregexp.d.ts
@@ -1,0 +1,1 @@
+declare module 'xregexp';


### PR DESCRIPTION
- After searching  for class="alert" or class="alert error"  in the codebase of platform-client, I found it in two files survey-task.component.html and data-export.component.html
- I add role=alert in the html element in the two files
- The image is showing below after adding the roles to the html element 

![edit1](https://github.com/ushahidi/platform-client-mzima/assets/81489510/42a5bf01-b333-4e7d-b1b7-e4be454d4825)
![edit2](https://github.com/ushahidi/platform-client-mzima/assets/81489510/ac8f7608-0580-4db4-8e49-e1d4560104cd)

-When pushing to my branch I encountered an error with the image below which made me add a xregexp.d.ts to the root folder to fix the error
![Screenshot 2024-03-05 162049](https://github.com/ushahidi/platform-client-mzima/assets/81489510/a83babb3-5048-4e68-b7b5-13a0884c3b79)
