### PR TITLE
[Outreachy Task Submission] Accessibility Fix for Collections modal form labels

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/collections/collections.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/collections/collections.component.html
@@ -47,11 +47,13 @@
   >
     <div class="form-row">
       <mat-form-field appearance="outline">
+        <label for="search-input" class="visually-hidden">Search</label>
         <input
           matInput
           placeholder="{{ 'location.search' | translate }}"
           name="query"
           formControlName="query"
+          id="search-input"
         />
         <mzima-client-button
           matPrefix

--- a/apps/web-mzima-client/src/styles.scss
+++ b/apps/web-mzima-client/src/styles.scss
@@ -193,3 +193,14 @@ a {
     bottom: 100px !important;
   }
 }
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}


### PR DESCRIPTION
# Introduction
This fixes [#4888](https://github.com/ushahidi/platform/issues/4888)

# How to test this PR using Accessibility checkers
1. Go to any page in your Ushahidi deployment in localhost.
2. Click on the `Collections` navigation button by the side of your screen.
3. When the `Collection` modal opens, activate or enable your browser plug-in. 
4. You will see the error being flagged.
5. Checkout to this PR.
6. Reload your running deployment.
7. Repeat steps 1-3.
8. This time around, the error doesn't get flagged.

## Extra comment
It requires use of the "visually-hidden" class I created in a different PR, however, I also added that logic here for easy testing.