### PR TITLE
 Resolving Accessibility Issue: Inadequate Color Contrast

### DIFF
--- a/apps/web-mzima-client/src/app/settings/data-export/data-export.component.html
+++ b/apps/web-mzima-client/src/app/settings/data-export/data-export.component.html
@@ -13,7 +13,8 @@
           <p>{{ 'data_export.hxl_apikey_alert_1' | translate }}</p>
           <p>
             {{ 'data_export.hxl_apikey_alert_2' | translate }}
-            <a [routerLink]="['/settings/user-settings']" class="link-blue">
+            <!--Inadequate Color Contrast for Accessibility -->
+            <a [routerLink]="['/settings/user-settings']" class="colorLink">
               {{ 'data_export.hxl_configure' | translate }}
             </a>
             {{ 'data_export.hxl_apikey_alert_3' | translate }}

--- a/apps/web-mzima-client/src/app/settings/data-export/data-export.component.scss
+++ b/apps/web-mzima-client/src/app/settings/data-export/data-export.component.scss
@@ -15,7 +15,9 @@
     }
   }
 }
-
+.colorLink {
+  color: black;
+}
 .mat-column-download {
   text-align: center;
 }


### PR DESCRIPTION
To address the accessibility issue, the text color was changed to a color that provides sufficient contrast against the background color. This adjustment significantly increased the contrast ratio from 1.45, which falls below the WCAG standard, to 19.05, which is highly recommended in the WCAG standard.

<img width="1503" alt="Screenshot 2024-03-19 at 10 15 18 AM" src="https://github.com/ushahidi/platform-client-mzima/assets/134989328/b0122503-f64b-434f-ac88-b785eab27dd8">
