### PR TITLE
[Outreachy Task Submission] Umbrella Accessibility Issue Fix

### DIFF
--- a/apps/web-mzima-client/src/styles.scss
+++ b/apps/web-mzima-client/src/styles.scss
@@ -193,3 +193,14 @@ a {
     bottom: 100px !important;
   }
 }
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  border: 0 !important;
+}

--- a/apps/web-mzima-client/src/styles.scss
+++ b/apps/web-mzima-client/src/styles.scss
@@ -195,12 +195,12 @@ a {
 }
 
 .visually-hidden {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  margin: -1px !important;
-  padding: 0 !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  border: 0 !important;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }


### PR DESCRIPTION
# Intro
When using automated software to check for WCAG violations on web accessibility, a lot of the issues that come up are because of stylistic choices. For example; input forms not having labels even when the purpose of the form is contextually defined both for regular users and people with screen readers. When you put these labels in, they change the visual appeal, and when you give them an attribute of `hidden-"true"`, we go back full circle to the automated software flagging them as omissions. This problem happens not only across forms, but also across buttons that use SVGs, even with `aria-label` attributes.

## Solution
My solution is to create a new class called `visually-hidden`. I added the CSS for this in the `styles.css` so that it can be used across the entire web platform client. It will retain the semantic detail of any element it is used in, while hiding the visual content. This gives us the benefits of retaining our stylistic choices (provided `aria-label` attributes are set when necessary), and still fixing errors flagged by automated web accessibility checkers.

## Alternative solutions
- Remove the stylistic choices already in place (a full refactor of the entire codebase).
- Leave as it currently is, knowing fully well that automated software will continue to flag these issues.