### PR TITLE
USH-956 - General Settings Bugs

### DIFF
--- a/apps/web-mzima-client/src/app/settings/general/general.component.ts
+++ b/apps/web-mzima-client/src/app/settings/general/general.component.ts
@@ -150,8 +150,8 @@ export class GeneralComponent implements OnInit {
     this.langService.changeLanguage(siteConfig.language);
 
     return this.configService.update('site', siteConfig).pipe(
-      mergeMap((updatedSite) => {
-        this.sessionService.setConfigurations('site', updatedSite);
+      mergeMap((updatedSite: any) => {
+        this.sessionService.setConfigurations('site', updatedSite.result);
         return this.configService.update('map', this.mapSettings.mapConfig);
       }),
     );


### PR DESCRIPTION
This PR fixes two issues with General Settings:

1) Saving settings wipes out the site information on the site (Top Left) until page is refreshed.
2) After saving the settings and leaving the general settings section, on returning the general settings have all been wiped.

https://linear.app/ushahidi/issue/USH-956/saving-changes-general-settings-doesnt-reflect-on-client-until-refresh