### PR TITLE
[Outreachy Task Submission] Add Copy Button to Survey Address in Share modal

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.html
@@ -18,19 +18,28 @@
     <div class="form-row">
       <mat-label>{{ 'share.web_address' | translate }}</mat-label>
       <mat-form-field appearance="outline">
+        <div class="copy-success" *ngIf="copyAddressSuccess">{{ 'share.copied' | translate }}</div>
         <input
           matInput
           [(ngModel)]="address"
           (input)="changeAddress($event)"
           [data-qa]="'survey-web-address'"
+          [ngClass]="{ success: copyAddressSuccess }"
         />
+        <mat-icon
+          (click)="copyToClipboard('address')"
+          class="fab-button__icon copy"
+          svgIcon="copy"
+        ></mat-icon>
       </mat-form-field>
     </div>
     <div class="form-row">
       <mat-label>{{ 'share.embed_on_websites' | translate }}</mat-label>
-      <div class="copy-success" *ngIf="copySuccess">{{ 'share.copied' | translate }}</div>
-      <div [ngClass]="{ success: copySuccess }">
+      <div>
         <mat-form-field appearance="outline">
+          <div class="copy-success" *ngIf="copyHtmlEmbedSuccess">
+            {{ 'share.copied' | translate }}
+          </div>
           <textarea
             class="html-embed"
             matInput
@@ -39,10 +48,11 @@
             cdkAutosizeMinRows="3"
             cdkAutosizeMaxRows="6"
             [(ngModel)]="htmlEmbed"
+            [ngClass]="{ success: copyHtmlEmbedSuccess }"
           >
           </textarea>
           <mat-icon
-            (click)="copyToClipboard()"
+            (click)="copyToClipboard('htmlEmbed')"
             class="fab-button__icon copy"
             svgIcon="copy"
           ></mat-icon>

--- a/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.scss
@@ -22,7 +22,7 @@
     &-success {
       position: absolute;
       width: 100%;
-      height: 86px;
+      height: 100%;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.ts
@@ -18,7 +18,8 @@ interface DataShareModal {
 export class ShareModalComponent implements OnInit {
   public address: string;
   public htmlEmbed: string;
-  public copySuccess = false;
+  public copyHtmlEmbedSuccess = false;
+  public copyAddressSuccess = false;
   public width = 560;
   public height = 315;
   public title: string;
@@ -46,9 +47,14 @@ export class ShareModalComponent implements OnInit {
     this.htmlEmbed = `<iframe width="${this.width}" height="${this.height}" src="${value}" frameborder="0" allowfullscreen></iframe>`;
   }
 
-  public copyToClipboard() {
-    this.copySuccess = this.clipboard.copy(this.htmlEmbed);
-    setTimeout(() => (this.copySuccess = !this.copySuccess), 2000);
+  public copyToClipboard(ngModel: string) {
+    if (ngModel === 'address') {
+      this.copyAddressSuccess = this.clipboard.copy(this.address);
+      setTimeout(() => (this.copyAddressSuccess = !this.copyAddressSuccess), 2000);
+    } else {
+      this.copyHtmlEmbedSuccess = this.clipboard.copy(this.htmlEmbed);
+      setTimeout(() => (this.copyHtmlEmbedSuccess = !this.copyHtmlEmbedSuccess), 2000);
+    }
   }
 
   private trimText(text: string, length: number) {


### PR DESCRIPTION
# Introduction
This is an additional feature I worked on in the `Share` modal. Currently, the option to copy to the clipboard is only in the `htmlEmbed` TextArea. I made it possible to do that in the SurveyAddress field as well.

## How to test this PR.
1. Go to your running Ushahidi deployment in localhost.
2. On any page, click on the `share` button at the top of the screen.
3. When the modal opens, check to see it looks like the following screenshot:
![image](https://github.com/ushahidi/platform-client-mzima/assets/29470516/be6cded7-ed97-47c9-b851-144bc6470778)
> **Notice** that while the `htmlEmbed` input has a copy button by the right, the one for URL (right above it) does not.

4. Checkout to this PR.
5. Reload your running Ushahidi deployment.
6. Clink on the `share` button at the top of the screen.
7. This time around, you will see a copy button for both. It will look like the following screenshot:
![image](https://github.com/ushahidi/platform-client-mzima/assets/29470516/d5d46e6e-68b3-4a8e-832a-5a0ade63c25b)

8. Play around with the buttons, you will see that they work as expected for each input.