### PR TITLE
Fix Share button in mobile view.

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/fragments/share-and-donate/share-and-donate.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/fragments/share-and-donate/share-and-donate.component.html
@@ -13,7 +13,7 @@
 </div>
 
 <!-- Smaller screens -->
-<ng-container *ngIf="!isDesktop">
+<ng-container *ngIf="!isDesktop && navToolbarService.isBurgerMenuOpen">
   <div class="menu__footer-container">
     <div class="menu__footer">
       <app-donation-button

--- a/apps/web-mzima-client/src/app/shared/components/fragments/share-and-donate/share-and-donate.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/fragments/share-and-donate/share-and-donate.component.ts
@@ -5,6 +5,7 @@ import { BreadcrumbService, BreakpointService, SessionService } from '@services'
 import { ShareModalComponent } from '../../share-modal/share-modal.component';
 import { TranslateService } from '@ngx-translate/core';
 import { BaseComponent } from '../../../../base.component';
+import { NavToolbarService } from '../../../helpers/navtoolbar.service';
 
 @UntilDestroy()
 @Component({
@@ -22,6 +23,7 @@ export class ShareAndDonateComponent extends BaseComponent {
     private dialog: MatDialog,
     private translate: TranslateService,
     private breadcrumbService: BreadcrumbService,
+    public navToolbarService: NavToolbarService,
   ) {
     super(sessionService, breakpointService);
     this.checkDesktop();


### PR DESCRIPTION
As pointed out in [issue#4867](https://github.com/ushahidi/platform/issues/4867) the overlaying share button in the home page prevents user from clicking buttons on the Bottom navigation bar in Mobile view. This pr fixes that issue.

Before:


https://github.com/ushahidi/platform-client-mzima/assets/91622060/bd13d048-4df8-4226-8133-b7d43f13b8f1


After:

https://github.com/ushahidi/platform-client-mzima/assets/91622060/7fb83799-96aa-4d7a-8c54-24651a3358f9


