### PR TITLE
[Outreachy Task Submission] Fixed add collection when only me option is selected.

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/collections/collections.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/collections/collections.component.ts
@@ -241,7 +241,9 @@ export class CollectionsComponent extends BaseComponent implements OnInit {
     const visibleTo = collectionData.visible_to.value;
     if (visibleTo === 'only_me') {
       collectionData.role = ['me'];
-      collectionData['view_only']['only_me'] = true;
+      collectionData['view_only'] = {
+        only_me: true
+      }
     } else if (visibleTo === 'everyone') {
       collectionData.role = ['everyone'];
     } else {


### PR DESCRIPTION
**PR Description**
This PR addresses the issue of, when the "only me" option under the "Who can see this" label is selected, a collection cannot be added and no error is displayed back to the user.

**How to test**

1. Login/SignUp
2. Go to "Collections"
3. Click "Add Collection Button".
4. Fill in the form, select "only me" option under "Who can see this" label.
5. Click the "save" button. The collection should be added succeeefully.

**Link to the issue**
[https://github.com/ushahidi/platform/issues/4804](#4804)

**screenshot**
![Screenshot from 2024-03-11 14-01-20](https://github.com/ushahidi/platform-client-mzima/assets/101701821/d27b4113-4149-430f-9ca3-fdd375107b65)


 
