### PR TITLE
[Outreachy Task Submission]: Handle error message persistence for posts without images

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
@@ -356,6 +356,8 @@
                   form.get(field.key)?.touched && form.get(field.key)?.hasError('photoRequired')
                 "
                 [maxSizeError]="maxSizeError"
+                [form]="form"
+                [key]="field.key"
               >
               </app-image-uploader>
             </ng-container>


### PR DESCRIPTION
### Description:
This pull request addresses the issue ushahidi/platform#4813 where an error message persisting when submitting a new post without uploading an image but adding an image caption. Additionally, even after removing the image caption, the error persisted, causing confusion for users.

### Changes Made:
- Updated the ImageUploaderComponent to accept form and key inputs.
- Implemented error handling logic in the ImageUploaderComponent to display a clear pop-up message when users attempt to submit a post with an image caption but without uploading an image.
- Modified the component to remove any persisted error when users remove the image caption.

### Testing Checklist:
1. Start the web app with `npm run web:serve`.
2. Log in to an existing account or create a new account.
3. Click on the "Add New Post" icon in the sidebar.
4. Select a survey template that includes an option to upload an image.
5. Verify that attempting to submit a post with an image caption but without uploading an image displays an error message and disables the submit button.
6. Verify that removing the image caption removes any persisted error messages.

https://github.com/ushahidi/platform-client-mzima/assets/68381641/56a9d6b2-6abf-47a6-98cf-74eeb12b7219