### PR TITLE
Outreachy task submission] lack of confirm password field during sign up #4880

### DIFF
--- a/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.html
+++ b/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.html
@@ -46,6 +46,28 @@
   </div>
 
   <div class="form-row">
+    <mat-form-field appearance="fill">
+      <mat-label>{{ 'user.confirm_password' | translate }}</mat-label>
+      <mzima-client-button
+        matSuffix
+        fill="clear"
+        color="secondary"
+        [iconOnly]="true"
+        (buttonClick)="togglePasswordVisible()"
+      >
+        <mat-icon icon [svgIcon]="isPasswordVisible ? 'eye-open' : 'eye'"></mat-icon>
+      </mzima-client-button>
+      <input
+        matInput
+        formControlName="confirmPassword"
+        required
+        [type]="isPasswordVisible ? 'text' : 'password'"
+      />
+      <mat-hint>{{ 'Match your password in both fields for security. Thanks!' }}.</mat-hint>
+    </mat-form-field>
+  </div>
+
+  <div class="form-row">
     <div class="checkbox">
       <mat-checkbox [data-qa]="'i-agree'" formControlName="agreement" required>
         <span [innerHTML]="'terms_of_service.i_agree' | translate"></span>

--- a/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.html
+++ b/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.html
@@ -40,6 +40,9 @@
       <mat-error [data-qa]="'invalid-password'" *ngIf="form.get('password')?.invalid">{{
         getErrorMessage('password')
       }}</mat-error>
+      <mat-error [data-qa]="'invalid-confirmPassword'" *ngIf="form.hasError('mismatch')">{{
+        'user.password_match' | translate
+      }}</mat-error>
       <mat-hint>{{ 'user.password_hint' | translate }}.</mat-hint>
     </mat-form-field>
     <app-password-strength [passwordToCheck]="form.value.password"></app-password-strength>
@@ -53,16 +56,19 @@
         fill="clear"
         color="secondary"
         [iconOnly]="true"
-        (buttonClick)="togglePasswordVisible()"
+        (buttonClick)="toggleConfirmPasswordVisible()"
       >
-        <mat-icon icon [svgIcon]="isPasswordVisible ? 'eye-open' : 'eye'"></mat-icon>
+        <mat-icon icon [svgIcon]="isConfirmasswordVisible ? 'eye-open' : 'eye'"></mat-icon>
       </mzima-client-button>
       <input
         matInput
         formControlName="confirmPassword"
         required
-        [type]="isPasswordVisible ? 'text' : 'password'"
+        [type]="isConfirmasswordVisible ? 'text' : 'password'"
       />
+      <mat-error [data-qa]="'invalid-confirmPassword'" *ngIf="form.hasError('mismatch')">{{
+        'user.password_match' | translate
+      }}</mat-error>
       <mat-hint>{{ 'Match your password in both fields for security. Thanks!' }}.</mat-hint>
     </mat-form-field>
   </div>

--- a/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.scss
+++ b/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.scss
@@ -3,3 +3,8 @@
     margin-top: 24px;
   }
 }
+form {
+  .mat-dialog-actions {
+    margin-top: 16px;
+  }
+}

--- a/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.ts
+++ b/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.ts
@@ -28,6 +28,7 @@ export class RegistrationFormComponent {
           Validators.maxLength(generalHelpers.CONST.MAX_PASSWORD_LENGTH),
         ],
       ],
+      confirmPassword: ['', Validators.required],
       agreement: [false, [Validators.required]],
     });
   }

--- a/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.ts
+++ b/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.ts
@@ -1,5 +1,12 @@
 import { Component, EventEmitter, Output } from '@angular/core';
-import { AbstractControl, FormBuilder, FormGroup, ValidatorFn, Validators } from '@angular/forms';
+import {
+  AbstractControl,
+  FormBuilder,
+  FormGroup,
+  ValidatorFn,
+  Validators,
+  ValidationErrors,
+} from '@angular/forms';
 import { AuthService } from '@services';
 import { regexHelper } from '@helpers';
 import { emailExistsValidator } from '../../../core/validators';
@@ -13,25 +20,42 @@ import { generalHelpers } from '@mzima-client/sdk';
 export class RegistrationFormComponent {
   @Output() registered = new EventEmitter();
   public isPasswordVisible = false;
+  public isConfirmasswordVisible = false;
   public form: FormGroup;
   public submitted = false;
 
   constructor(private authService: AuthService, private formBuilder: FormBuilder) {
-    this.form = this.formBuilder.group({
-      name: ['', [Validators.required]],
-      email: ['', [Validators.required, Validators.pattern(regexHelper.emailValidate())]],
-      password: [
-        '',
-        [
-          Validators.required,
-          Validators.minLength(generalHelpers.CONST.MIN_PASSWORD_LENGTH),
-          Validators.maxLength(generalHelpers.CONST.MAX_PASSWORD_LENGTH),
+    this.form = this.formBuilder.group(
+      {
+        name: ['', [Validators.required]],
+        email: ['', [Validators.required, Validators.pattern(regexHelper.emailValidate())]],
+        password: [
+          '',
+          [
+            Validators.required,
+            Validators.minLength(generalHelpers.CONST.MIN_PASSWORD_LENGTH),
+            Validators.maxLength(generalHelpers.CONST.MAX_PASSWORD_LENGTH),
+          ],
         ],
-      ],
-      confirmPassword: ['', Validators.required],
-      agreement: [false, [Validators.required]],
-    });
+        confirmPassword: ['', [Validators.required]],
+        agreement: [false, [Validators.required]],
+      },
+      {
+        validators: this.passwordMatchValidator,
+      },
+    );
   }
+
+  private passwordMatchValidator: ValidatorFn = (
+    control: AbstractControl,
+  ): ValidationErrors | null => {
+    if (!control) return null;
+    console.log(this.form);
+
+    return control.get('password')?.value === control.get('confirmPassword')?.value
+      ? null
+      : { mismatch: true };
+  };
 
   getErrorMessage(field: string) {
     switch (field) {
@@ -55,6 +79,9 @@ export class RegistrationFormComponent {
 
   togglePasswordVisible() {
     this.isPasswordVisible = !this.isPasswordVisible;
+  }
+  toggleConfirmPasswordVisible() {
+    this.isConfirmasswordVisible = !this.isConfirmasswordVisible;
   }
 
   signup() {

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "http://localhost:8080/",
+  "backend_url": "https://mzima-dev-api.staging.ush.zone/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",


### PR DESCRIPTION

**Description:**
This pull request addresses the issue of the sign-up form lacking a "Confirm Password" field, which currently makes it challenging for users to ensure the accuracy of their chosen password during registration. By adding a "Confirm Password" field, users will be able to verify their password input, reducing the likelihood of errors and enhancing the overall user experience.

**Changes Made:**
- Added a "Confirm Password" field to the sign-up form.
- Updated form validation logic to ensure that the password and confirm password fields match before allowing form submission.
- Implemented error messaging to prompt users to re-enter their password if the passwords do not match.

**Testing:**
- [ ] Verify that the "Confirm Password" field is displayed next to the "Password" field in the sign-up form.
- [ ] Test entering matching passwords in both fields and ensure the form submission is successful.
- [ ] Test entering mismatching passwords and verify that appropriate error messages are displayed prompting the user to re-enter their password.
- [ ] Conduct usability testing to assess the clarity and ease of use of the updated sign-up form.
- [ ] Ensure that the form validation logic correctly prevents form submission if the passwords do not match.
- [ ] Test the responsiveness of the sign-up form across different screen sizes and devices.


**Related Issue:**
https://github.com/ushahidi/platform/issues/4880

**Reviewer:**
@Angamanga 

This pull request aims to enhance the usability and accuracy of the sign-up process by adding a "Confirm Password" field to the form. Your feedback and review are greatly appreciated. Thank you!