### PR TITLE
Show collections in mobile app

### DIFF
--- a/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.html
+++ b/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.html
@@ -2,7 +2,8 @@
   class="page-content ion-padding-horizontal"
   [ngClass]="{
     'at-bottom': atBottom,
-    'at-top': atTop
+    'at-top': atTop,
+    collection: isCollection
   }"
 >
   <app-select
@@ -18,9 +19,29 @@
       <app-icon name="sorting"></app-icon>
     </ng-container>
   </app-select>
-  <div class="total-posts" *ngIf="!isPostsLoading">
+
+  <div *ngIf="isCollection" class="feed-header">
+    <div class="feed-header--button">
+      <app-button
+        fill="clear"
+        [color]="'primary'"
+        class="back-button"
+        *ngIf="isCollection"
+        (buttonClick)="removeCollection()"
+      >
+        <app-icon name="arrow-back"></app-icon>
+      </app-button>
+      <span class="feed-header--title">Back</span>
+    </div>
+    <p *ngIf="!isPostsLoading">
+      {{ totalPosts }} {{ totalPosts > 1 ? 'posts' : 'post' }} {{ ' - ' + collectionName }}
+    </p>
+  </div>
+
+  <div class="total-posts" *ngIf="!isPostsLoading && !isCollection">
     {{ totalPosts }} {{ totalPosts > 1 ? 'posts' : 'post' }}
   </div>
+
   <ng-container *ngIf="posts.length; else emptyBox">
     <app-post-item
       *ngFor="let post of posts"

--- a/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.html
+++ b/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.html
@@ -25,15 +25,14 @@
       <app-button
         fill="clear"
         [color]="'primary'"
-        class="back-button"
         *ngIf="isCollection"
         (buttonClick)="removeCollection()"
       >
         <app-icon name="arrow-back"></app-icon>
       </app-button>
-      <span class="feed-header--title">Back</span>
+      <span>Back</span>
     </div>
-    <p *ngIf="!isPostsLoading">
+    <p class="feed-header--title" *ngIf="!isPostsLoading">
       {{ totalPosts }} {{ totalPosts > 1 ? 'posts' : 'post' }} {{ ' - ' + collectionName }}
     </p>
   </div>

--- a/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.scss
+++ b/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.scss
@@ -27,6 +27,27 @@
   }
 }
 
+.collection {
+  .feed-header {
+    justify-content: space-between;
+    font-weight: 700;
+    height: 56px;
+    display: flex;
+    &--title {
+      font-weight: 700;
+    }
+    &--button {
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      color: var(--color-primary-50);
+      app-icon {
+        color: var(--color-primary-50);
+        font-size: 40px;
+      }
+    }
+  }
+}
 .total-posts {
   height: 56px;
   display: flex;

--- a/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.scss
+++ b/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.scss
@@ -33,10 +33,9 @@
     font-weight: 700;
     height: 56px;
     display: flex;
-    &--title {
-      font-weight: 700;
-    }
+
     &--button {
+      width: 40%;
       display: flex;
       justify-content: flex-start;
       align-items: center;
@@ -45,6 +44,9 @@
         color: var(--color-primary-50);
         font-size: 40px;
       }
+    }
+    &--title {
+      padding-left: 20px;
     }
   }
 }

--- a/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.ts
@@ -9,6 +9,7 @@ import {
   PostResult,
   PostsService,
   SavedsearchesService,
+  CollectionsService,
 } from '@mzima-client/sdk';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { DatabaseService, EnvService, SessionService } from '@services';
@@ -35,6 +36,8 @@ export class FeedViewComponent extends MainViewComponent {
   public destroy$ = new Subject();
   public isConnection = true;
   public sorting = 'created?desc';
+  public isCollection = false;
+  public collectionName: string;
   public sortingOptions = [
     {
       label: 'Date created (Newest first)',
@@ -71,6 +74,7 @@ export class FeedViewComponent extends MainViewComponent {
     private databaseService: DatabaseService,
     private mediaService: MediaService,
     private envService: EnvService,
+    private collectionService: CollectionsService,
   ) {
     super(router, route, postsService, savedSearchesService, sessionService);
     this.envService.deployment$.subscribe({
@@ -78,6 +82,26 @@ export class FeedViewComponent extends MainViewComponent {
         this.posts = [];
       },
     });
+    if (this.route.snapshot.data['view'] === 'collection') {
+      this.openCollection();
+    }
+  }
+
+  openCollection() {
+    const collectionId: any = this.route.snapshot.paramMap.get('id');
+    this.collectionService.getCollection(collectionId).subscribe((result: any) => {
+      this.isCollection = true;
+      this.collectionName = result.result.name;
+    });
+  }
+
+  removeCollection() {
+    this.postsService.applyFilters({
+      ...this.postsService.normalizeFilter(this.filters),
+    });
+    this.router.navigate(['/']);
+    this.isCollection = false;
+    this.collectionName = '';
   }
 
   ionViewDidLeave(): void {

--- a/apps/mobile-mzima-client/src/app/map/components/main-view.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/main-view.component.ts
@@ -12,7 +12,7 @@ import { Subject } from 'rxjs';
 })
 export abstract class MainViewComponent {
   searchId = '';
-  collectionId = '';
+  collectionId: any = '';
   params: any = {
     limit: 200,
     offset: 0,
@@ -56,14 +56,22 @@ export abstract class MainViewComponent {
   abstract loadData(): void;
 
   initCollection() {
-    this.collectionId = '';
-    this.params.set = '';
-
-    if (this.route.snapshot.data['view'] === 'search') {
-      this.searchId = this.route.snapshot.paramMap.get('id')!;
-      this.savedSearchesService.getById(this.searchId).subscribe((sSearch) => {
-        this.postsService.applyFilters(Object.assign(sSearch.result.filter, { set: [] }));
+    if (this.route.snapshot.data['view'] === 'collection') {
+      this.collectionId = this.route.snapshot.paramMap.get('id');
+      this.params.set = this.collectionId;
+      this.postsService.applyFilters({
+        ...this.postsService.normalizeFilter(this.filters),
+        set: this.collectionId,
       });
+    } else {
+      this.collectionId = '';
+      this.params.set = '';
+      if (this.route.snapshot.data['view'] === 'search') {
+        this.searchId = this.route.snapshot.paramMap.get('id')!;
+        this.savedSearchesService.getById(this.searchId).subscribe((sSearch) => {
+          this.postsService.applyFilters(Object.assign(sSearch.result.filter, { set: [] }));
+        });
+      }
     }
   }
 }

--- a/apps/mobile-mzima-client/src/app/shared/components/choose-collection/choose-collection.component.ts
+++ b/apps/mobile-mzima-client/src/app/shared/components/choose-collection/choose-collection.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Router } from '@angular/router';
 import { Observable, Subject, debounceTime, forkJoin, lastValueFrom } from 'rxjs';
 import { fieldErrorMessages, formHelper } from '@helpers';
 import { FormBuilder, Validators } from '@angular/forms';
@@ -103,6 +104,7 @@ export class ChooseCollectionComponent {
     private toastService: ToastService,
     private notificationsService: NotificationsService,
     private databaseService: DatabaseService,
+    private router: Router,
   ) {
     this.searchSubject.pipe(debounceTime(500)).subscribe({
       next: (query: string) => {
@@ -437,7 +439,6 @@ export class ChooseCollectionComponent {
   }
 
   public showCollection(collectionId: number): void {
-    // TODO: Open collection page
-    console.log('showCollection: ', collectionId);
+    this.router.navigate([`/collection/${collectionId}`]);
   }
 }

--- a/libs/sdk/src/lib/services/collections.service.ts
+++ b/libs/sdk/src/lib/services/collections.service.ts
@@ -32,7 +32,9 @@ export class CollectionsService extends ResourceService<any> {
   getCollections(queryParams?: any): Observable<Collection> {
     return super.get('', queryParams);
   }
-
+  getCollection(collectionId: string): Observable<Collection> {
+    return super.get(collectionId);
+  }
   addToCollection(collectionId: string | number, postId: string | number) {
     return super.post({ post_id: postId } as any, `${collectionId}/posts`);
   }

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -278,4 +278,22 @@ export class PostsService extends ResourceService<any> {
       ...sorting,
     });
   }
+
+  public normalizeFilter(values: any) {
+    if (!values) return {};
+
+    const filters = {
+      ...values,
+      'form[]': values.form,
+      'source[]': values.source,
+      'status[]': values.status,
+      'tags[]': values.tags,
+    };
+
+    delete filters.form;
+    delete filters.source;
+    delete filters.status;
+    delete filters.tags;
+    return filters;
+  }
 }


### PR DESCRIPTION
This PR shows collections to logged in users in the mobile app. To test
As a logged in user:
1. Go to "profile"
2. Tap on Collections
3. Tap on a Collection
- You should now be directed to the Map-view with only posts from that collection visible in the map/feed-list. 
- Above the feed-list there is a back-arrow, number of posts in the collection and collection-name.
- When tapping on the back-arrow, filters are reset and you see all posts again