### PR TITLE
[Outreachy Task Submission] Keyboard Support For Posts Bulk Actions

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.html
+++ b/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.html
@@ -1,6 +1,7 @@
 <div
   class="post"
   *ngIf="post"
+  (click)="$event.stopPropagation(); postClicked()"
   [ngStyle]="{ '--color': post.color || 'var(--color-neutral-100)' }"
   [ngClass]="{
     'post--feed': feedView,
@@ -9,7 +10,11 @@
 >
   <div class="post__head">
     <ng-container *ngIf="selectable">
-      <mat-checkbox [(ngModel)]="isChecked" (ngModelChange)="postClicked($event)"></mat-checkbox>
+      <mat-checkbox
+        [checked]="isChecked"
+        (keydown.enter)="$event.preventDefault(); postClicked()"
+        (keydown.Space)="$event.preventDefault(); postClicked()"
+      ></mat-checkbox>
     </ng-container>
     <app-post-head
       [post]="post"

--- a/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.html
+++ b/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.html
@@ -1,7 +1,6 @@
 <div
   class="post"
   *ngIf="post"
-  (click)="postClicked($event)"
   [ngStyle]="{ '--color': post.color || 'var(--color-neutral-100)' }"
   [ngClass]="{
     'post--feed': feedView,
@@ -10,7 +9,7 @@
 >
   <div class="post__head">
     <ng-container *ngIf="selectable">
-      <mat-checkbox [(ngModel)]="isChecked"></mat-checkbox>
+      <mat-checkbox [(ngModel)]="isChecked" (ngModelChange)="postClicked($event)"></mat-checkbox>
     </ng-container>
     <app-post-head
       [post]="post"

--- a/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.ts
@@ -63,7 +63,8 @@ export class PostPreviewComponent implements OnInit, OnChanges {
     this.details.next(true);
   }
 
-  public postClicked(event: MouseEvent): void {
+  public postClicked(event: any): void {
+    console.log(this.isChecked);
     if (this.selectable) {
       event.stopPropagation();
       this.isChecked = !this.isChecked;

--- a/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.ts
@@ -63,10 +63,8 @@ export class PostPreviewComponent implements OnInit, OnChanges {
     this.details.next(true);
   }
 
-  public postClicked(event: any): void {
-    console.log(this.isChecked);
+  public postClicked(): void {
     if (this.selectable) {
-      event.stopPropagation();
       this.isChecked = !this.isChecked;
       this.selected.emit(this.isChecked);
     }


### PR DESCRIPTION
Should resolve [#4887](https://github.com/ushahidi/platform/issues/4887)

**Description**
Currently, on the data view page keyboard support for posts bulk actions doesn't work.

**How to test**
Using just the keyboard do the following steps: 

1. click bulk action
2. check the checkboxes using either spacebar or enter
3. notice the action buttons are no longer disabled
4. tab backwards (shift + tab) to select any action you want.

@Angamanga This PR is ready for review 🙏🏽 