### PR TITLE
[Outreachy Task Submission] Keyboard Accessibility Issue With File Upload Button On Data Import Page

### DIFF
--- a/apps/web-mzima-client/src/app/settings/data-import/data-import.component.html
+++ b/apps/web-mzima-client/src/app/settings/data-import/data-import.component.html
@@ -1,6 +1,6 @@
 <div class="head">
   <h1 *ngIf="isDesktop">{{ 'app.import' | translate }}</h1>
-  <mzima-client-button class="upload-button" [data-qa]="'btn-upload'">
+  <mzima-client-button class="upload-button" [data-qa]="'btn-upload'" (click)="openFileSelector()">
     <span>
       {{
         (selectedFile ? 'data_import.change_csv_file' : 'data_import.upload_csv_file')
@@ -13,7 +13,15 @@
       }}
     </span>
     <mat-icon icon svgIcon="plus"></mat-icon>
-    <input name="file" type="file" accept=".csv" (change)="uploadFile($event)" />
+    <input
+      tabindex="-1"
+      class="hidden-input"
+      #fileInput
+      name="file"
+      type="file"
+      accept=".csv"
+      (change)="uploadFile($event)"
+    />
   </mzima-client-button>
 </div>
 

--- a/apps/web-mzima-client/src/app/settings/data-import/data-import.component.ts
+++ b/apps/web-mzima-client/src/app/settings/data-import/data-import.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { omit, clone, invert, keys, includes } from 'lodash';
 import { TranslateService } from '@ngx-translate/core';
@@ -32,6 +32,7 @@ enum PostStatus {
   styleUrls: ['./data-import.component.scss'],
 })
 export class DataImportComponent extends BaseComponent implements OnInit {
+  @ViewChild('fileInput') fileInput: ElementRef;
   PostStatus = PostStatus;
   selectedFile: File;
   selectedForm: SurveyItem;
@@ -77,6 +78,10 @@ export class DataImportComponent extends BaseComponent implements OnInit {
     });
   }
   loadData(): void {}
+
+  openFileSelector(): void {
+    this.fileInput.nativeElement.click();
+  }
 
   uploadFile($event: any) {
     this.fileChanged = true;

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "http://localhost:8080/",
+  "backend_url": "https://mzima-dev-api.staging.ush.zone/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "https://mzima-dev-api.staging.ush.zone/",
+  "backend_url": "http://localhost:8080/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",


### PR DESCRIPTION
Resolves [#4903](https://github.com/ushahidi/platform/issues/4903)

**Description**
On the data import page, the "upload csv file" button doesn't respond immediately to keyboard enter event, you have to tab twice. I initially thought it was the same issue with router link buttons in [#982](https://github.com/ushahidi/platform-client-mzima/pull/982), but this one is different.

**Why does this happen?**
There are two issues with this implementation of file upload input:

1. The button relies on the visually hidden input to be clicked before it opens up the file/folder widget so clicking on the area around the input doesn't open the input field unless you click on the input directly. see image below 👇🏽 

<img width="250" alt="Screenshot 2024-03-29 at 12 01 40" src="https://github.com/ushahidi/platform/assets/46582086/a6800a27-1259-4172-9c44-e19fdd2adc81">

2. The visually hidden input also receives an extra focus when tabbed into.

**Fix** 
Use the button to programmatically control the input by using the it's elementRef and set the tabindex of the visually hidden input to -1 to prevent the extra focus. This way when any area of the button is clicked it opens up the file/folder widget.

**How to test** 

1. https://mzima-dev.staging.ush.zone/settings/data-import
2. Try to upload csv using only your keyboard to notice the issue
3. On this branch, to http://localhost:4200/settings/data-import
4. Repeat step 2 and notice the difference

@Angamanga This pr is ready for review 🙏🏽 
