### PR TITLE
USH-1216: switch db engine to MariaDB 10.11 for e2e tests

### DIFF
--- a/.github/workflows/test-and-ship.yml
+++ b/.github/workflows/test-and-ship.yml
@@ -88,14 +88,14 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mariadb:10.11
         ports:
           - '33061:3306'
         env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: ushahidi
-          MYSQL_USER: ushahidi
-          MYSQL_PASSWORD: ushahidi
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: ushahidi
+          MARIADB_USER: ushahidi
+          MARIADB_PASSWORD: ushahidi
           LC_ALL: ${{ env.LC_ALL }}
           TZ: ${{ env.TZ }}
       redis:


### PR DESCRIPTION
Addresses changes identified in ~~USH-1216~~ more precisely USH-1218