### PR TITLE
[USH-1138] Data view: Page content jumps around when navigating to post details

### DIFF
--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -14,11 +14,12 @@
         [ngClass]="{ 'feed-page__results-info__dim': !posts.length }"
         [attr.data-qa]="'feed-page-results'"
       >
-        <ng-container *ngIf="!posts.length">Loading current posts...</ng-container>
-        <ng-container *ngIf="posts.length"
-          >{{ 'app.current_results' | translate }} {{ postCurrentLength }} /
-          {{ total }}</ng-container
-        >
+        <ng-container *ngIf="!posts.length && isLoading">Loading posts...</ng-container>
+        <ng-container *ngIf="posts.length || (!posts.length && !isLoading)">
+          {{ 'app.current_results' | translate }}
+          {{ postCurrentLength }}
+        </ng-container>
+        <ng-container *ngIf="posts.length"> / {{ total }} </ng-container>
       </span>
       <div class="feed-page__mode-switcher">
         <mzima-client-button

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -1,8 +1,13 @@
+<!-- POST mode notes [for when there are no posts at all or if there are no posts that match filters]: 
+    When there are no posts in POST mode,
+    Page (css) style just adopts that of TILES mode
+    Better than making extra route request to TILES mode
+-->
 <div
   class="feed-page"
   [ngClass]="{
     'feed-page--filters-visible': isFiltersVisible,
-    'feed-page--post-view': mode === FeedMode.Post,
+    'feed-page--post-view': mode === FeedMode.Post && (isLoading || posts.length),
     'feed-page--no-offset': !isMainFiltersOpen
   }"
 >
@@ -14,7 +19,9 @@
         [ngClass]="{ 'feed-page__results-info__dim': !posts.length }"
         [attr.data-qa]="'feed-page-results'"
       >
-        <ng-container *ngIf="!posts.length && isLoading">Loading posts...</ng-container>
+        <ng-container *ngIf="!posts.length && isLoading"
+          >Loading posts in {{ mode }} mode...</ng-container
+        >
         <ng-container *ngIf="posts.length || (!posts.length && !isLoading)">
           {{ 'app.current_results' | translate }}
           {{ postCurrentLength }}
@@ -202,8 +209,9 @@
       #feed
       class="feed"
       [ngClass]="{
-        'feed--post-view': mode === FeedMode.Post,
-        'feed--post-view-loaded': mode === FeedMode.Post && !isLoading,
+        'feed__posts-scroll': !isLoading,
+        'feed--post-view': mode === FeedMode.Post && (isLoading || posts.length),
+        'feed--post-view-loaded': mode === FeedMode.Post && !isLoading && posts.length,
         'feed--post-view-skeleton': mode === FeedMode.Post && isLoading
       }"
     >

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -6,7 +6,7 @@
     'feed-page--no-offset': !isMainFiltersOpen
   }"
 >
-  <ng-container *ngIf="posts.length">
+  <ng-container>
     <div class="feed-page__info-panel" *ngIf="isDesktop">
       <span class="feed-page__results-info" [attr.data-qa]="'feed-page-results'"
         >{{ 'app.current_results' | translate }} {{ postCurrentLength }} / {{ total }}</span
@@ -19,6 +19,7 @@
           [color]="mode === FeedMode.Tiles ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Tiles"
           (buttonClick)="switchMode(FeedMode.Tiles)"
+          [disabled]="!posts.length"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="tiles"></mat-icon>
@@ -30,6 +31,7 @@
           [color]="mode === FeedMode.Post ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Post"
           (buttonClick)="switchMode(FeedMode.Post)"
+          [disabled]="!posts.length"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="sidebar"></mat-icon>
@@ -134,6 +136,7 @@
           class="feed-page__control feed-page__control--bulk"
           *ngIf="user?.allowed_privileges?.includes('update')"
           (buttonClick)="toggleBulkOptions(!isBulkOptionsVisible)"
+          [disabled]="!posts.length"
         >
           {{ 'post.modify.bulk_actions' | translate }}
         </mzima-client-button>
@@ -144,6 +147,7 @@
             [iconOnly]="!isDesktop"
             [matMenuTriggerFor]="sortingMenu"
             class="feed-page__control feed-page__control--sorting"
+            [disabled]="!posts.length"
           >
             <span *ngIf="isDesktop">{{ 'global_filter.sorting' | translate }}</span>
             <mat-icon icon svgIcon="sorting"></mat-icon>

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -6,8 +6,9 @@
     'feed-page--no-offset': !isMainFiltersOpen
   }"
 >
-  <!-- Reminder: "isLoading" and "postsCheck().stillLoading" are not the same - see github comment: https://github.com/ushahidi/platform-client-mzima/pull/783#discussion_r1492422808 -->
-  <ng-container *ngIf="(posts.length > 0 && isLoading) || (posts.length === 0 && isLoading)">
+  <!-- When there are no posts or filters match no posts: --
+    -- This entire switch Mode area should not show up    -->
+  <ng-container *ngIf="isLoading || atLeastOnePostExists">
     <div class="feed-page__info-panel" *ngIf="isDesktop">
       <span
         class="feed-page__results-info"
@@ -28,7 +29,7 @@
           [color]="mode === FeedMode.Tiles ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Tiles"
           (buttonClick)="switchMode(FeedMode.Tiles)"
-          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
+          [disabled]="isLoading"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="tiles"></mat-icon>
@@ -40,7 +41,7 @@
           [color]="mode === FeedMode.Post ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Post"
           (buttonClick)="switchMode(FeedMode.Post)"
-          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
+          [disabled]="isLoading"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="sidebar"></mat-icon>
@@ -145,7 +146,7 @@
           class="feed-page__control feed-page__control--bulk"
           *ngIf="user?.allowed_privileges?.includes('update')"
           (buttonClick)="toggleBulkOptions(!isBulkOptionsVisible)"
-          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
+          [disabled]="isLoading"
         >
           {{ 'post.modify.bulk_actions' | translate }}
         </mzima-client-button>
@@ -156,7 +157,7 @@
             [iconOnly]="!isDesktop"
             [matMenuTriggerFor]="sortingMenu"
             class="feed-page__control feed-page__control--sorting"
-            [disabled]="posts.length >= 0 && postsCheck().stillLoading"
+            [disabled]="isLoading"
           >
             <span *ngIf="isDesktop">{{ 'global_filter.sorting' | translate }}</span>
             <mat-icon icon svgIcon="sorting"></mat-icon>
@@ -197,23 +198,11 @@
 
   <div class="feed-page__main" [attr.data-qa]="'posts'">
     <!-- (scroll)="onScroll($event)" -->
-    <div
-      #feed
-      class="feed"
-      [ngClass]="{
-        'feed__posts-scroll': !isLoading,
-        'feed--post-view': mode === FeedMode.Post,
-        'feed--post-view-loaded': mode === FeedMode.Post && !isLoading,
-        'feed--post-view-skeleton': mode === FeedMode.Post && isLoading
-      }"
-    >
+    <div #feed class="feed" [ngClass]="{ 'feed--post-view': mode === FeedMode.Post }">
       <ng-container>
         <div class="feed__posts">
           <ng-container *ngIf="isLoading">
-            <app-spinner *ngIf="mode === FeedMode.Tiles" class="spinner"></app-spinner>
-            <ng-container *ngIf="mode === FeedMode.Post">
-              <div *ngFor="let single of postsSkeleton" class="post post--feed-skeleton"></div>
-            </ng-container>
+            <app-spinner class="spinner"></app-spinner>
           </ng-container>
           <ng-container *ngIf="!isLoading">
             <!-- No posts yet -->
@@ -300,7 +289,7 @@
     </div>
     <div class="feed-page__post" *ngIf="mode === FeedMode.Post" [attr.data-qa]="'post-details'">
       <router-outlet
-        *ngIf="posts.length || !postsCheck().stillLoading; else loader"
+        *ngIf="posts.length || !isLoading; else loader"
         (activate)="onOutletLoaded($event)"
       ></router-outlet>
     </div>

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -6,8 +6,9 @@
     'feed-page--no-offset': !isMainFiltersOpen
   }"
 >
-  <!-- Reminder: "isLoading" and "postsCheck().stillLoading" are not the same - see github comment: https://github.com/ushahidi/platform-client-mzima/pull/783#discussion_r1492422808 -->
-  <ng-container *ngIf="(posts.length > 0 && isLoading) || (posts.length === 0 && isLoading)">
+  <!-- When there are no posts or filters match no posts: --
+    -- This entire switch Mode area should not show up    -->
+  <ng-container *ngIf="isLoading || atLeastOnePostExists">
     <div class="feed-page__info-panel" *ngIf="isDesktop">
       <span
         class="feed-page__results-info"
@@ -28,7 +29,7 @@
           [color]="mode === FeedMode.Tiles ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Tiles"
           (buttonClick)="switchMode(FeedMode.Tiles)"
-          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
+          [disabled]="isLoading"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="tiles"></mat-icon>
@@ -40,7 +41,7 @@
           [color]="mode === FeedMode.Post ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Post"
           (buttonClick)="switchMode(FeedMode.Post)"
-          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
+          [disabled]="isLoading"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="sidebar"></mat-icon>
@@ -145,7 +146,7 @@
           class="feed-page__control feed-page__control--bulk"
           *ngIf="user?.allowed_privileges?.includes('update')"
           (buttonClick)="toggleBulkOptions(!isBulkOptionsVisible)"
-          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
+          [disabled]="isLoading"
         >
           {{ 'post.modify.bulk_actions' | translate }}
         </mzima-client-button>
@@ -156,7 +157,7 @@
             [iconOnly]="!isDesktop"
             [matMenuTriggerFor]="sortingMenu"
             class="feed-page__control feed-page__control--sorting"
-            [disabled]="posts.length >= 0 && postsCheck().stillLoading"
+            [disabled]="isLoading"
           >
             <span *ngIf="isDesktop">{{ 'global_filter.sorting' | translate }}</span>
             <mat-icon icon svgIcon="sorting"></mat-icon>
@@ -198,85 +199,97 @@
   <div class="feed-page__main" [attr.data-qa]="'posts'">
     <!-- (scroll)="onScroll($event)" -->
     <div #feed class="feed" [ngClass]="{ 'feed--post-view': mode === FeedMode.Post }">
-      <ng-container *ngIf="!postsCheck().stillLoading; else loader">
-        <div class="feed__posts" *ngIf="postsCheck().atLeastOneExists; else postsEmpty">
-          <ngx-masonry
-            #masonry
-            [ordered]="true"
-            [options]="masonryOptions"
-            [updateLayout]="updateMasonryLayout"
-            [attr.data-qa]="'post-preview'"
-          >
-            <app-post-preview
-              [attr.data-qa]="'post-item'"
-              class="post"
-              [post]="post"
-              [attr.postId]="post.id"
-              [user]="user"
-              ngxMasonryItem
-              [feedView]="true"
-              (edit)="editPost(post)"
-              (refresh)="refreshPost(post)"
-              (deleted)="postDeleted([post])"
-              (click)="showPostDetails(post)"
-              [selectable]="isBulkOptionsVisible"
-              [isChecked]="isPostChecked(post)"
-              (statusChanged)="postStatusChanged()"
-              (selected)="isPostSelected($event, post)"
-              (mediaLoaded)="updateMasonry()"
-              [ngClass]="{
-                'post--selected':
-                  post.id === postDetails?.id ||
-                  (mode === FeedMode.Post && post.id === activePostId)
-              }"
-              *ngFor="
-                let post of posts
-                  | paginate
-                    : {
-                        itemsPerPage: mode === FeedMode.Post ? 0 : itemsPerPage,
-                        currentPage: currentPage,
-                        totalItems: total
-                      }
-              "
-            >
-            </app-post-preview>
-          </ngx-masonry>
-          <ng-container *ngIf="!isLoading && paginationElementsAllowed">
-            <!-- load more -->
-            <ng-container
-              *ngIf="
-                mode === FeedMode.Post && params.page !== undefined && params.limit !== undefined
-              "
-            >
-              <mzima-client-button
-                fill="clear"
-                color="secondary"
-                (buttonClick)="loadMore()"
-                class="feed__load-more"
-                *ngIf="!loadingMorePosts && postCurrentLength < total"
-              >
-                <mat-icon iconPrefix svgIcon="refresh"></mat-icon>
-                <span>{{ 'app.load_more' | translate }}</span>
-              </mzima-client-button>
-              <app-spinner *ngIf="loadingMorePosts && postCurrentLength < total"></app-spinner>
-              <div class="endofPosts" *ngIf="!loadingMorePosts && postCurrentLength >= total">
-                End of Posts
-              </div>
+      <ng-container>
+        <div class="feed__posts">
+          <ng-container *ngIf="isLoading">
+            <app-spinner class="spinner"></app-spinner>
+          </ng-container>
+          <ng-container *ngIf="!isLoading">
+            <!-- No posts yet -->
+            <ng-container *ngIf="noPostsYet">
+              <span class="posts-empty">{{ 'post.no_posts_yet' | translate }}</span>
             </ng-container>
-            <!-- pagination -->
-            <pagination-controls
-              class="pagination"
-              (pageChange)="changePage($event)"
-              *ngIf="mode === FeedMode.Tiles"
-            >
-            </pagination-controls>
+            <!-- Posts -->
+            <ng-container *ngIf="atLeastOnePostExists">
+              <ngx-masonry
+                #masonry
+                [ordered]="true"
+                [options]="masonryOptions"
+                [updateLayout]="updateMasonryLayout"
+                [attr.data-qa]="'post-preview'"
+              >
+                <app-post-preview
+                  [attr.data-qa]="'post-item'"
+                  class="post"
+                  [post]="post"
+                  [attr.postId]="post.id"
+                  [user]="user"
+                  ngxMasonryItem
+                  [feedView]="true"
+                  (edit)="editPost(post)"
+                  (refresh)="refreshPost(post)"
+                  (deleted)="postDeleted([post])"
+                  (click)="showPostDetails(post)"
+                  [selectable]="isBulkOptionsVisible"
+                  [isChecked]="isPostChecked(post)"
+                  (statusChanged)="postStatusChanged()"
+                  (selected)="isPostSelected($event, post)"
+                  (mediaLoaded)="updateMasonry()"
+                  [ngClass]="{
+                    'post--selected':
+                      post.id === postDetails?.id ||
+                      (mode === FeedMode.Post && post.id === activePostId)
+                  }"
+                  *ngFor="
+                    let post of posts
+                      | paginate
+                        : {
+                            itemsPerPage: mode === FeedMode.Post ? 0 : itemsPerPage,
+                            currentPage: currentPage,
+                            totalItems: total
+                          }
+                  "
+                >
+                </app-post-preview>
+              </ngx-masonry>
+            </ng-container>
+            <ng-container *ngIf="paginationElementsAllowed">
+              <!-- load more -->
+              <ng-container
+                *ngIf="
+                  mode === FeedMode.Post && params.page !== undefined && params.limit !== undefined
+                "
+              >
+                <mzima-client-button
+                  fill="clear"
+                  color="secondary"
+                  (buttonClick)="loadMore()"
+                  class="feed__load-more"
+                  *ngIf="!loadingMorePosts && postCurrentLength < total"
+                >
+                  <mat-icon iconPrefix svgIcon="refresh"></mat-icon>
+                  <span>{{ 'app.load_more' | translate }}</span>
+                </mzima-client-button>
+                <app-spinner *ngIf="loadingMorePosts && postCurrentLength < total"></app-spinner>
+                <div class="endofPosts" *ngIf="!loadingMorePosts && postCurrentLength >= total">
+                  End of Posts
+                </div>
+              </ng-container>
+              <!-- pagination -->
+              <pagination-controls
+                class="pagination"
+                (pageChange)="changePage($event)"
+                *ngIf="mode === FeedMode.Tiles"
+              >
+              </pagination-controls>
+            </ng-container>
           </ng-container>
         </div>
       </ng-container>
     </div>
     <div class="feed-page__post" *ngIf="mode === FeedMode.Post" [attr.data-qa]="'post-details'">
       <router-outlet
-        *ngIf="posts.length || !postsCheck().stillLoading; else loader"
+        *ngIf="posts.length || !isLoading; else loader"
         (activate)="onOutletLoaded($event)"
       ></router-outlet>
     </div>
@@ -287,6 +300,6 @@
   <app-spinner class="spinner"></app-spinner>
 </ng-template>
 
-<ng-template #postsEmpty>
+<!-- <ng-template #postsEmpty>
   <span class="posts-empty">{{ 'post.no_posts_yet' | translate }}</span>
-</ng-template>
+</ng-template> -->

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -217,7 +217,7 @@
     >
       <ng-container>
         <div class="feed__posts">
-          <ng-container *ngIf="isLoading">
+          <ng-container *ngIf="isLoading || (!posts.length && !noPostsYet)">
             <app-spinner *ngIf="mode === FeedMode.Tiles" class="spinner"></app-spinner>
             <ng-container *ngIf="mode === FeedMode.Post">
               <div *ngFor="let single of postsSkeleton" class="post post--feed-skeleton"></div>
@@ -229,7 +229,7 @@
               <span class="posts-empty">{{ 'post.no_posts_yet' | translate }}</span>
             </ng-container>
             <!-- Posts -->
-            <ng-container *ngIf="atLeastOnePostExists">
+            <ng-container *ngIf="posts.length">
               <ngx-masonry
                 #masonry
                 [ordered]="true"
@@ -271,12 +271,20 @@
                 >
                 </app-post-preview>
               </ngx-masonry>
-            </ng-container>
-            <ng-container *ngIf="paginationElementsAllowed">
-              <!-- load more -->
+              <!-- pagination -->
+              <pagination-controls
+                class="pagination"
+                (pageChange)="changePage($event)"
+                *ngIf="mode === FeedMode.Tiles && paginationElementsAllowed"
+              >
+              </pagination-controls>
+              <!-- Load more posts -->
               <ng-container
                 *ngIf="
-                  mode === FeedMode.Post && params.page !== undefined && params.limit !== undefined
+                  mode === FeedMode.Post &&
+                  paginationElementsAllowed &&
+                  params.page !== undefined &&
+                  params.limit !== undefined
                 "
               >
                 <mzima-client-button
@@ -294,13 +302,6 @@
                   End of Posts
                 </div>
               </ng-container>
-              <!-- pagination -->
-              <pagination-controls
-                class="pagination"
-                (pageChange)="changePage($event)"
-                *ngIf="mode === FeedMode.Tiles"
-              >
-              </pagination-controls>
             </ng-container>
           </ng-container>
         </div>

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -6,7 +6,8 @@
     'feed-page--no-offset': !isMainFiltersOpen
   }"
 >
-  <ng-container>
+  <!-- Reminder: "isLoading" and "postsCheck().stillLoading" are not the same - see github comment: https://github.com/ushahidi/platform-client-mzima/pull/783#discussion_r1492422808 -->
+  <ng-container *ngIf="(posts.length > 0 && isLoading) || (posts.length === 0 && isLoading)">
     <div class="feed-page__info-panel" *ngIf="isDesktop">
       <span
         class="feed-page__results-info"
@@ -27,7 +28,7 @@
           [color]="mode === FeedMode.Tiles ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Tiles"
           (buttonClick)="switchMode(FeedMode.Tiles)"
-          [disabled]="!posts.length"
+          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="tiles"></mat-icon>
@@ -39,7 +40,7 @@
           [color]="mode === FeedMode.Post ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Post"
           (buttonClick)="switchMode(FeedMode.Post)"
-          [disabled]="!posts.length"
+          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="sidebar"></mat-icon>
@@ -144,7 +145,7 @@
           class="feed-page__control feed-page__control--bulk"
           *ngIf="user?.allowed_privileges?.includes('update')"
           (buttonClick)="toggleBulkOptions(!isBulkOptionsVisible)"
-          [disabled]="!posts.length"
+          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
         >
           {{ 'post.modify.bulk_actions' | translate }}
         </mzima-client-button>
@@ -155,7 +156,7 @@
             [iconOnly]="!isDesktop"
             [matMenuTriggerFor]="sortingMenu"
             class="feed-page__control feed-page__control--sorting"
-            [disabled]="!posts.length"
+            [disabled]="posts.length >= 0 && postsCheck().stillLoading"
           >
             <span *ngIf="isDesktop">{{ 'global_filter.sorting' | translate }}</span>
             <mat-icon icon svgIcon="sorting"></mat-icon>
@@ -297,16 +298,11 @@
         </div>
       </ng-container>
     </div>
-    <div
-      class="feed-page__post"
-      [ngClass]="{ 'feed--post-view-skeleton': isLoading }"
-      *ngIf="mode === FeedMode.Post"
-      [attr.data-qa]="'post-details'"
-    >
-      <ng-container *ngIf="isLoading">
-        <app-spinner class="spinner"></app-spinner>
-      </ng-container>
-      <router-outlet *ngIf="!isLoading" (activate)="onOutletLoaded($event)"></router-outlet>
+    <div class="feed-page__post" *ngIf="mode === FeedMode.Post" [attr.data-qa]="'post-details'">
+      <router-outlet
+        *ngIf="posts.length || !postsCheck().stillLoading; else loader"
+        (activate)="onOutletLoaded($event)"
+      ></router-outlet>
     </div>
   </div>
 </div>

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -198,11 +198,22 @@
 
   <div class="feed-page__main" [attr.data-qa]="'posts'">
     <!-- (scroll)="onScroll($event)" -->
-    <div #feed class="feed" [ngClass]="{ 'feed--post-view': mode === FeedMode.Post }">
+    <div
+      #feed
+      class="feed"
+      [ngClass]="{
+        'feed--post-view': mode === FeedMode.Post,
+        'feed--post-view-loaded': mode === FeedMode.Post && !isLoading,
+        'feed--post-view-skeleton': mode === FeedMode.Post && isLoading
+      }"
+    >
       <ng-container>
         <div class="feed__posts">
           <ng-container *ngIf="isLoading">
-            <app-spinner class="spinner"></app-spinner>
+            <app-spinner *ngIf="mode === FeedMode.Tiles" class="spinner"></app-spinner>
+            <ng-container *ngIf="mode === FeedMode.Post">
+              <div *ngFor="let single of postsSkeleton" class="post post--feed-skeleton"></div>
+            </ng-container>
           </ng-container>
           <ng-container *ngIf="!isLoading">
             <!-- No posts yet -->
@@ -287,11 +298,16 @@
         </div>
       </ng-container>
     </div>
-    <div class="feed-page__post" *ngIf="mode === FeedMode.Post" [attr.data-qa]="'post-details'">
-      <router-outlet
-        *ngIf="posts.length || !isLoading; else loader"
-        (activate)="onOutletLoaded($event)"
-      ></router-outlet>
+    <div
+      class="feed-page__post"
+      [ngClass]="{ 'feed--post-view-skeleton': isLoading }"
+      *ngIf="mode === FeedMode.Post"
+      [attr.data-qa]="'post-details'"
+    >
+      <ng-container *ngIf="isLoading">
+        <app-spinner class="spinner"></app-spinner>
+      </ng-container>
+      <router-outlet *ngIf="!isLoading" (activate)="onOutletLoaded($event)"></router-outlet>
     </div>
   </div>
 </div>

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -6,9 +6,7 @@
     'feed-page--no-offset': !isMainFiltersOpen
   }"
 >
-  <!-- When there are no posts or filters match no posts: --
-    -- This entire switch Mode area should not show up    -->
-  <ng-container *ngIf="isLoading || atLeastOnePostExists">
+  <ng-container>
     <div class="feed-page__info-panel" *ngIf="isDesktop">
       <span
         class="feed-page__results-info"
@@ -29,7 +27,7 @@
           [color]="mode === FeedMode.Tiles ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Tiles"
           (buttonClick)="switchMode(FeedMode.Tiles)"
-          [disabled]="isLoading"
+          [disabled]="!posts.length"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="tiles"></mat-icon>
@@ -41,7 +39,7 @@
           [color]="mode === FeedMode.Post ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Post"
           (buttonClick)="switchMode(FeedMode.Post)"
-          [disabled]="isLoading"
+          [disabled]="!posts.length"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="sidebar"></mat-icon>
@@ -146,7 +144,7 @@
           class="feed-page__control feed-page__control--bulk"
           *ngIf="user?.allowed_privileges?.includes('update')"
           (buttonClick)="toggleBulkOptions(!isBulkOptionsVisible)"
-          [disabled]="isLoading"
+          [disabled]="!posts.length"
         >
           {{ 'post.modify.bulk_actions' | translate }}
         </mzima-client-button>
@@ -157,7 +155,7 @@
             [iconOnly]="!isDesktop"
             [matMenuTriggerFor]="sortingMenu"
             class="feed-page__control feed-page__control--sorting"
-            [disabled]="isLoading"
+            [disabled]="!posts.length"
           >
             <span *ngIf="isDesktop">{{ 'global_filter.sorting' | translate }}</span>
             <mat-icon icon svgIcon="sorting"></mat-icon>

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -6,9 +6,8 @@
     'feed-page--no-offset': !isMainFiltersOpen
   }"
 >
-  <!-- When there are no posts or filters match no posts: --
-    -- This entire switch Mode area should not show up    -->
-  <ng-container *ngIf="isLoading || atLeastOnePostExists">
+  <!-- This entire switch Mode area should always show up -->
+  <ng-container>
     <div class="feed-page__info-panel" *ngIf="isDesktop">
       <span
         class="feed-page__results-info"
@@ -29,7 +28,7 @@
           [color]="mode === FeedMode.Tiles ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Tiles"
           (buttonClick)="switchMode(FeedMode.Tiles)"
-          [disabled]="isLoading"
+          [disabled]="isLoading || !posts.length"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="tiles"></mat-icon>
@@ -41,7 +40,7 @@
           [color]="mode === FeedMode.Post ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Post"
           (buttonClick)="switchMode(FeedMode.Post)"
-          [disabled]="isLoading"
+          [disabled]="isLoading || !posts.length"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="sidebar"></mat-icon>
@@ -146,7 +145,7 @@
           class="feed-page__control feed-page__control--bulk"
           *ngIf="user?.allowed_privileges?.includes('update')"
           (buttonClick)="toggleBulkOptions(!isBulkOptionsVisible)"
-          [disabled]="isLoading"
+          [disabled]="isLoading || !posts.length"
         >
           {{ 'post.modify.bulk_actions' | translate }}
         </mzima-client-button>
@@ -157,7 +156,7 @@
             [iconOnly]="!isDesktop"
             [matMenuTriggerFor]="sortingMenu"
             class="feed-page__control feed-page__control--sorting"
-            [disabled]="isLoading"
+            [disabled]="isLoading || !posts.length"
           >
             <span *ngIf="isDesktop">{{ 'global_filter.sorting' | translate }}</span>
             <mat-icon icon svgIcon="sorting"></mat-icon>

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -8,9 +8,17 @@
 >
   <ng-container>
     <div class="feed-page__info-panel" *ngIf="isDesktop">
-      <span class="feed-page__results-info" [attr.data-qa]="'feed-page-results'"
-        >{{ 'app.current_results' | translate }} {{ postCurrentLength }} / {{ total }}</span
+      <span
+        class="feed-page__results-info"
+        [ngClass]="{ 'feed-page__results-info__dim': !posts.length }"
+        [attr.data-qa]="'feed-page-results'"
       >
+        <ng-container *ngIf="!posts.length">Loading current posts...</ng-container>
+        <ng-container *ngIf="posts.length"
+          >{{ 'app.current_results' | translate }} {{ postCurrentLength }} /
+          {{ total }}</ng-container
+        >
+      </span>
       <div class="feed-page__mode-switcher">
         <mzima-client-button
           [fill]="mode === FeedMode.Tiles ? 'outline' : 'solid'"

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -6,7 +6,8 @@
     'feed-page--no-offset': !isMainFiltersOpen
   }"
 >
-  <ng-container>
+  <!-- Reminder: "isLoading" and "postsCheck().stillLoading" are not the same - see github comment: https://github.com/ushahidi/platform-client-mzima/pull/783#discussion_r1492422808 -->
+  <ng-container *ngIf="(posts.length > 0 && isLoading) || (posts.length === 0 && isLoading)">
     <div class="feed-page__info-panel" *ngIf="isDesktop">
       <span
         class="feed-page__results-info"
@@ -27,7 +28,7 @@
           [color]="mode === FeedMode.Tiles ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Tiles"
           (buttonClick)="switchMode(FeedMode.Tiles)"
-          [disabled]="!posts.length"
+          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="tiles"></mat-icon>
@@ -39,7 +40,7 @@
           [color]="mode === FeedMode.Post ? 'primary' : 'light'"
           [isActive]="mode === FeedMode.Post"
           (buttonClick)="switchMode(FeedMode.Post)"
-          [disabled]="!posts.length"
+          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
           class="feed-page__mode-switcher__button"
         >
           <mat-icon icon svgIcon="sidebar"></mat-icon>
@@ -144,7 +145,7 @@
           class="feed-page__control feed-page__control--bulk"
           *ngIf="user?.allowed_privileges?.includes('update')"
           (buttonClick)="toggleBulkOptions(!isBulkOptionsVisible)"
-          [disabled]="!posts.length"
+          [disabled]="posts.length >= 0 && postsCheck().stillLoading"
         >
           {{ 'post.modify.bulk_actions' | translate }}
         </mzima-client-button>
@@ -155,7 +156,7 @@
             [iconOnly]="!isDesktop"
             [matMenuTriggerFor]="sortingMenu"
             class="feed-page__control feed-page__control--sorting"
-            [disabled]="!posts.length"
+            [disabled]="posts.length >= 0 && postsCheck().stillLoading"
           >
             <span *ngIf="isDesktop">{{ 'global_filter.sorting' | translate }}</span>
             <mat-icon icon svgIcon="sorting"></mat-icon>
@@ -274,7 +275,10 @@
       </ng-container>
     </div>
     <div class="feed-page__post" *ngIf="mode === FeedMode.Post" [attr.data-qa]="'post-details'">
-      <router-outlet></router-outlet>
+      <router-outlet
+        *ngIf="posts.length || !postsCheck().stillLoading; else loader"
+        (activate)="onOutletLoaded($event)"
+      ></router-outlet>
     </div>
   </div>
 </div>

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -311,11 +311,3 @@
     </div>
   </div>
 </div>
-
-<ng-template #loader>
-  <app-spinner class="spinner"></app-spinner>
-</ng-template>
-
-<!-- <ng-template #postsEmpty>
-  <span class="posts-empty">{{ 'post.no_posts_yet' | translate }}</span>
-</ng-template> -->

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -202,6 +202,7 @@
       #feed
       class="feed"
       [ngClass]="{
+        'feed__posts-scroll': !isLoading,
         'feed--post-view': mode === FeedMode.Post,
         'feed--post-view-loaded': mode === FeedMode.Post && !isLoading,
         'feed--post-view-skeleton': mode === FeedMode.Post && isLoading

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -316,7 +316,7 @@
       <ng-container *ngIf="isLoading">
         <app-spinner class="spinner"></app-spinner>
       </ng-container>
-      <router-outlet *ngIf="!isLoading" (activate)="onOutletLoaded($event)"></router-outlet>
+      <router-outlet *ngIf="!isLoading"></router-outlet>
     </div>
   </div>
 </div>

--- a/apps/web-mzima-client/src/app/feed/feed.component.scss
+++ b/apps/web-mzima-client/src/app/feed/feed.component.scss
@@ -235,6 +235,10 @@
     font-size: 14px;
     line-height: 17px;
     color: var(--color-neutral-100);
+
+    &__dim {
+      color: var(--color-neutral-70);
+    }
   }
 
   &__mode-switcher {

--- a/apps/web-mzima-client/src/app/feed/feed.component.scss
+++ b/apps/web-mzima-client/src/app/feed/feed.component.scss
@@ -317,6 +317,14 @@
     padding-inline-end: 16px;
   }
 
+  &__posts-scroll {
+    --scrollbar-background: var(--color-light);
+    overflow-y: auto;
+    overflow-x: hidden;
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+  }
+
   &--post-view {
     padding: 0;
     width: 337px;
@@ -331,11 +339,6 @@
 
     &-loaded {
       background: var(--color-light);
-      --scrollbar-background: var(--color-light);
-      overflow-y: auto;
-      overflow-x: hidden;
-      scroll-behavior: smooth;
-      -webkit-overflow-scrolling: touch;
     }
 
     &-skeleton {

--- a/apps/web-mzima-client/src/app/feed/feed.component.scss
+++ b/apps/web-mzima-client/src/app/feed/feed.component.scss
@@ -296,13 +296,9 @@
 .feed {
   height: 100%;
   flex-shrink: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scroll-behavior: smooth;
   padding-bottom: 32px;
   padding-inline-end: 8px;
   padding-inline-start: 24px;
-  -webkit-overflow-scrolling: touch;
 
   @include breakpoint-max($laptop-small) {
     padding-inline-end: 0;
@@ -326,21 +322,41 @@
     width: 337px;
     border-radius: 4px;
     padding-bottom: 24px;
+    border: 1px solid var(--color-neutral-20);
 
     @include breakpoint-max($laptop-small) {
       width: 280px;
       padding-bottom: 16px;
     }
+
+    &-loaded {
+      background: var(--color-light);
+      --scrollbar-background: var(--color-light);
+      overflow-y: auto;
+      overflow-x: hidden;
+      scroll-behavior: smooth;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    &-skeleton {
+      border: 1px solid var(--color-neutral-20);
+    }
   }
 
   &__posts {
-    .feed--post-view & {
+    .feed--post-view-loaded & {
       padding: 16px 32px 24px 16px;
-      background: var(--color-light);
-      --scrollbar-background: var(--color-light);
 
       @include breakpoint-max($laptop-small) {
         padding: 8px 16px 16px 8px;
+      }
+    }
+
+    .feed--post-view-skeleton & {
+      padding: 16px;
+
+      @include breakpoint-max($laptop-small) {
+        padding: 8px;
       }
     }
   }
@@ -395,6 +411,15 @@
     width: 100%;
     margin-left: 0;
     margin-right: 0;
+  }
+
+  &--feed-skeleton {
+    padding: 32px 24px;
+    cursor: default;
+    min-height: 135px;
+    border-radius: 4px;
+    box-shadow: inset 0 0 0 1px var(--color-neutral-30);
+    background: var(--color-neutral-20);
   }
 
   &--selected {

--- a/apps/web-mzima-client/src/app/feed/feed.component.scss
+++ b/apps/web-mzima-client/src/app/feed/feed.component.scss
@@ -339,6 +339,11 @@
 
     &-loaded {
       background: var(--color-light);
+      --scrollbar-background: var(--color-light);
+      overflow-y: auto;
+      overflow-x: hidden;
+      scroll-behavior: smooth;
+      -webkit-overflow-scrolling: touch;
     }
 
     &-skeleton {

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -336,6 +336,8 @@ export class FeedComponent extends MainViewComponent implements OnInit {
   public onOutletLoaded(component: PostDetailsComponent) {
     // This set this.posts @Input() in child(ren) component (if you ever need to use it in there)
     component.posts = this.posts;
+    // component.isLoading = this.isLoading;
+    // component.noPostsYet = this.noPostsYet;
   }
 
   public pageChanged(page: any): void {

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -329,9 +329,8 @@ export class FeedComponent extends MainViewComponent implements OnInit {
         }, 500);
         setTimeout(() => {
           //is inside this much delayed setTimeout to prevent pagination elements flicker on load/routing
-          this.paginationElementsAllowed =
-            data.meta.total > dataMetaPerPage && this.posts.length >= 20; // show pagination-related elements
-        }, 800);
+          this.paginationElementsAllowed = data.meta.total > dataMetaPerPage; // show pagination-related elements
+        }, 2100);
       },
     });
   }

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -291,7 +291,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
   }
 
   private getPosts(params: any, add = true): void {
-    this.currentMode().set;
+    this.currentFeedViewMode().set;
     const isPostsAlreadyExist = !!this.posts.length;
     if (!add) {
       this.posts = [];
@@ -534,7 +534,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
     this.sessionService.toggleFiltersVisibility(value);
   }
 
-  public currentMode() {
+  public currentFeedViewMode() {
     return {
       get: localStorage.getItem('ui_feed_mode'),
       set: localStorage.setItem('ui_feed_mode', this.mode),
@@ -547,7 +547,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
     // So the check is a defense for or "validation" against errors that may occur from clicking it - if the button shows up by mistake when it's not supposed to [when there are no posts].
 
     // 2. The switch mode button of the mode you are on should also not work if you click on it while in that mode
-    const localStorageFeedMode = this.currentMode().get;
+    const localStorageFeedMode = this.currentFeedViewMode().get;
     const sameSwitchButtonClicked = localStorageFeedMode === mode;
     if (this.atLeastOnePostExists && !sameSwitchButtonClicked) {
       this.isLoading = true;

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -298,7 +298,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
     // if (this.mode === FeedMode.Post) {
     //   this.currentPage = 1;
     // }
-    this.isLoading = true;
+    this.isLoading = !this.posts.length; // With this skeleton loader shows up only on mode switch, and the loadmore button is able to detect to not load the skeleton UI loader on click
     this.paginationElementsAllowed = this.loadingMorePosts; // this check prevents the load more button & area from temporarily disappearing (on click)
     this.postsService.getPosts('', { ...params, ...this.activeSorting }).subscribe({
       next: (data) => {

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -53,6 +53,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
     page: 1,
     size: this.params.limit,
   };
+  public postsSkeleton = new Array(20).fill(''); // used for Post mode's skeleton loader
   public posts: PostResult[] = [];
   public postCurrentLength = 0;
   public isLoading: boolean = true;

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -522,7 +522,6 @@ export class FeedComponent extends MainViewComponent implements OnInit {
   public loadMore(): void {
     if (this.params.limit !== undefined && this.params.limit * this.params.page! < this.total) {
       this.loadingMorePosts = true;
-      this.currentPage += 1;
       this.params.page! += 1;
       this.getPostsSubject.next({ params: this.params });
     }

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -23,7 +23,6 @@ import {
   postHelpers,
 } from '@mzima-client/sdk';
 import _ from 'lodash';
-import { PostDetailsComponent } from '../post/post-details/post-details.component';
 
 enum FeedMode {
   Tiles = 'TILES',
@@ -339,13 +338,6 @@ export class FeedComponent extends MainViewComponent implements OnInit {
 
   public updateMasonry(): void {
     this.masonry?.layout();
-  }
-
-  public onOutletLoaded(component: PostDetailsComponent) {
-    // This set this.posts @Input() in child(ren) component (if you ever need to use it in there)
-    component.posts = this.posts;
-    // component.isLoading = this.isLoading;
-    // component.noPostsYet = this.noPostsYet;
   }
 
   public pageChanged(page: any): void {

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -336,8 +336,6 @@ export class FeedComponent extends MainViewComponent implements OnInit {
   public onOutletLoaded(component: PostDetailsComponent) {
     // This set this.posts @Input() in child(ren) component (if you ever need to use it in there)
     component.posts = this.posts;
-    // component.isLoading = this.isLoading;
-    // component.noPostsYet = this.noPostsYet;
   }
 
   public pageChanged(page: any): void {

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -156,7 +156,6 @@ export class FeedComponent extends MainViewComponent implements OnInit {
 
     this.postsService.postsFilters$.pipe(untilDestroyed(this)).subscribe({
       next: () => {
-        console.log(this.mode);
         this.isLoading = true; // "There are no posts yet!" flicker is fixed here and for (most) places where isLoading is set to true
         if (this.initialLoad) {
           this.initialLoad = false;

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -346,8 +346,17 @@ export class FeedComponent extends MainViewComponent implements OnInit {
     this.getPostsSubject.next({ params: this.params });
   }
 
+  public setIsLoadingOnCardClick() {
+    // With this skeleton loader's css is properly displayed (when navigating to POST mode) through post card click,
+    // and the post card is able to detect to not load the skeleton UI loader after posts have successfully shown up
+    this.posts.length && this.mode === FeedMode.Tiles
+      ? (this.isLoading = true)
+      : this.isLoading === !this.posts.length;
+  }
+
   public showPostDetails(post: any): void {
     if (this.isDesktop) {
+      this.setIsLoadingOnCardClick();
       if (this.collectionId) {
         this.router.navigate(['/feed', 'collection', this.collectionId, post.id, 'view'], {
           queryParams: {
@@ -635,6 +644,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
 
   public editPost(post: any): void {
     if (this.isDesktop) {
+      this.setIsLoadingOnCardClick();
       if (this.collectionId) {
         this.router.navigate(['/feed', 'collection', this.collectionId, post.id, 'edit'], {
           queryParams: {

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -23,6 +23,7 @@ import {
   postHelpers,
 } from '@mzima-client/sdk';
 import _ from 'lodash';
+import { PostDetailsComponent } from '../post/post-details/post-details.component';
 
 enum FeedMode {
   Tiles = 'TILES',
@@ -332,6 +333,11 @@ export class FeedComponent extends MainViewComponent implements OnInit {
 
   public updateMasonry(): void {
     this.masonry?.layout();
+  }
+
+  public onOutletLoaded(component: PostDetailsComponent) {
+    // This set this.posts @Input() in child(ren) component (if you ever need to use it in there)
+    component.posts = this.posts;
   }
 
   public pageChanged(page: any): void {

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -291,6 +291,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
   }
 
   private getPosts(params: any, add = true): void {
+    this.currentMode().set;
     const isPostsAlreadyExist = !!this.posts.length;
     if (!add) {
       this.posts = [];
@@ -533,11 +534,22 @@ export class FeedComponent extends MainViewComponent implements OnInit {
     this.sessionService.toggleFiltersVisibility(value);
   }
 
+  public currentMode() {
+    return {
+      get: localStorage.getItem('ui_feed_mode'),
+      set: localStorage.setItem('ui_feed_mode', this.mode),
+    };
+  }
+
   public switchMode(mode: FeedMode): void {
-    // If there are no posts "The switch buttons shouldn't 'try to work'"
+    // 1. If there are no posts "The switch buttons shouldn't 'try to work'"
     // Reason is because the switch buttons alongside all other elements disabled when the page is still loading, shouldn't even show up in the first place) [when there are no posts].
     // So the check is a defense for or "validation" against errors that may occur from clicking it - if the button shows up by mistake when it's not supposed to [when there are no posts].
-    if (this.atLeastOnePostExists) {
+
+    // 2. The switch mode button of the mode you are on should also not work if you click on it while in that mode
+    const localStorageFeedMode = this.currentMode().get;
+    const sameSwitchButtonClicked = localStorageFeedMode === mode;
+    if (this.atLeastOnePostExists && !sameSwitchButtonClicked) {
       this.isLoading = true;
       this.mode = mode;
       if (this.collectionId) {

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -35,9 +35,6 @@ import { BreakpointService, EventBusService, EventType, SessionService } from '@
 })
 export class PostDetailsComponent extends BaseComponent implements OnChanges, OnDestroy {
   @Input() post: PostResult;
-  @Input() posts: PostResult[];
-  // @Input() isLoading: boolean = true;
-  // @Input() noPostsYet: boolean = false;
   @Input() feedView: boolean = true;
   @Input() userId?: number | string;
   @Input() color?: string;

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -36,8 +36,6 @@ import { BreakpointService, EventBusService, EventType, SessionService } from '@
 export class PostDetailsComponent extends BaseComponent implements OnChanges, OnDestroy {
   @Input() post: PostResult;
   @Input() posts: PostResult[];
-  // @Input() isLoading: boolean = true;
-  // @Input() noPostsYet: boolean = false;
   @Input() feedView: boolean = true;
   @Input() userId?: number | string;
   @Input() color?: string;

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -35,6 +35,7 @@ import { BreakpointService, EventBusService, EventType, SessionService } from '@
 })
 export class PostDetailsComponent extends BaseComponent implements OnChanges, OnDestroy {
   @Input() post: PostResult;
+  @Input() posts: PostResult[];
   @Input() feedView: boolean = true;
   @Input() userId?: number | string;
   @Input() color?: string;

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -36,6 +36,8 @@ import { BreakpointService, EventBusService, EventType, SessionService } from '@
 export class PostDetailsComponent extends BaseComponent implements OnChanges, OnDestroy {
   @Input() post: PostResult;
   @Input() posts: PostResult[];
+  // @Input() isLoading: boolean = true;
+  // @Input() noPostsYet: boolean = false;
   @Input() feedView: boolean = true;
   @Input() userId?: number | string;
   @Input() color?: string;

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
@@ -1,4 +1,8 @@
-<div *ngIf="!formId" class="post-item-page" [ngClass]="{ 'page-content': !surveys }">
+<div
+  *ngIf="!formId"
+  class="post-item-page"
+  [ngClass]="{ 'page-content page-content__isLoading': !surveys }"
+>
   <div class="page-content" *ngIf="surveys; else spinner">
     <h1 class="survey-name">{{ 'post.unstructured.add_survey.title' | translate }}</h1>
     <span class="info-message">
@@ -23,7 +27,10 @@
   </div>
 </div>
 <div *ngIf="formId" class="post-item-page">
-  <div class="page-content">
+  <div
+    class="page-content"
+    [ngClass]="{ 'page-content__isLoading': !formId || !(form && tasks.length) }"
+  >
     <div class="translate-container">
       <h1 class="survey-name">{{ surveyName }}</h1>
       <div class="form-row" *ngIf="postLanguages.length">

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!formId" class="post-item-page">
+<div *ngIf="!formId" class="post-item-page" [ngClass]="{ 'page-content': !surveys }">
   <div class="page-content" *ngIf="surveys; else spinner">
     <h1 class="survey-name">{{ 'post.unstructured.add_survey.title' | translate }}</h1>
     <span class="info-message">

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
@@ -45,6 +45,7 @@
   background: var(--color-light);
   box-shadow: inset 0 0 0 1px var(--color-neutral-30);
   max-width: 833px;
+  min-height: 100%;
 }
 
 .survey-name {

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
@@ -45,7 +45,10 @@
   background: var(--color-light);
   box-shadow: inset 0 0 0 1px var(--color-neutral-30);
   max-width: 833px;
-  min-height: 100%;
+
+  &__isLoading {
+    min-height: 100%;
+  }
 }
 
 .survey-name {


### PR DESCRIPTION
**This PR fixes:** 
- [USH-1138] Data view: Page content jumps around when navigating to post details

#

**Expected Result:**

> Please note "POST mode" involves post details, post edit (and post not found).

**A. Prevent page UI content from jumping around and when posts are still loading generally:**

- The "sort button" area should always stay visible every time (i.e. whether posts are loading, or posts have finished loading, or even when there are no posts or filters don't match)
- When posts are still loading:
    - The "sort button" area:
        - The "switch mode", "bulk actions" and "sort" buttons should be disabled (note: smaller devices do not have "switch mode" button)
        - Greyed out Loading text (note: only on desktop)
    - Content area: Show loader

- When posts have loaded or there are no posts:
    - The "sort button" area:
        - The "switch mode", "bulk actions" and "sort" buttons should now be accessible (note: smaller devices do not have "switch mode" button)
        - Result text shows up (note: only on desktop)
    - Content area: show posts or "there are no posts yet" text depending on if there are no posts or not.
[note: a different issue is to take care of separating no post text - [USH-1238](https://linear.app/ushahidi/issue/USH-1238/there-are-no-posts-yet-separate-the-text-for-when-there-are-no-posts) ]

#

**B. Plus Fix 🎁🥳:**

This Fix automatically takes care of these too that either prevent the "jump around" fix from being complete, or that helps in achieving a clean UI transition:
- Semi-skeleton loader style only when navigating to POST mode only (this loader is employed when all posts are still loading - if the posts have loaded when in POST mode, the semi-skeleton loader is not employed)
- Post details on the right now wait for post cards on the left to load before they show up (i.e. for times when posts are still loading) - when in POST mode
- Edit mode loader/loading is now consistent with content and much cleaner - when in POST mode
- Fixed disappearing posts card list on the left, when "Load more" button gets to end of posts - in POST mode
- Pagination elements flicker fixed: Posts now first show up before pagination element shows up

#

**C. Check that all works as expected in these scenarios:**

- When you enter data view's TILES mode through the app's sidebar link 
[note: Please check for desktop. For smaller devices, see: [USH-1199](https://linear.app/ushahidi/issue/USH-1199/web-client-smaller-devices-page-links-and-buttons-at-page-bottom)]
- On page load or reload:
    - When in TILES mode
    - When in POST mode
- When switching to and fro the TILES and POST mode though the "switch mode" buttons (desktop only)
- On post card click:
    - When in TILES mode
    - When in POST mode
- On edit button (found on post card) click:
    - When in TILES mode
    - When in POST mode
- When filters are selected, and when filters are cleared either with individual filters clear button or the "clear all filters" button:
    - When in TILES mode
    - When in POST mode
 - When pagination buttons are clicked in TILES mode (you can also check "load more" button click in POST mode)
 - Don't forget when in Collections too