### PR TITLE
[Outreachy Task Submission] Added translation for the "add new post" button for all available languages

### DIFF
--- a/apps/web-mzima-client/src/assets/locales/ar.json
+++ b/apps/web-mzima-client/src/assets/locales/ar.json
@@ -120,7 +120,7 @@
     "oldest_first": "الاقدم اولا",
     "language": "اللغة",
     "select_language": "اختر اللغة",
-    "add_new_post": "Add new post",
+    "add_new_post": "إضافة مقالة جديدة",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "عنوان البريد الإلكتروني للاتصال:",

--- a/apps/web-mzima-client/src/assets/locales/bg-BG.json
+++ b/apps/web-mzima-client/src/assets/locales/bg-BG.json
@@ -120,7 +120,7 @@
     "oldest_first": "Старите първо",
     "language": "Език",
     "select_language": "Избери език",
-    "add_new_post": "Add new post",
+    "add_new_post": "Добавяне на нов пост",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Имейл адрес за контакт:",

--- a/apps/web-mzima-client/src/assets/locales/cs.json
+++ b/apps/web-mzima-client/src/assets/locales/cs.json
@@ -120,7 +120,7 @@
     "oldest_first": "Nejstarší první",
     "language": "Jazyk",
     "select_language": "Zvolit jazyk",
-    "add_new_post": "Add new post",
+    "add_new_post": "Přidat nový příspěvek",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Kontaktní e-mailová adresa:",

--- a/apps/web-mzima-client/src/assets/locales/de.json
+++ b/apps/web-mzima-client/src/assets/locales/de.json
@@ -120,7 +120,7 @@
     "oldest_first": "Älteste zuerst",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Neuen Beitrag hinzufügen",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Kontakt-E-Mail-Adresse:",

--- a/apps/web-mzima-client/src/assets/locales/es.json
+++ b/apps/web-mzima-client/src/assets/locales/es.json
@@ -120,7 +120,7 @@
     "oldest_first": "Las más antiguas primero",
     "language": "Idioma",
     "select_language": "Seleccione un idioma",
-    "add_new_post": "Add new post",
+    "add_new_post": "Agregar nueva publicación",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "add_collection": "Agregar colección",

--- a/apps/web-mzima-client/src/assets/locales/fa-IR.json
+++ b/apps/web-mzima-client/src/assets/locales/fa-IR.json
@@ -120,7 +120,7 @@
     "oldest_first": "اول قدیمی ترها",
     "language": "زبان",
     "select_language": "انتخاب زبان",
-    "add_new_post": "Add new post",
+    "add_new_post": "افزودن پست جدید",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "ادرس ایمیل تماس:",

--- a/apps/web-mzima-client/src/assets/locales/fr-FR.json
+++ b/apps/web-mzima-client/src/assets/locales/fr-FR.json
@@ -120,7 +120,7 @@
     "oldest_first": "Ordre croissant",
     "language": "Langue",
     "select_language": "Séléctionner la langue",
-    "add_new_post": "Add new post",
+    "add_new_post": "Ajouter article",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Adresse e-mail de contact :",

--- a/apps/web-mzima-client/src/assets/locales/fr.json
+++ b/apps/web-mzima-client/src/assets/locales/fr.json
@@ -120,7 +120,7 @@
     "oldest_first": "Le plus ancien en premier",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Ajouter article",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Adresse e-mail de contact :",

--- a/apps/web-mzima-client/src/assets/locales/hr.json
+++ b/apps/web-mzima-client/src/assets/locales/hr.json
@@ -120,7 +120,7 @@
     "oldest_first": "Najstariji prvo",
     "language": "Jezik",
     "select_language": "Odaberi jezik",
-    "add_new_post": "Add new post",
+    "add_new_post": "Dodaj novi post",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Adresa e-pošte za kontakt:",

--- a/apps/web-mzima-client/src/assets/locales/ht.json
+++ b/apps/web-mzima-client/src/assets/locales/ht.json
@@ -113,7 +113,7 @@
     "oldest_first": "Oldest first",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Ajoute nouvo pòs",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Kontakte adrès imèl:",

--- a/apps/web-mzima-client/src/assets/locales/hu.json
+++ b/apps/web-mzima-client/src/assets/locales/hu.json
@@ -120,7 +120,7 @@
     "oldest_first": "Legrégebbi legelőre",
     "language": "nyelv",
     "select_language": "Válassz nyelvet",
-    "add_new_post": "Add new post",
+    "add_new_post": "Új bejegyzés hozzáadása",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Kapcsolattartási e-mail cím:",

--- a/apps/web-mzima-client/src/assets/locales/hy.json
+++ b/apps/web-mzima-client/src/assets/locales/hy.json
@@ -120,7 +120,7 @@
     "oldest_first": "Հնից նոր",
     "language": "Լեզու",
     "select_language": "Ընտրել լեզուն",
-    "add_new_post": "Add new post",
+    "add_new_post": "Ավելացնել նոր գրառում",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Հետադարձ կապ էլ. փոստի հասցեով.",

--- a/apps/web-mzima-client/src/assets/locales/id.json
+++ b/apps/web-mzima-client/src/assets/locales/id.json
@@ -113,7 +113,7 @@
     "oldest_first": "Oldest first",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Tambahkan postingan baru",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Alamat email kontak:",

--- a/apps/web-mzima-client/src/assets/locales/it.json
+++ b/apps/web-mzima-client/src/assets/locales/it.json
@@ -113,7 +113,7 @@
     "oldest_first": "Oldest first",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Aggiungi nuovo post",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Indirizzo e-mail di contatto:",

--- a/apps/web-mzima-client/src/assets/locales/ja.json
+++ b/apps/web-mzima-client/src/assets/locales/ja.json
@@ -120,7 +120,7 @@
     "oldest_first": "古い順",
     "language": "言語",
     "select_language": "言語を選択",
-    "add_new_post": "Add new post",
+    "add_new_post": "新しい投稿を追加する",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "連絡先メールアドレス:",

--- a/apps/web-mzima-client/src/assets/locales/nl.json
+++ b/apps/web-mzima-client/src/assets/locales/nl.json
@@ -120,7 +120,7 @@
     "oldest_first": "Oldest first",
     "language": "Taal",
     "select_language": "Selecteer taal",
-    "add_new_post": "Add new post",
+    "add_new_post": "Nieuwe post toevoegen",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "E-mailadres voor contact:",

--- a/apps/web-mzima-client/src/assets/locales/pt-BR.json
+++ b/apps/web-mzima-client/src/assets/locales/pt-BR.json
@@ -120,7 +120,7 @@
     "oldest_first": "Mais antigos primeiro",
     "language": "Idioma",
     "select_language": "Selecionar Idioma",
-    "add_new_post": "Add new post",
+    "add_new_post": "Adicionar nova publicação",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "add_collection": "Adicionar coleção",

--- a/apps/web-mzima-client/src/assets/locales/ru.json
+++ b/apps/web-mzima-client/src/assets/locales/ru.json
@@ -120,7 +120,7 @@
     "oldest_first": "Oldest first",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Добавить новую запись",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Контактный адрес электронной почты:",

--- a/apps/web-mzima-client/src/assets/locales/sq-AL.json
+++ b/apps/web-mzima-client/src/assets/locales/sq-AL.json
@@ -113,7 +113,7 @@
     "oldest_first": "Oldest first",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Shto postim të ri",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Adresa e emailit të kontaktit:",

--- a/apps/web-mzima-client/src/assets/locales/sw.json
+++ b/apps/web-mzima-client/src/assets/locales/sw.json
@@ -113,7 +113,7 @@
     "oldest_first": "Oldest first",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Ongeza chapisho",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Anwani ya barua pepe ya mawasiliano:",

--- a/apps/web-mzima-client/src/assets/locales/vi-VN.json
+++ b/apps/web-mzima-client/src/assets/locales/vi-VN.json
@@ -113,7 +113,7 @@
     "oldest_first": "Oldest first",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Thêm bài viết mới",
     "previous": "Previous",
     "choose_survey": "Choose survey"
   },

--- a/apps/web-mzima-client/src/assets/locales/vi.json
+++ b/apps/web-mzima-client/src/assets/locales/vi.json
@@ -113,7 +113,7 @@
     "oldest_first": "Oldest first",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "Thêm bài viết mới",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "Địa chỉ email liên hệ:",

--- a/apps/web-mzima-client/src/assets/locales/zh-TW.json
+++ b/apps/web-mzima-client/src/assets/locales/zh-TW.json
@@ -120,7 +120,7 @@
     "oldest_first": "舊的在前面",
     "language": "語言",
     "select_language": "選擇語言",
-    "add_new_post": "Add new post",
+    "add_new_post": "新增文章",
     "previous": "Previous",
     "choose_survey": "Choose survey",
     "contact_email_address": "聯絡電子郵件地址：",

--- a/apps/web-mzima-client/src/assets/locales/zh.json
+++ b/apps/web-mzima-client/src/assets/locales/zh.json
@@ -114,7 +114,7 @@
     "oldest_first": "Oldest first",
     "language": "Language",
     "select_language": "Select language",
-    "add_new_post": "Add new post",
+    "add_new_post": "添加新帖子",
     "previous": "Previous",
     "choose_survey": "Choose survey"
   },


### PR DESCRIPTION
# Engineers Checklist

## What this PR does?
-  Adds translation on the "add new post" button for all the available languages because the button initially was in english across all the languages.

## How can it be tested?
- Launch the local server
- Login/signup to the platform
- Navigate to the language setting at the top right part of the (default) page
- Chose a specific language and check on the "add new post" button on the sidebar to confirm if language changes.

# Where is it documented?
- It's documented on an issue I raised : https://github.com/ushahidi/platform/issues/4814

## What would be the Impact of this solution
- Users will be able to use the platform comfortably and create posts in the language they understand best. It promotes inclusivity and improves the overall user experience.

## UI Update
### The button translated -- some few language demo

![Group 8](https://github.com/ushahidi/platform-client-mzima/assets/124133577/cfa32d76-8992-47af-8596-e97c0d206c6a)

![Group 7](https://github.com/ushahidi/platform-client-mzima/assets/124133577/c99cd5bd-c2d3-4695-b934-7be6a0006e42)

![Group 6](https://github.com/ushahidi/platform-client-mzima/assets/124133577/4a66ffaa-fb83-444d-8db4-0809a5a77847)

