### PR TITLE
add skip to main content link

### DIFF
--- a/apps/web-mzima-client/src/app/app.component.html
+++ b/apps/web-mzima-client/src/app/app.component.html
@@ -15,7 +15,7 @@
       [languages]="languages"
       [selectedLanguage]="selectedLanguage$ | async"
     ></app-toolbar>
-    <div class="content-wrapper">
+    <div class="content-wrapper" id="main-content">
       <router-outlet></router-outlet>
     </div>
     <div class="mobile-page-nav" *ngIf="!isDesktop && !isInnerPage">

--- a/apps/web-mzima-client/src/app/shared/components/main/sidebar/sidebar.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/main/sidebar/sidebar.component.html
@@ -8,7 +8,7 @@
     *ngIf="checkAllowedAccessToSite()"
   >
   </app-submit-post-button>
-
+  <button (click)="skipToMain()" class="visibly-hidden">Skip to main content</button>
   <nav class="sidebar__controls">
     <app-menu-list-links></app-menu-list-links>
     <app-menu-list-non-links></app-menu-list-non-links>

--- a/apps/web-mzima-client/src/app/shared/components/main/sidebar/sidebar.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/main/sidebar/sidebar.component.scss
@@ -15,25 +15,6 @@
   -webkit-overflow-scrolling: touch;
   padding: 24px var(--side-offset) 20px;
 
-  .visibly-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-
-    &:focus {
-      position: static;
-      width: auto;
-      height: auto;
-      margin: 0;
-    }
-  }
-
   &__add-post-btn {
     display: block;
     border-width: 1px 0;

--- a/apps/web-mzima-client/src/app/shared/components/main/sidebar/sidebar.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/main/sidebar/sidebar.component.scss
@@ -15,6 +15,25 @@
   -webkit-overflow-scrolling: touch;
   padding: 24px var(--side-offset) 20px;
 
+  .visibly-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+
+    &:focus {
+      position: static;
+      width: auto;
+      height: auto;
+      margin: 0;
+    }
+  }
+
   &__add-post-btn {
     display: block;
     border-width: 1px 0;

--- a/apps/web-mzima-client/src/app/shared/components/main/sidebar/sidebar.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/main/sidebar/sidebar.component.ts
@@ -25,4 +25,9 @@ export class SidebarComponent extends BaseComponent {
   }
 
   loadData(): void {}
+  skipToMain() {
+    const element = document.querySelector<HTMLDivElement>('#main-content');
+    element?.setAttribute('tabindex', '-1'); //You can set tabindex in HTML too than in JS
+    element?.focus();
+  }
 }

--- a/apps/web-mzima-client/src/styles.scss
+++ b/apps/web-mzima-client/src/styles.scss
@@ -193,3 +193,23 @@ a {
     bottom: 100px !important;
   }
 }
+
+// Visually hides an element and only displays it when it receives focus.
+.visibly-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
This pr fixes issue [#4860](https://github.com/ushahidi/platform/issues/4860) which talked about users not being able to skip navigation panel. This fix adds a "Skip to main content" button that only becomes visible when tabbed into. Clicking it skips the navigation and search and gets to the main content of the page.

To test:

- Using the tab key, start navigating through the page.
- Just after the "Add new post" button and before the navigation, a "skip to main content" should appear.
- Activating it (by pressing space or enter key depending on browser settings) should skip to the main content of the page