### PR TITLE
[Outreachy Task Submission]: Fix default visibility setting issue in collection editing

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/collections/collections.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/collections/collections.component.ts
@@ -243,7 +243,7 @@ export class CollectionsComponent extends BaseComponent implements OnInit {
       collectionData.role = ['me'];
       collectionData['view_only']['only_me'] = true;
     } else if (visibleTo === 'everyone') {
-      collectionData.role = ['everyone'];
+      collectionData.role = null;
     } else {
       collectionData.role = collectionData.visible_to.options;
     }


### PR DESCRIPTION
### Description:
This pull request resolves issue ushahidi/platform#4868, ensuring that the "Who can see this" option defaults to "everyone" when editing a collection in the web application, maintaining consistency with the initial selection during creation.

### Testing Checklist:
1. Launch the web application with npm run web:serve.
2. Log in to the application.
3. Navigate to the collections section by clicking on the collections icon in the sidebar.
4. Click on the "Add collection" button to create a new collection.
5. Set the "Who can see this" option to "everyone" when creating the collection.
6. Navigate back to the collections section.
7. Find and click on edit icon of the collection you created.
8. Observe that the "Who can see this" option defaults to "everyone" instead of "only me"

https://github.com/ushahidi/platform-client-mzima/assets/68381641/e8a60e8a-308b-473f-a742-73189b1aff1d

