### PR TITLE
[Outreachy Task Submission] Fix Language Dropdown Icon Bug (#4772)

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/language/language.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/language/language.component.html
@@ -7,7 +7,6 @@
     >
       <mat-select-trigger class="language__selected">
         {{ selectedLanguage }}
-        <!-- <mat-icon svgIcon="arrow-down" class="language__selected__arrow"></mat-icon> -->
       </mat-select-trigger>
       <mat-option *ngFor="let lang of languages" [value]="lang.code" class="language__option">
         <img

--- a/apps/web-mzima-client/src/app/shared/components/language/language.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/language/language.component.html
@@ -7,7 +7,7 @@
     >
       <mat-select-trigger class="language__selected">
         {{ selectedLanguage }}
-        <mat-icon svgIcon="arrow-down" class="language__selected__arrow"></mat-icon>
+        <!-- <mat-icon svgIcon="arrow-down" class="language__selected__arrow"></mat-icon> -->
       </mat-select-trigger>
       <mat-option *ngFor="let lang of languages" [value]="lang.code" class="language__option">
         <img

--- a/apps/web-mzima-client/src/app/shared/components/language/language.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/language/language.component.scss
@@ -21,9 +21,9 @@
       transform: rotate(180deg);
     }
 
-    .mat-select-arrow-wrapper {
-      display: none;
-    }
+    // .mat-select-arrow-wrapper {
+    //   display: none;
+    // }
 
     .option-wrapper {
       display: flex;

--- a/apps/web-mzima-client/src/app/shared/components/language/language.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/language/language.component.scss
@@ -21,10 +21,6 @@
       transform: rotate(180deg);
     }
 
-    // .mat-select-arrow-wrapper {
-    //   display: none;
-    // }
-
     .option-wrapper {
       display: flex;
       align-items: center;

--- a/apps/web-mzima-client/src/app/shared/components/toolbar/toolbar.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/toolbar/toolbar.component.scss
@@ -53,7 +53,7 @@
   }
 
   &__language {
-    width: 50px;
+    width: 70px;
     display: block;
     margin-inline-start: 16px;
   }


### PR DESCRIPTION
This pull request addresses a bug ([ushahidi/platform#4772](https://github.com/ushahidi/platform/issues/4772)) encountered when switching languages using the Language dropdown menu. The bug caused the dropdown icon to remain stuck in the upward position or disappear entirely after language selection, affecting languages such as Bulgarian (Bulgaria), Chinese (Taiwan), French (France), and Portuguese (Brazil).

**Changes Made:**

- Implemented a fix to ensure the dropdown icon reverts to its default downward position after language selection.
- Resolved the issue causing the dropdown icon to disappear for specific languages, ensuring consistent behavior across all language selections.

### **Before:**
**Video**
https://github.com/ushahidi/platform/assets/118375524/9838bd8a-7475-4c99-aece-a7e71724f581
**Screenshots**
![Screenshot 2024-03-07 225435](https://github.com/ushahidi/platform-client-mzima/assets/118375524/a109fdb0-5b4a-4ec1-b7ab-afcd4f6a1239)
![ulim](https://github.com/ushahidi/platform-client-mzima/assets/118375524/776bcfdb-bea6-482a-b107-a1b54ebf33e1)


### **After:**
**Video**
https://github.com/ushahidi/platform-client-mzima/assets/118375524/97c4911c-bfa0-4a0e-8ac8-3e4acbbb8657
**Screenshots**
![Screenshot 2024-03-08 185632](https://github.com/ushahidi/platform-client-mzima/assets/118375524/59664c46-cd35-45dd-9dc6-f204f824afe9)
![Screenshot 2024-03-08 185539](https://github.com/ushahidi/platform-client-mzima/assets/118375524/5fe9d7a4-e878-4814-8ff6-1a4f4d325427)