### PR TITLE
[Outreachy Task Submission] Stop Support Modal from Closing When list item is clicked

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
@@ -39,7 +39,6 @@ export class SupportModalComponent extends BaseComponent {
         description: this.translate.instant('app.documentation.description'),
         action: () => {
           this.openUrl('https://docs.ushahidi.com/platform-user-manual');
-          this.closeModal();
         },
       },
       {
@@ -47,7 +46,6 @@ export class SupportModalComponent extends BaseComponent {
         description: this.translate.instant('app.report_a_bug.description'),
         action: () => {
           this.openUrl('https://github.com/ushahidi/platform/issues/new');
-          this.closeModal();
         },
       },
       {
@@ -55,7 +53,6 @@ export class SupportModalComponent extends BaseComponent {
         description: this.translate.instant('app.features.description'),
         action: () => {
           this.openUrl('https://www.ushahidi.com/features/');
-          this.closeModal();
         },
       },
       {
@@ -66,7 +63,6 @@ export class SupportModalComponent extends BaseComponent {
             type: EventType.ShowOnboarding,
             payload: true,
           });
-          this.closeModal();
         },
       },
       // {


### PR DESCRIPTION
# Introduction
This fixes [#4877](https://github.com/ushahidi/platform/issues/4877).
It stops the support modal in the `help & support` section from closing every time one of the listen items in it is clicked.

## How to Test the PR
1. In your browser, go to your current deployment page (your `localhost:4200` homepage).
2. Log in.
3. Click on `help & support`.
4. When the modal pops up, click on any of the listed items there.
5. You will notice that it redirects you to a different page, but on a new tab. Go back or close this current tab.
6. You will find yourself back on the tab you opened your deployment in, but you will notice that the modal is no longer there.
7. You will also notice that you have to repeat step 3 to make the modal open again.
8. Stop your running deployment.
9. Checkout to this PR.
10. Restart your deployment (with this PR as the checked-out branch).
11. Repeat steps 1 - 5 (you can ignore step 2 if you're still logged in).
12. You will find yourself back on the tab you were in, but this time around, the modal will still be there.
