### PR TITLE
[Outreachy Task Submission] Fix typo in Survey address label in Share modal.

### DIFF
--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -730,7 +730,7 @@
   "share": {
     "share_deployment": "Share deployment",
     "share_post": "Share post",
-    "web_address": "You survey's web address",
+    "web_address": "Your survey's web address",
     "embed_on_websites": "HTML embed on websites",
     "copied": "Copied!",
     "share_on_twitter": "Share on Twitter",

--- a/apps/web-mzima-client/src/assets/locales/hy.json
+++ b/apps/web-mzima-client/src/assets/locales/hy.json
@@ -2707,7 +2707,7 @@
   "share": {
     "share_deployment": "Կիսվեք տեղաբաշխումով",
     "share_post": "Share post",
-    "web_address": "You survey's web address",
+    "web_address": "Your survey's web address",
     "embed_on_websites": "HTML-ը embed է կայքերում",
     "copied": "Պատճենվել է!",
     "share_on_twitter": "Տարածեք Twitter- ում",


### PR DESCRIPTION
# Introduction
This PR fixes a small typo in the `Share` modal.
The label for `Your survey's web address` omitted the letter 'r' in 'your'.
See before vs after screenshots.

before:

![Screenshot 2024-03-26 004912](https://github.com/ushahidi/platform-client-mzima/assets/29470516/ea6fad87-8adc-465b-bc2f-7a04204da52e)

after:

![image](https://github.com/ushahidi/platform-client-mzima/assets/29470516/90e77ef8-9a8a-4783-9c01-b44735598fc5)


> **Notice the first word.**

## To test this PR
1. Go to your running Ushahidi deployment in localhost.
2. Click on the `Share` button.
3. When the modal appears, the output will look like the first screenshot.
4. Checkout to this PR.
5. Reload your running Ushahidi deployment.
6. Click on the `Share` button.
7. When the modal appears, the output will look like the second screenshot.