### PR TITLE
fix Title Overlaps Close Button in Onboarding Modal for RTL Languages #4797

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.scss
@@ -49,12 +49,12 @@
 
   &__head {
     display: flex;
+    align-items: center;
+    justify-content: center;
     flex-wrap: wrap;
     position: relative;
     margin: 0 -4px 24px;
-    align-items: flex-start;
     padding-inline-end: 64px;
-    justify-content: flex-start;
 
     &__icon {
       width: 1em;


### PR DESCRIPTION
## PR Summary

🛠️ **Related Issue:** [Issue #4797](https://github.com/ushahidi/platform/issues/4797)

**Summary:**  
This pull request addresses [Issue #4797](https://github.com/ushahidi/platform/issues/4797) by fixing the title overlapping issue in the onboarding modal for RTL languages. Now, the title is clearly visible for both RTL and LTR languages.

---

**Details:**
- **Problem:** The title was overlapping with the close button in the onboarding modal for RTL languages, obstructing visibility.
- **Solution:** Adjusted the layout to ensure the title remains fully visible for both RTL and LTR languages.
- **Screencast**



[not-running.webm](https://github.com/ushahidi/platform-client-mzima/assets/162261453/f8e85de5-f263-4810-87f7-2a58baaee8b4)




**Testing:**
- Verified the fix by testing in various language orientations.
- Ensured the title is no longer obstructed by the close button in RTL languages.

---

🚀 **Impact:**  
This fix enhances the user experience for RTL language users, ensuring they can fully engage with the onboarding process without visibility issues.

---

Your feedback and review are appreciated. Let me know if there are any further adjustments needed!

