### PR TITLE
[Outreachy Task Submission] Fix Accessibility issue with unlabeled search form in Data & Map view

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -12,8 +12,10 @@
     <mzima-client-button matPrefix [iconOnly]="true" fill="clear" color="secondary">
       <mat-icon icon svgIcon="search-small"></mat-icon>
     </mzima-client-button>
+    <label for="searchInput" class="visually-hidden">Search</label>
     <input
       matInput
+      id="searchInput"
       [(ngModel)]="searchQuery"
       (ngModelChange)="searchPosts()"
       class="search-form__form-control"

--- a/apps/web-mzima-client/src/styles.scss
+++ b/apps/web-mzima-client/src/styles.scss
@@ -193,3 +193,14 @@ a {
     bottom: 100px !important;
   }
 }
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  border: 0 !important;
+}


### PR DESCRIPTION
# Intro
Accessibility-checking software flags the search form in the Data & Map views as problematic because there is no appropriate label for the search field. This fix addresses that by adding a the label, along with a class attribute that will make it hidden, so as not to alter pre-existing stylistic choices.

## Dependency
This particular code change has a dependency, which is this [PR](https://github.com/ushahidi/platform-client-mzima/pull/860).
Ideally, merging that PR will help this one. 

## How to Test the PR Manually
1. Open your browser and log into your running Ushahidi deployment (from localhost).
2. Navigate to either the `data` or `map` section.
3. Try right-clicking on the search form field at the top of the screen and selecting 'inspect'.
4. View the properties, and look for a `label` element.
5. You will not see any.
6. Stop the running Ushahidi deployment in your terminal.
7. Checkout to this PR branch.
8. Re-run your Ushahidi deployment.
9. Repeat steps 1-4.
10. You will see a `label` element this time around.

## How to test with a browser plugin.
If you use a tool like [WAVE evaluation tool](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh), it's as simple as following steps 1 and 2 above, and then turning on the browser extension. It will flag the issue. Checkout to the PR and do this again, you will notice the issue is no longer there. 