### PR TITLE
fix: make search input accessible

### DIFF
--- a/apps/web-mzima-client/src/app/app.component.html
+++ b/apps/web-mzima-client/src/app/app.component.html
@@ -15,7 +15,7 @@
       [languages]="languages"
       [selectedLanguage]="selectedLanguage$ | async"
     ></app-toolbar>
-    <div class="content-wrapper">
+    <div class="content-wrapper" id="content">
       <router-outlet></router-outlet>
     </div>
     <div class="mobile-page-nav" *ngIf="!isDesktop && !isInnerPage">

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -9,10 +9,19 @@
   }"
 >
   <mat-form-field appearance="outline" class="search-form__control">
-    <mzima-client-button matPrefix [iconOnly]="true" fill="clear" color="secondary">
+    <mzima-client-button
+      matPrefix
+      [iconOnly]="true"
+      fill="clear"
+      color="secondary"
+      aria-hidden="true"
+      tabindex="-1"
+    >
       <mat-icon icon svgIcon="search-small"></mat-icon>
     </mzima-client-button>
     <input
+      [attr.aria-label]="'global_filter.search' | translate"
+      aria-label=""
       matInput
       [(ngModel)]="searchQuery"
       (ngModelChange)="searchPosts()"


### PR DESCRIPTION
This pr fixes issue [4858](https://github.com/ushahidi/platform/issues/4858) which talked about the search input being inaccessible to users relying on screen readers. This pr fixes that issue by adding an '''aria-label''' attribute with the same content as the placeholder text users with normal vision would see. I also made the button just beside it (the one with the search icon) invisible to ATs as it did not perform any specific purpose other than visual aesthetics. 

To test the fix:

- Access the site with a screen reader.
- Focus on the search input.
- Should be described with the same content contained in its placeholder text.