### PR TITLE
fix "Filtering" onboarding modal is absent for Arabic translation #4738

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.scss
@@ -49,12 +49,12 @@
 
   &__head {
     display: flex;
+    align-items: center;
+    justify-content: center;
     flex-wrap: wrap;
     position: relative;
     margin: 0 -4px 24px;
-    align-items: flex-start;
     padding-inline-end: 64px;
-    justify-content: flex-start;
 
     &__icon {
       width: 1em;


### PR DESCRIPTION
Issue link
https://github.com/ushahidi/platform/issues/4738

When a language is changed to Arabic which is a Right to left language (RTL), The heading of the onboarding modal for example "Filtering" and others, changes text direction. This makes the text run into the close-button as shown here

screanshort before

![filter-two](https://github.com/ushahidi/platform-client-mzima/assets/162261453/072bfef5-71e0-41b8-ad33-e6a94090a6e1)
![filter-4](https://github.com/ushahidi/platform-client-mzima/assets/162261453/4ed7f526-9c97-48bc-b55f-cef61431eda6)


 I have come up with the solutiion uniform to both RLT & LTR languages that fixes all modals.

screanshot after fix
![fixed-4](https://github.com/ushahidi/platform-client-mzima/assets/162261453/4f4e9514-198c-4b1b-a6ed-a84d4706aa7b)
