### PR TITLE
[Outreachy Task Submission] Accessibility Fix For Keyboard Navigation in Help & Support

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.html
@@ -14,7 +14,7 @@
 <strong mat-dialog-title>{{ 'nav.help_support' | translate }}</strong>
 
 <div mat-dialog-content>
-  <div
+  <a
     matRipple
     class="menu-item"
     (click)="item?.action()"
@@ -24,12 +24,12 @@
   >
     <h4 class="menu-item__title">{{ item.title }}</h4>
     <p *ngIf="item.description?.length">{{ item.description }}</p>
-  </div>
+  </a>
   <!-- <div matRipple class="menu-item" *ngIf="isLoggedIn">
     <h4 class="menu-item__title">{{ 'app.intercom.intercom' | translate }}</h4>
     <p class="intercom_custom_launcher">{{ 'app.intercom.description' | translate }}</p>
   </div> -->
-  <div
+  <a
     matRipple
     class="menu-item"
     (click)="openUrl('https://www.ushahidi.com/terms-of-service/')"
@@ -37,8 +37,8 @@
     tabindex="0"
   >
     <h4 class="menu-item__title">{{ 'app.terms_and_conditions' | translate }}</h4>
-  </div>
-  <div
+  </a>
+  <a
     matRipple
     class="menu-item"
     (click)="openUrl('https://www.ushahidi.com/privacy-policy/')"
@@ -46,5 +46,5 @@
     tabindex="0"
   >
     <h4 class="menu-item__title">{{ 'app.privacy_policy' | translate }}</h4>
-  </div>
+  </a>
 </div>

--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.html
@@ -14,7 +14,14 @@
 <strong mat-dialog-title>{{ 'nav.help_support' | translate }}</strong>
 
 <div mat-dialog-content>
-  <div matRipple class="menu-item" (click)="item?.action()" *ngFor="let item of menu">
+  <div
+    matRipple
+    class="menu-item"
+    (click)="item?.action()"
+    (keydown.enter)="item?.action()"
+    *ngFor="let item of menu"
+    tabindex="0"
+  >
     <h4 class="menu-item__title">{{ item.title }}</h4>
     <p *ngIf="item.description?.length">{{ item.description }}</p>
   </div>
@@ -22,10 +29,22 @@
     <h4 class="menu-item__title">{{ 'app.intercom.intercom' | translate }}</h4>
     <p class="intercom_custom_launcher">{{ 'app.intercom.description' | translate }}</p>
   </div> -->
-  <div matRipple class="menu-item" (click)="openUrl('https://www.ushahidi.com/terms-of-service/')">
+  <div
+    matRipple
+    class="menu-item"
+    (click)="openUrl('https://www.ushahidi.com/terms-of-service/')"
+    (keydown.enter)="openUrl('https://www.ushahidi.com/terms-of-service/')"
+    tabindex="0"
+  >
     <h4 class="menu-item__title">{{ 'app.terms_and_conditions' | translate }}</h4>
   </div>
-  <div matRipple class="menu-item" (click)="openUrl('https://www.ushahidi.com/privacy-policy/')">
+  <div
+    matRipple
+    class="menu-item"
+    (click)="openUrl('https://www.ushahidi.com/privacy-policy/')"
+    (keydown.enter)="openUrl('https://www.ushahidi.com/privacy-policy/')"
+    tabindex="0"
+  >
     <h4 class="menu-item__title">{{ 'app.privacy_policy' | translate }}</h4>
   </div>
 </div>

--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.scss
@@ -9,6 +9,10 @@
   color: var(--color-neutral-80);
   background-color: var(--color-neutral-10);
 
+  /* Additional styles for anchor tag */
+  text-decoration: none; /* Remove default underline */
+  display: block; /* Anchor tags are inline by default, change to inline-block for padding and border-radius to take effect */
+
   @include breakpoint-max($tablet) {
     font-size: 14px;
   }


### PR DESCRIPTION
Fixes [#4774](https://github.com/ushahidi/platform/issues/4774)

I added `(keydown.enter)` attributes to the `matRipple` divs with their appropriate mappings.
I also tested with my screen reader app and it worked fine,

## How to Test the PR.
1. Open your browser and log into your running Ushahidi deployment (from localhost).
2. Navigate to the 'Help & Support' section.
3. When the modal opens, click on any white/blank space on the modal to put it in focus.
4. The idea is to traverse each menu item, so keep clicking the `tab` on your keyboard till you can do this.
5. Notice that the menu items cannot be navigated to or receive focus.
6. Switch off the deployment from your terminal.
7. Checkout to this PR branch.
8. Re-run your deployment from the Localhost.
9. Repeat steps 1-4.
10. Notice you can now navigate through the menu items with the `tab` button.
11. Also try pressing the `enter` key while any menu item is in focus.
12. Notice that navigation with `tab` and `enter` keys works this time around.