### PR TITLE
[Outreachy Task Submission] Fix footer menu buttons navigation on mobile screens(#4775)

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/fragments/share-and-donate/share-and-donate.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/fragments/share-and-donate/share-and-donate.component.scss
@@ -16,7 +16,7 @@
 
 .menu {
   &__footer-container {
-    position: fixed;
+    position: absolute;
     bottom: 0;
     left: 0;
     width: 100%;


### PR DESCRIPTION
This is the PR for the issue ushahidi/platform#4775 I raise. 
The footer menu buttons now navigate to their respective pages instead of bringing up the share deployment modal whenever each button is clicked.

Here's a video of how it works now


https://github.com/ushahidi/platform-client-mzima/assets/68845318/225e390e-d18f-49b3-8f46-e6c34b9dc7ca

Test checklist:
- [x] Navigate to https://localhost:4200/map  of the Ushahidi platform on a mobile screen.
- [x] Verify that the footer is visible and contains the menu buttons as expected.

For Each Footer Menu Button:
 - [x] Click on the button to navigate to its respective page.
 - [x] Verify that the page loads correctly and matches the button's intended destination.
 - [x] Ensure that the URL in the browser's address bar corresponds to the expected page.
 - [x] Confirm that the 'share deployment modal' does not appear when the button is clicked.
 - [x] Navigate back to the homepage and repeat the steps for the next button.

Fixes Ushahidi/platform#4775
@Angamanga please review.



