### PR TITLE
[Outreachy Task Submission] Improve Color Contrast of Required Field Indicators in Data Import Forms

### DIFF
--- a/apps/web-mzima-client/src/app/settings/data-import/data-import.component.html
+++ b/apps/web-mzima-client/src/app/settings/data-import/data-import.component.html
@@ -19,8 +19,8 @@
 
 <div class="form-row">
   <mat-label
-    >{{ 'data_import.import_to' | translate }}
-    {{ 'data_import.which_survey' | translate }}*</mat-label
+    >{{ 'data_import.import_to' | translate }} {{ 'data_import.which_survey' | translate
+    }}<span class="color-accent">*</span></mat-label
   >
   <mat-form-field appearance="outline">
     <mat-select
@@ -152,7 +152,7 @@
           <th mat-header-cell *matHeaderCellDef>{{ 'data_import.survey_field' | translate }}</th>
           <td mat-cell *matCellDef="let field">
             {{ field.label }}&nbsp;
-            <ng-container *ngIf="field.required">*</ng-container>
+            <span class="color-accent" *ngIf="field.required">*</span>
           </td>
         </ng-container>
 


### PR DESCRIPTION
This PR is a fix for this [issue](https://github.com/ushahidi/platform/issues/4817)
**Problem:**
The asterisk symbol indicates an input that is required was not visible enough for the user hence not perceivable to the user thus violating accessibility.
![Screenshot from 2024-03-23 17-47-00](https://github.com/ushahidi/platform-client-mzima/assets/49617104/d25d826b-eab8-4491-a584-3a9d65c99051)

**Fix:**
The asterisks in the data import forms have been replaced with a color accent, a mild red, to indicate required fields.

**Steps to Reproduce the Fix:**

1. Log in to the platform and navigate to /settings/data-import.
2. Import a CSV file and choose a survey.
3. In my case, I chose the "Simple Survey." The table fields will then appear, with all required fields marked by a color-accented asterisk (mild red).

See the screenshot below for reference.
![Screenshot from 2024-03-23 17-41-43](https://github.com/ushahidi/platform-client-mzima/assets/49617104/0bcce38c-bfa6-418c-98f0-6291d0963c52)

