### PR TITLE
Fixing accessibility to Aria nodes and input fields

### DIFF
--- a/apps/mobile-mzima-client/src/app/core/helpers/map.ts
+++ b/apps/mobile-mzima-client/src/app/core/helpers/map.ts
@@ -11,7 +11,7 @@ export const pointIcon = (type: string = 'default', color?: string) => {
   return divIcon({
     className: 'custom-map-marker',
     html: `
-    <svg style="height: 100%; width: 100%; fill:${color};">
+    <svg aria-label="Custom map marker location"  style="height: 100%; width: 100%; fill:${color};" >
       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="assets/markers.svg#${type}"></use>
     </svg>
     `,

--- a/apps/mobile-mzima-client/src/app/post/components/location-control/location-control.component.html
+++ b/apps/mobile-mzima-client/src/app/post/components/location-control/location-control.component.html
@@ -5,6 +5,7 @@
       leaflet
       class="map"
       tabindex="-1"
+      aria-label="Map of the current location"
       *ngIf="isMapReady"
       [leafletLayers]="mapLayers"
       [leafletOptions]="leafletOptions"

--- a/apps/web-mzima-client/src/app/core/helpers/map.ts
+++ b/apps/web-mzima-client/src/app/core/helpers/map.ts
@@ -11,7 +11,7 @@ export const pointIcon = (color: string, type: string = 'default') => {
   return divIcon({
     className: 'custom-map-marker',
     html: `
-    <svg class="iconic" style="height: 100%; width: 100%; fill:${color};">
+    <svg class="iconic" style="height: 100%; width: 100%; fill:${color};" aria-label="Map leaflet icon">
       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="assets/markers.svg#${type}"></use>
     </svg>
     <span class="iconic-bg" style="background-color:${color};"></span>

--- a/apps/web-mzima-client/src/app/shared/components/filter-control/filter-control.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/filter-control/filter-control.component.html
@@ -6,6 +6,7 @@
       color="gray"
       [matMenuTriggerFor]="menu"
       class="filter-control__button"
+      ariaLabel="Open Filter Menu"
     >
       <ng-container *ngTemplateOutlet="buttonContent"></ng-container>
     </mzima-client-button>
@@ -77,6 +78,7 @@
         (ngModelChange)="valueChanged()"
         (click)="$event.stopPropagation()"
         (selectionChange)="filterChange.emit($event)"
+        [attr.data-qa]="'filter-selection-list'"
       >
         <mat-list-option
           color="primary"
@@ -86,6 +88,7 @@
           [selected]="option.checked"
           [disabled]="option.disabled"
           *ngFor="let option of options"
+          [attr.data-qa]="'filter-list-option'"
         >
           {{ option[fields[1]] | translate }}
         </mat-list-option>

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -153,6 +153,7 @@
             </div>
             <mat-selection-list
               name="surveys"
+              aria-label="Surveys selection list"
               class="selection-list"
               formControlName="form"
               [data-qa]="'survey-selection-list'"
@@ -330,6 +331,7 @@
         (clear)="clearFilter('status')"
         [title]="'global_filter.status' | translate"
         [badge]="form.controls['status'].value?.length || null"
+        [data-qa]="'status'"
       >
         <div class="clear-button" suffix>
           <mzima-client-button

--- a/apps/web-mzima-client/src/app/shared/components/spinner/spinner.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/spinner/spinner.component.html
@@ -3,5 +3,5 @@
 </div>
 
 <ng-template #spinner>
-  <mat-spinner class="spinner"></mat-spinner>
+  <mat-spinner class="spinner" aria-label="Loading"></mat-spinner>
 </ng-template>


### PR DESCRIPTION
# Description

Input fields and ARIA progress nodes do not have accessible names or description. This PR fixes this.

## Test
To test:
- Install [axe chrome extension](https://axe.deque.com/install-success).  Open the developer console tab and scan the page.
- There should be no aria accessible name errors
-  Make a change in one of the files in the PR by removing the ariaLabel. 
- Reload and scan the page - you should see aria accessibility errors.

## Fixes
Fixes: https://github.com/ushahidi/platform/issues/4800#event-12132665123


