### PR TITLE
[Outreachy Task Submission] Accessibility Fix for Share Modal form labels

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.html
@@ -15,7 +15,7 @@
   <strong mat-dialog-title>{{ label }}</strong>
 
   <div mat-dialog-content>
-    <div class="form-row">
+    <label class="form-row">
       <mat-label>{{ 'share.web_address' | translate }}</mat-label>
       <mat-form-field appearance="outline">
         <input
@@ -25,8 +25,8 @@
           [data-qa]="'survey-web-address'"
         />
       </mat-form-field>
-    </div>
-    <div class="form-row">
+    </label>
+    <label class="form-row">
       <mat-label>{{ 'share.embed_on_websites' | translate }}</mat-label>
       <div class="copy-success" *ngIf="copySuccess">{{ 'share.copied' | translate }}</div>
       <div [ngClass]="{ success: copySuccess }">
@@ -48,7 +48,7 @@
           ></mat-icon>
         </mat-form-field>
       </div>
-    </div>
+    </label>
     <div class="buttons">
       <mzima-client-button
         fill="outline"

--- a/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.scss
@@ -1,6 +1,7 @@
 .share-modal {
   .form-row {
     position: relative;
+    display: block;
   }
 
   .html-embed {


### PR DESCRIPTION
# Introduction
This fixes [#4878](https://github.com/ushahidi/platform/issues/4878)
I swapped out the `div` tags for `label` tags for proper linking of the form label and input fields

# How to test this PR
## Via manual testing
1. Go to any page in your Ushahidi deployment in localhost.
2. Click on the `Share` button at the top of your screen.
3. When the `Share` modal opens, click on any of the two form labels. For example, the "You survey's web address" or "HTML embed on websites". See a sample screenshot below.
   
![image](https://github.com/ushahidi/platform-client-mzima/assets/29470516/75fce09f-ebae-4f8f-b446-8b11fc75168c)

4. Click on the form label. The default behavior of any form label, when clicked, is to lead you to the form input field. This does not happen, indicating there is an error.
5. Checkout to this PR.
6. Reload your running deployment.
7. Repeat steps 1-3.
8. This time around, when you click on the form label, it leads you to the form input field.

## Using Accessibility Checkers
1. Go to any page in your Ushahidi deployment in localhost.
2. Click on the `Share` button at the top of your screen.
3. When the `Share` modal opens, activate or enable your browser plug-in. 
4. You will see the error being flagged.
5. Checkout to this PR.
6. Reload your running deployment.
7. Repeat steps 1-3.
8. This time around, the error doesn't get flagged.

## Extra comment
I had to update the `.form-row` class in the CSS, because `div` is a block element, but label is not.