### PR TITLE
[Outreachy Task Submission] Bring Intercom back in Help & Support

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.html
@@ -18,10 +18,10 @@
     <h4 class="menu-item__title">{{ item.title }}</h4>
     <p *ngIf="item.description?.length">{{ item.description }}</p>
   </div>
-  <!-- <div matRipple class="menu-item" *ngIf="isLoggedIn">
+  <div matRipple class="menu-item intercom_custom_launcher" *ngIf="isLoggedIn">
     <h4 class="menu-item__title">{{ 'app.intercom.intercom' | translate }}</h4>
-    <p class="intercom_custom_launcher">{{ 'app.intercom.description' | translate }}</p>
-  </div> -->
+    <p>{{ 'app.intercom.description' | translate }}</p>
+  </div>
   <div matRipple class="menu-item" (click)="openUrl('https://www.ushahidi.com/terms-of-service/')">
     <h4 class="menu-item__title">{{ 'app.terms_and_conditions' | translate }}</h4>
   </div>

--- a/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/support-modal/support-modal.component.ts
@@ -69,14 +69,6 @@ export class SupportModalComponent extends BaseComponent {
           this.closeModal();
         },
       },
-      // {
-      //   title: this.translate.instant('app.intercom.intercom'),
-      //   description: this.translate.instant('app.intercom.description'),
-      //   action: () => {
-      //     window.open('mailto:hl5rfiga@intercom-mail.com');
-      //     this.closeModal();
-      //   },
-      // },
     ];
   }
 


### PR DESCRIPTION
# Introduction
I noticed that in the `support-modal` component, there was some code that was commented out. I played with it and realized it was meant to provide an Intercom chat button to the "Help & Support" modal. I also saw that in the `.ts` file, there was some extra code that accounted for the button, but prompted a user to send an email, instead of opening the intercom chat. 
I felt the Intercom chat would be a nice addition and reinstated it, but with a fix to make the full button area clickable, and not just the paragraph.

Here's a video of a live deployment before my PR:

https://github.com/ushahidi/platform-client-mzima/assets/29470516/0bb636f2-0f1b-46ad-a9c0-a153bca2ae2d
> Notice that there is no "Intercom" option in the modal, and how I opened the Intercom manually to show that it works independently of the "Help & Support" modal.

Here's a video of my localhost deployment after my PR:

https://github.com/ushahidi/platform-client-mzima/assets/29470516/45403866-1a66-44b1-ba78-c60ab1d758e5
> Notice the "Intercom" option appears below "Onboarding", and that clicking it opens the Intercom chat.

## How to test this PR.
1. Login to your running Ushahidi deployment.
2. Click on the "Help & Support" navigation.
3. When the modal opens, scroll through all the listings. You won't see any called "intercom".
4. Checkout to this PR.
5. Repeat steps 1 and 2.
6. When the modal opens, scroll through all the listings. You will see an "intercom" option this time around. Click on it, and the chat modal will open.

## Extra comments
I revamped the old code to make the button completely clickable, and then removed the leftover code from the old way of prompting the user to send an email (instead of the Intercom chat).

