### PR TITLE
[Outreachy Task Submission] Fix Inconsistent Link Styling in 'Export and Tag Data' Description (#4799)

### DIFF
--- a/apps/web-mzima-client/src/app/settings/data-export/data-export.component.html
+++ b/apps/web-mzima-client/src/app/settings/data-export/data-export.component.html
@@ -146,8 +146,10 @@
   <p *ngIf="hxlEnabled">
     {{ 'data_export.description_hxl' | translate }}
     <a href="https://hxlstandard.org/standard/1-1final/tagging/" class="link-blue" target="_blank">
-      <mat-icon svgIcon="external-link"></mat-icon>
-      {{ 'data_export.hxl_tags' | translate }} </a
+      <strong>
+        <mat-icon svgIcon="external-link"></mat-icon>
+        {{ 'data_export.hxl_tags' | translate }}
+      </strong> </a
     >,
     <a
       href="https://hxlstandard.org/standard/1-1final/dictionary/"


### PR DESCRIPTION
In this update, I ensured consistent styling for links within the <ng-template #description> section of the code. Previously, two links were wrapped in strong tags while the HXL tag was not. To improve accessibility and maintain uniformity, I wrapped the HXL tag inside a strong tag, aligning its styling with the other two links. This change ensures a cohesive visual presentation and enhances user experience. This resolves issue ([ushahidi/platform#4799](https://github.com/ushahidi/platform/issues/4799))

**Changes Made:**
- Improved link styling consistency in <ng-template #description>.
- Added `<strong>` tag to **HXL tag** for uniformity.

**Before:**
![Screenshot 2024-03-11 121829](https://github.com/ushahidi/platform-client-mzima/assets/118375524/9650a2a9-4fcf-4279-a4fd-be537e913eef)

**After:**
![Screenshot 2024-03-11 123212](https://github.com/ushahidi/platform-client-mzima/assets/118375524/e870ba0f-2952-431c-9ff5-19f9994cbb08)
