### PR TITLE
[Outreachy Task Submission]: Adjust category name validation to trigger on user interaction

### DIFF
--- a/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.html
+++ b/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.html
@@ -26,7 +26,7 @@
           placeholder="{{ 'category.placeholder.name' | translate }}"
         />
       </mat-form-field>
-      <mat-error *ngIf="form.get('name')?.hasError('required')">
+      <mat-error *ngIf="form.get('name')?.hasError('required') && form.get('name')?.touched">
         {{ 'category.validation.required.name' | translate }}
       </mat-error>
       <ng-container *ngFor="let err of formErrors">


### PR DESCRIPTION
### Description:
This pull request addresses the issue ushahidi/platform#4885, where the validation error for the "Category Name" input field is displayed instantly without any user interaction triggering it.

### Testing Checklist:
1. Launch the web application using `npm run web:serve`.
2. Log in to the application.
3. Click on the setting icon on the sidebar.
4. Navigate to the category card in the left sidebar.
5. Click on the "Add category" button.
6. Verify that the error message "Category name is required" is not visible initially.

### Additional Context:
For more clarification, a video attachment has been provided on the issue [#4885](https://github.com/ushahidi/platform/issues/4885).