### PR TITLE
[Outreachy Task Submission] Make Visibility Toggle Button Readable by Screen Reader

### DIFF
--- a/apps/web-mzima-client/src/app/auth/forms/login-form/login-form.component.html
+++ b/apps/web-mzima-client/src/app/auth/forms/login-form/login-form.component.html
@@ -29,6 +29,7 @@
         [iconOnly]="true"
         (buttonClick)="togglePasswordVisible()"
         [data-qa]="'toggle-password'"
+        ariaLabel="Toggle password visibility"
       >
         <mat-icon icon [svgIcon]="isPasswordVisible ? 'eye-open' : 'eye'"></mat-icon>
       </mzima-client-button>


### PR DESCRIPTION
# Summary
Fixes [#4765](https://github.com/ushahidi/platform/issues/4765).
I added an `aria-label` to make the visibility toggle button readable by a screen reader

## How to Test the PR
1. You'll need to download/install a screen reader if you don't already have one. I used [NVDA](https://www.nvaccess.org/download/).
2. Follow the instruction setup.
3. Open your browser and log into your running Ushahidi deployment (from localhost). At this point, if your installation was successful, the screen reader would already be working.
4. Navigate to the login page.
5. Click on the password field, and then press the `tab` button on your keyboard. Alternatively, you can click on the 'eye' icon to toggle password visibility.
6. Take note of what gets read aloud.
7. Close the running Ushahidi deployment.
8. Checkout to this PR's branch.
9. Run the localhost deployment again.
10. Repeat steps 4-6.
11. You will notice a change in the output of the screen reader when it encounters the button.
