### PR TITLE
[Outreachy Task Submission]Fix inconsistent closing behavior of help and support modal (#4776)

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.html
@@ -18,14 +18,9 @@
     <h4 class="menu-item__title">{{ item.title }}</h4>
     <p *ngIf="item.description?.length">{{ item.description }}</p>
   </div>
+
   <!-- <div matRipple class="menu-item" *ngIf="isLoggedIn">
     <h4 class="menu-item__title">{{ 'app.intercom.intercom' | translate }}</h4>
     <p class="intercom_custom_launcher">{{ 'app.intercom.description' | translate }}</p>
   </div> -->
-  <div matRipple class="menu-item" (click)="openUrl('https://www.ushahidi.com/terms-of-service/')">
-    <h4 class="menu-item__title">{{ 'app.terms_and_conditions' | translate }}</h4>
-  </div>
-  <div matRipple class="menu-item" (click)="openUrl('https://www.ushahidi.com/privacy-policy/')">
-    <h4 class="menu-item__title">{{ 'app.privacy_policy' | translate }}</h4>
-  </div>
 </div>

--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
@@ -77,6 +77,22 @@ export class SupportModalComponent extends BaseComponent {
       //     this.closeModal();
       //   },
       // },
+      {
+        title: this.translate.instant('app.terms_and_conditions'),
+        description: this.translate.instant('app.terms_and_conditions'),
+        action: () => {
+          this.openUrl('https://www.ushahidi.com/terms-of-service/');
+          this.closeModal();
+        },
+      },
+      {
+        title: this.translate.instant('app.privacy_policy'),
+        description: this.translate.instant('app.privacy_policy'),
+        action: () => {
+          this.openUrl('https://www.ushahidi.com/privacy-policy/');
+          this.closeModal();
+        },
+      },
     ];
   }
 


### PR DESCRIPTION
Resolved the issue where the Help and Support modal remained open when the Privacy Policy and Terms & Conditions links were clicked. This fix ensures the modal now closes consistently across all links, improving user experience by maintaining uniform behavior. 

Closes ushahidi/platform#4776
Here's a video confirming this.

https://github.com/ushahidi/platform-client-mzima/assets/68845318/78d5b908-46fd-4a11-933f-f85ba2e14d4d

@Angamanga please this is ready for review