### PR TITLE
[Outreachy Task Submission] No Keyboard Focus Effect For Tabs

### DIFF
--- a/apps/web-mzima-client/src/styles/_tabs.scss
+++ b/apps/web-mzima-client/src/styles/_tabs.scss
@@ -46,6 +46,11 @@
       }
     }
 
+    &.cdk-keyboard-focused {
+      background: var(--color-primary-60) !important;
+      color: var(--color-black);
+    }
+
     &.mat-tab-disabled {
       color: var(--color-neutral-50);
     }


### PR DESCRIPTION
Resolves [#4871](https://github.com/ushahidi/platform/issues/4871)

**Description**

The Ushahidi Platform currently lacks a visible focus effect on tabs, making it difficult for keyboard users to identify which tabs are currently focused. Adding visible focus styles, such as a distinct outline or background color, will improve accessibility by providing clear visual cues for keyboard navigation. This simple enhancement will empower users to navigate the tab interface with ease, ensuring a more inclusive experience for all

**Before Fix**

https://github.com/ushahidi/platform-client-mzima/assets/46582086/c8d16bcf-a057-406a-baa6-c28bf6d19cc3

**After Fix**

https://github.com/ushahidi/platform-client-mzima/assets/46582086/e108a4e9-34e8-482d-bfef-0b6a3a899717

**How to test**

1. Navigate to any tab component using keyboard tab key.
2. when the focus gets to the component you'll notice the background color of the focused tab changes.
3. click right and left arrow keys to change focus between tabs headers
4. press enter to switch tab view.

@Angamanga This pr is ready for review 🙏🏽 
