### PR TITLE
[Outreachy Task Submission]: Fix general settings bug

### DIFF
--- a/apps/web-mzima-client/src/app/settings/general/general.component.ts
+++ b/apps/web-mzima-client/src/app/settings/general/general.component.ts
@@ -57,6 +57,7 @@ export class GeneralComponent implements OnInit {
 
   ngOnInit(): void {
     this.siteConfig = this.sessionService.getSiteConfigurations();
+    console.log(this.siteConfig);
 
     this.generalForm.patchValue({
       name: this.siteConfig.name,
@@ -151,7 +152,7 @@ export class GeneralComponent implements OnInit {
 
     return this.configService.update('site', siteConfig).pipe(
       mergeMap((updatedSite) => {
-        this.sessionService.setConfigurations('site', updatedSite);
+        this.sessionService.setConfigurations('site', (updatedSite as any).result);
         return this.configService.update('map', this.mapSettings.mapConfig);
       }),
     );

--- a/apps/web-mzima-client/src/app/settings/general/general.component.ts
+++ b/apps/web-mzima-client/src/app/settings/general/general.component.ts
@@ -57,7 +57,6 @@ export class GeneralComponent implements OnInit {
 
   ngOnInit(): void {
     this.siteConfig = this.sessionService.getSiteConfigurations();
-    console.log(this.siteConfig);
 
     this.generalForm.patchValue({
       name: this.siteConfig.name,


### PR DESCRIPTION
This pr fixes issue [4876](https://github.com/ushahidi/platform/issues/4876) which referenced a bug that occurs in the general settings menu. Apparently, it was caused by passing slightly incorrect data to the setConfigurations method. While it expects an object containing the updated site config, when setting changes are saved, it gets passed an object with a result property holding the actual data it requires.

## Steps to test fix

- Navigate to the general settings menu.
- Change a setting.
- Save the changes.
- Navigate away from the settings menu (to map view for example).
- Navigate back to the general settings menu.
- Changes should be reflected.