### PR TITLE
[Outreachy Task Submission] Fix npm install error in mobile-client-mzima

### DIFF
--- a/apps/mobile-mzima-client/package.json
+++ b/apps/mobile-mzima-client/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@capacitor-community/intercom": "^5.0.0",
     "@capacitor/android": "^5.6.0",
-    "@capacitor/app": "^5.6.0",
+    "@capacitor/app": "^5.0.6",
     "@capacitor/camera": "^5.0.8",
     "@capacitor/core": "^5.0.0",
     "@capacitor/device": "^5.0.6",


### PR DESCRIPTION
# Introduction
This fixes #843 
Running `npm install` in the `mobile-mzima-client` keeps failing due to an incorrect dependency version on `@capacitor/app` in the `package.json`.
To fix this, I checked the `package-lock.json` to see what version was locked in as a dependency. See the code here:
```json
"node_modules/@capacitor/app": {
      "version": "5.0.6",
      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-5.0.6.tgz",
      "integrity": "sha512-6ZXVdnNmaYILasC/RjQw+yfTmq2ZO7Q3v5lFcDVfq3PFGnybyYQh+RstBrYri+376OmXOXxBD7E6UxBhrMzXGA==",
      "peerDependencies": {
        "@capacitor/core": "^5.0.0"
      }
    },
```
I copied the version number and replaced it with the mistake in the `package.json` still in the `mobile-mzima-client`

## How to test this PR
1. Navigate to the `mobile-mzima-client` directory in the `apps` directory of the `platform-client-mzima`.
2. Run `npm install`.
3. You will notice the following errors:
```sh
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @capacitor/app@^5.6.0.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```
4. Checkout to this PR.
5. Repeat step 2.
6. Notice that it works this time around.