### PR TITLE
Modify category name form to be optional without user interaction

### DIFF
--- a/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.html
+++ b/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.html
@@ -25,17 +25,17 @@
           formControlName="name"
           placeholder="{{ 'category.placeholder.name' | translate }}"
         />
-      </mat-form-field>
-      <mat-error *ngIf="form.get('name')?.hasError('required')">
-        {{ 'category.validation.required.name' | translate }}
-      </mat-error>
-      <ng-container *ngFor="let err of formErrors">
-        <ng-container *ngIf="err?.field === 'tag'">
-          <mat-error *ngFor="let msg of err?.error_messages">
-            {{ msg | translate }}
-          </mat-error>
+        <mat-error *ngIf="form.get('name')?.hasError('required')">
+          {{ 'category.validation.required.name' | translate }}
+        </mat-error>
+        <ng-container *ngFor="let err of formErrors">
+          <ng-container *ngIf="err?.field === 'tag'">
+            <mat-error *ngFor="let msg of err?.error_messages">
+              {{ msg | translate }}
+            </mat-error>
+          </ng-container>
         </ng-container>
-      </ng-container>
+      </mat-form-field>
     </div>
 
     <div class="form-row">

--- a/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.ts
+++ b/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.ts
@@ -19,7 +19,7 @@ import {
   generalHelpers,
 } from '@mzima-client/sdk';
 import { BreakpointService, SessionService, LanguageService, ConfirmModalService } from '@services';
-
+import { noWhitespaceValidator } from '../../../core/validators';
 @UntilDestroy()
 @Component({
   selector: 'app-create-category-form',
@@ -62,6 +62,25 @@ export class CreateCategoryFormComponent extends BaseComponent implements OnInit
     this.languages = this.languageService.getLanguages();
     this.defaultLanguage = this.languages.find((lang) => lang.code === 'en'); // FIXME
 
+    this.form = this.fb.group({
+      id: [''],
+      name: ['', [Validators.required, noWhitespaceValidator]],
+      description: [''],
+      is_child_to: [''],
+      language: ['en'],
+      visible_to: [
+        {
+          value: 'everyone',
+          options: [],
+          disabled: false,
+        },
+      ],
+      translations: this.fb.array<TranslationInterface>([]),
+      translate_name: [''],
+      translate_description: [''],
+      parent: [],
+    });
+
     this.categoriesService.categoryErrors$.pipe(untilDestroyed(this)).subscribe((value) => {
       this.formErrors = value;
     });
@@ -69,7 +88,7 @@ export class CreateCategoryFormComponent extends BaseComponent implements OnInit
 
   ngOnInit(): void {
     this.getUserData();
-    this.initializeForm();
+
     this.formSubscribe();
     this.getCategories();
     this.getRoles();
@@ -109,27 +128,6 @@ export class CreateCategoryFormComponent extends BaseComponent implements OnInit
 
   ngOnDestroy() {
     this.categoriesService.categoryErrors.next(null);
-  }
-
-  private initializeForm() {
-    this.form = this.fb.group({
-      id: [''],
-      name: ['', [Validators.required]],
-      description: [''],
-      is_child_to: [''],
-      language: ['en'],
-      visible_to: [
-        {
-          value: 'everyone',
-          options: [],
-          disabled: false,
-        },
-      ],
-      translations: this.fb.array<TranslationInterface>([]),
-      translate_name: [''],
-      translate_description: [''],
-      parent: [],
-    });
   }
 
   private formSubscribe() {


### PR DESCRIPTION
Fixes #4742
This pr fixes the bug in : (https://github.com/ushahidi/platform/issues/4742)
The category page when user tries to add category the enter name field gives error of 
Category name is required even when the user have not left the field blank
Before:

https://github.com/ushahidi/platform-client-mzima/assets/87182204/08723595-9867-40be-8270-f5abb84154fd



after:

https://github.com/ushahidi/platform-client-mzima/assets/87182204/4d6debdc-1678-4f7e-ad3d-0bda63ff21eb


