### PR TITLE
[Outreachy Task Submission] Improve Font Size For Survey Fields In Data Import Page.

### DIFF
--- a/apps/web-mzima-client/src/styles/_table.scss
+++ b/apps/web-mzima-client/src/styles/_table.scss
@@ -47,7 +47,7 @@
 
   td.mat-cell {
     @include breakpoint-max($laptop-small) {
-      font-size: 12px;
+      font-size: 16px;
     }
   }
 


### PR DESCRIPTION

This PR is a fix for this [issue](https://github.com/ushahidi/platform/issues/4865)
**Problem:**
The small font size for table cells under survey fields in the data import page makes the information difficult to read, creating a barrier for users with visual impairments. This violates accessibility guidelines.

**Fix:**
The font size for survey fields in the data import page has been changed from 12px to 16px.

**Steps to Reproduce the Fix:**

1. Log in to the platform and navigate to /settings/data-import.
2. Import a CSV file and choose a survey.
3. Select a survey, in my case 'Simple Survey', in the data import, the font size for the table cells beneath the survey is much bigger. This makes the information easier to read.

See the screenshot below for reference.
![Screenshot from 2024-03-23 17-41-43](https://github.com/ushahidi/platform-client-mzima/assets/49617104/0bcce38c-bfa6-418c-98f0-6291d0963c52)

