### PR TITLE
[Outreachy Task Submission] Remove Extra Focus From Add Buttons On Keyboard Navigation

### DIFF
--- a/apps/web-mzima-client/src/app/settings/data-sources/data-sources.component.html
+++ b/apps/web-mzima-client/src/app/settings/data-sources/data-sources.component.html
@@ -2,6 +2,7 @@
   <h1 *ngIf="isDesktop$ | async">{{ 'settings.data_sources.data_sources' | translate }}</h1>
   <mzima-client-button
     [routerLink]="['create']"
+    tabindex="-1"
     *ngIf="!isAllProvidersAdded"
     [data-qa]="'btn-add-provider'"
   >

--- a/apps/web-mzima-client/src/app/settings/roles/roles.component.html
+++ b/apps/web-mzima-client/src/app/settings/roles/roles.component.html
@@ -1,6 +1,6 @@
 <div class="form-head-panel">
   <h1 *ngIf="isDesktop$ | async">{{ 'app.roles' | translate }}</h1>
-  <mzima-client-button [routerLink]="['create']" [data-qa]="'btn-add-role'">
+  <mzima-client-button tabindex="-1" [routerLink]="['create']" [data-qa]="'btn-add-role'">
     <span>{{ 'role.add_role' | translate }}</span>
     <mat-icon icon svgIcon="plus"></mat-icon>
   </mzima-client-button>

--- a/apps/web-mzima-client/src/app/settings/webhooks/webhooks.component.html
+++ b/apps/web-mzima-client/src/app/settings/webhooks/webhooks.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="webhookList">
   <div class="form-head-panel">
     <h1 *ngIf="isDesktop$ | async">{{ 'app.webhooks' | translate }}</h1>
-    <mzima-client-button [routerLink]="['create']" [data-qa]="'btn-webhook-create'">
+    <mzima-client-button tabindex="-1" [routerLink]="['create']" [data-qa]="'btn-webhook-create'">
       <span>{{ 'webhook.add_webhook' | translate }}</span>
       <mat-icon icon svgIcon="plus"></mat-icon>
     </mzima-client-button>

--- a/apps/web-mzima-client/src/app/shared/components/settings-header/settings-header.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/settings-header/settings-header.component.html
@@ -33,7 +33,7 @@
     >
       {{ 'settings.bulk_actions' | translate }}
     </mzima-client-button>
-    <mzima-client-button [routerLink]="['create']" [data-qa]="'btn-settings-create'">
+    <mzima-client-button tabindex="-1" [routerLink]="['create']" [data-qa]="'btn-settings-create'">
       <span>{{ newButtonTitle | translate }}</span>
       <mat-icon icon svgIcon="plus"></mat-icon>
     </mzima-client-button>


### PR DESCRIPTION
Resolves [#4902](https://github.com/ushahidi/platform/issues/4902)
**Description**
Currently the add new buttons behave weirdly when navigating using just keyboard. The button has to be tabbed twice before it responds to the enter event. 

**Why does this happen?**
This happens because the mizima-client-buttons in this cases are router links and router links come with their own focus when tabbed into, so this focus + the buttons default focus results in tabbing twice before the button responds to the enter event.

**Fix**
Set tabindex to -1 on mizima-client-buttons when it's being used as a router link to prevent this extra focus.

**How to test**

1. Go to the staging: https://mzima-dev.staging.ush.zone/settings/surveys
2. Using the keyboard, navigate to "add survey" button (notice you have to tab twice before it responds)
3. Switch to this branch and perform the same action in step 2 (notice the extra focus is no longer needed)

This fix covers surveys, users, roles, categories, webhooks and data sources

@Angamanga This pr is ready for review 🙏🏽 