### PR TITLE
[Outreachy Task Submission] Accessibility Fix in 'Collections' screen to allow keyboard navigation

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/collections/collections.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/collections/collections.component.html
@@ -89,6 +89,8 @@
           [checked]="isPostInCollection(item)"
           (checkedChange)="onCheckChange($event, item)"
           [data-qa]="'collection-item'"
+          tabindex="0"
+          (keydown.enter)="goToCollection(item)"
         >
         </app-collection-item>
       </div>


### PR DESCRIPTION
Fixes [#4777](https://github.com/ushahidi/platform/issues/4777)
It solves the keyboard navigation problem.

## How to Test the PR.
1. Open your browser and log into your running Ushahidi deployment (from localhost).
2. Navigate to the 'Collections' section.
3. When the modal opens, click on any white/blank space on the modal to put it in focus.
4. The idea is to traverse each collection, so keep clicking the `tab` on your keyboard till you can do this.
5. Notice that the individual collection items in the `collections` modal cannot be navigated to or receive focus.
6. Switch off the deployment from your terminal.
7. Checkout to this PR branch.
8. Repeat steps 1-4.
9. Notice that you can now navigate through them.
10. You can also click on the `enter` button to try navigating into any of them.