### PR TITLE
[Outreachy Task Submission] Resolve issue with editing collections under "Only me" option

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/collections/collections.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/collections/collections.component.ts
@@ -241,6 +241,7 @@ export class CollectionsComponent extends BaseComponent implements OnInit {
     const visibleTo = collectionData.visible_to.value;
     if (visibleTo === 'only_me') {
       collectionData.role = ['me'];
+      if (!collectionData['view_only']) collectionData['view_only'] = {};
       collectionData['view_only']['only_me'] = true;
     } else if (visibleTo === 'everyone') {
       collectionData.role = ['everyone'];


### PR DESCRIPTION
### Description
This pull request addresses an issue ushahidi/platform#4810 where editing collections with the "Only Me" visibility option selected would fail silently due to an undefined 'view_only' object. The fix ensures that the 'view_only' object is properly initialized when the visibility option is set to 'only_me', preventing errors related to undefined properties.

### Testing Checklist:
1. Start the web application by running npm run web:serve.
2. Navigate to the collections section by clicking on the collections icon in the sidebar.
3. Identify and click on the edit icon of the collection you intend to modify from the collections list.
4. Within the edit form, verify that you can successfully change the visibility option to "Only Me".
5. Submit the form to save the changes and ensure the collection is edited without any errors.


https://github.com/ushahidi/platform-client-mzima/assets/68381641/2ad1e231-c07f-49a9-a70f-749b00727cf4

