### PR TITLE
[Outreachy Task Submission] Fixed redundant [alt] attributes in company logo image in default page 

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/company-info/company-info.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/company-info/company-info.component.html
@@ -7,8 +7,7 @@
 >
   <mat-expansion-panel-header>
     <mat-panel-title class="company-info__header" [data-qa]="'panel-title'">
-      <img [src]="logo" [alt]="title" class="company-info__logo" *ngIf="logo" />
-      <span class="company-info__title">{{ title }}</span>
+      <img [src]="logo" [alt]="title + ' logo'" class="company-info__logo" *ngIf="logo" />      <span class="company-info__title">{{ title }}</span>
       <mat-icon svgIcon="arrow-down" class="company-info__header__arrow"></mat-icon>
     </mat-panel-title>
   </mat-expansion-panel-header>


### PR DESCRIPTION
# Engineers Checklist

## What this PR does?
- It modifies the redundant [alt] attributes, ensuring that the attributes are correctly assigned and that they provide meaningful alternative text for the company logo image.

### Before Changes 
![Screenshot from 2024-03-21 14-28-03](https://github.com/ushahidi/platform-client-mzima/assets/124133577/94362df5-8193-4a76-9eae-8f8a0d891635)

### After Changes
![Screenshot from 2024-03-21 14-35-19](https://github.com/ushahidi/platform-client-mzima/assets/124133577/aa3a6289-388e-464d-a042-81ff0d35345f)


## How can it be tested?
- Launch the local server: http://localhost:4200
- Navigate to the default page of the platform : http://localhost:4200/map
- Inspect and open light house to test the accessibility 
- Alternatively, as a user, you can check this  by hovering over the logo image and verifying if a meaningful description or alternative text is displayed.

# Where is it documented?
- It is documented on an issue I raised: https://github.com/ushahidi/platform/issues/4856

## What would be the Impact of the solution?
- It would enhance accessibility for both typical users and those utilizing assistive technologies, promoting a more inclusive and accessible experience for everyone.


