### PR TITLE
[Outreachy Task Submission] Form Inputs Are Disconnected From Their Labels

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
@@ -100,7 +100,13 @@
             class="form-row"
             *ngFor="let field of task.fields | sortByField : 'priority' : 'asc'; let i = index"
           >
-            <mat-label>
+            <label
+              class="form-label"
+              [attr.aria-label]="
+                'Enter' + (field?.translations[activeLanguage]?.label || field?.label)
+              "
+              [for]="field.key"
+            >
               <mat-icon
                 aria-label="Field responses will be private"
                 *ngIf="field.response_private"
@@ -110,7 +116,7 @@
               ></mat-icon>
               {{ field?.translations[activeLanguage]?.label || field?.label }}
               <span class="color-accent" *ngIf="field?.required">*</span>
-            </mat-label>
+            </label>
             <span
               class="form-row__instruction"
               *ngIf="field?.instructions"
@@ -123,6 +129,7 @@
             >
               <mat-form-field appearance="outline">
                 <input
+                  [id]="field.key"
                   matInput
                   [formControlName]="field.key"
                   [data-qa]="field.label.replace(' ', '-') | lowercase"
@@ -134,6 +141,7 @@
               <mat-form-field appearance="outline">
                 <textarea
                   matInput
+                  [id]="field.key"
                   cdkTextareaAutosize
                   cdkAutosizeMinRows="2"
                   cdkAutosizeMaxRows="5"
@@ -148,6 +156,7 @@
               <mat-form-field appearance="outline">
                 <textarea
                   matInput
+                  [id]="field.key"
                   cdkTextareaAutosize
                   cdkAutosizeMinRows="2"
                   cdkAutosizeMaxRows="5"
@@ -300,6 +309,11 @@
             <ng-container *ngIf="field.input === 'checkbox'">
               <mat-selection-list
                 [formControlName]="field.key"
+                [attr.aria-label]="
+                  field?.instructions
+                    ? field?.translations[activeLanguage]?.instructions || field?.instructions
+                    : 'please select'
+                "
                 *ngIf="field.options?.length; else noOptions"
                 [data-qa]="
                   field.label.replaceAll(' ', '-').replace('(', '').replace(')', '') | lowercase

--- a/apps/web-mzima-client/src/app/settings/surveys/share-menu/share-menu.component.html
+++ b/apps/web-mzima-client/src/app/settings/surveys/share-menu/share-menu.component.html
@@ -1,22 +1,26 @@
 <div class="form-row">
-  <mat-label>{{ 'app.survey_web_address' | translate }}</mat-label>
+  <label for="url" [attr.aria-label]="'app.survey_web_address' | translate" class="form-label">{{
+    'app.survey_web_address' | translate
+  }}</label>
   <mat-form-field appearance="outline">
-    <input type="url" matInput [value]="shareUrl" readonly="true" />
+    <input id="url" type="url" matInput [value]="shareUrl" readonly="true" />
   </mat-form-field>
 </div>
 
 <div class="form-row">
-  <mat-label>HTML</mat-label>
   <div class="copy-success" *ngIf="copySuccess">{{ 'share.copied' | translate }}</div>
+  <label class="form-label" for="iframe" [attr.aria-label]="'HTML iframe'">HTML</label>
   <mat-form-field appearance="outline" class="copy" [ngClass]="{ success: copySuccess }">
     <textarea matInput readonly cdkTextareaAutosize cdkAutosizeMaxRows="10">{{ embed }}</textarea>
     <mzima-client-button
       matSuffix
+      id="iframe"
       fill="clear"
       color="secondary"
       [iconOnly]="true"
       class="copy-button"
       [disabled]="copySuccess"
+      [ariaLabel]="'copy html iframe to clipboard'"
       (buttonClick)="copyToClipboard(embed)"
     >
       <mat-icon icon svgIcon="copy"></mat-icon>

--- a/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.html
+++ b/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.html
@@ -37,10 +37,16 @@
   >
     <ng-container survey-info>
       <div class="form-row">
-        <mat-label>{{ 'survey.survey_name' | translate }} *</mat-label>
+        <label
+          for="survey-name"
+          class="form-label"
+          [attr.aria-label]="'enter ' + 'survey.survey_name' | translate"
+          >{{ 'survey.survey_name' | translate }} *</label
+        >
         <mat-form-field appearance="outline">
           <input
             matInput
+            id="survey-name"
             formControlName="name"
             [placeholder]="'survey.survey_name' | translate"
             [readonly]="!isDefaultLanguageSelected"
@@ -58,23 +64,36 @@
       </div>
 
       <div class="form-row" *ngIf="!isDefaultLanguageSelected">
-        <mat-label> {{ 'survey.survey_name' | translate }} ({{ selectLanguageCode }})</mat-label>
+        <label
+          [for]="'survey-name-' + selectLanguageCode"
+          class="form-label"
+          [attr.aria-label]="'enter ' + 'survey.survey_name' | translate"
+        >
+          {{ 'survey.survey_name' | translate }} ({{ selectLanguageCode }})</label
+        >
         <mat-form-field appearance="outline">
           <input
             matInput
             [placeholder]="'survey.survey_name' | translate"
             [value]="form.get('translations')?.value[selectLanguageCode]?.name"
             (change)="setTranslates(selectLanguageCode, 'name', $event)"
+            [id]="'survey-name-' + selectLanguageCode"
             [data-qa]="'survey-name-' + selectLanguageCode"
           />
         </mat-form-field>
       </div>
 
       <div class="form-row">
-        <mat-label>{{ 'survey.description' | translate }}</mat-label>
+        <label
+          for="description"
+          class="form-label"
+          [attr.aria-label]="'enter ' + 'survey.description' | translate"
+          >{{ 'survey.description' | translate }}</label
+        >
         <mat-form-field appearance="outline">
           <textarea
             matInput
+            id="description"
             cdkTextareaAutosize
             cdkAutosizeMinRows="2"
             cdkAutosizeMaxRows="5"
@@ -88,10 +107,17 @@
       </div>
 
       <div class="form-row" *ngIf="!isDefaultLanguageSelected">
-        <mat-label> {{ 'survey.description' | translate }} ({{ selectLanguageCode }})</mat-label>
+        <label
+          [for]="'survey-description-' + selectLanguageCode"
+          class="form-label"
+          [attr.aria-label]="'enter ' + 'survey.description' | translate"
+        >
+          {{ 'survey.description' | translate }} ({{ selectLanguageCode }})</label
+        >
         <mat-form-field appearance="outline">
           <textarea
             matInput
+            [id]="'survey-description-' + selectLanguageCode"
             cdkTextareaAutosize
             cdkAutosizeMinRows="2"
             cdkAutosizeMaxRows="5"

--- a/apps/web-mzima-client/src/app/settings/surveys/survey-task/survey-task.component.html
+++ b/apps/web-mzima-client/src/app/settings/surveys/survey-task/survey-task.component.html
@@ -3,10 +3,16 @@
     <mat-tab [label]="'survey.main_info' | translate" [data-qa]="'survey-main-info'">
       <ng-container *ngIf="!isPost">
         <div class="form-row">
-          <mat-label>{{ 'survey.task_name' | translate }} *</mat-label>
+          <label
+            [for]="task.label"
+            class="form-label"
+            [attr.aria-label]="'survey.task_name' | translate"
+            >{{ 'survey.task_name' | translate }} *</label
+          >
           <mat-form-field appearance="outline">
             <input
               matInput
+              [id]="task.label"
               [(ngModel)]="task.label"
               [placeholder]="'survey.untitled_task' | translate"
               [readonly]="!isDefaultLanguageSelected"
@@ -16,10 +22,16 @@
           </mat-form-field>
         </div>
         <div class="form-row" *ngIf="!isDefaultLanguageSelected">
-          <mat-label>{{ 'survey.task_name' | translate }} ({{ selectLanguageCode }})</mat-label>
+          <label
+            [for]="task.label + selectLanguageCode"
+            class="form-label"
+            [attr.aria-label]="'survey.task_name' | translate"
+            >{{ 'survey.task_name' | translate }} ({{ selectLanguageCode }})</label
+          >
           <mat-form-field appearance="outline">
             <input
               matInput
+              [id]="task.label + selectLanguageCode"
               [(ngModel)]="task.translations[selectLanguageCode].label"
               [placeholder]="'survey.untitled_task' | translate"
               (ngModelChange)="changeLabel($event)"
@@ -27,10 +39,16 @@
           </mat-form-field>
         </div>
         <div class="form-row">
-          <mat-label>{{ 'app.description' | translate }}</mat-label>
+          <label
+            class="form-label"
+            for="description"
+            [attr.aria-label]="'app.description' | translate"
+            >{{ 'app.description' | translate }}</label
+          >
           <mat-form-field appearance="outline">
             <textarea
               matInput
+              id="description"
               cdkTextareaAutosize
               [readonly]="!isDefaultLanguageSelected"
               [(ngModel)]="task.description"
@@ -41,11 +59,17 @@
         </div>
 
         <div class="form-row" *ngIf="!isDefaultLanguageSelected">
-          <mat-label>{{ 'app.description' | translate }} ({{ selectLanguageCode }})</mat-label>
+          <label
+            class="form-label"
+            [for]="'description-' + selectLanguageCode"
+            [attr.aria-label]="'app.description' | translate"
+            >{{ 'app.description' | translate }} ({{ selectLanguageCode }})</label
+          >
           <mat-form-field appearance="outline">
             <textarea
               matInput
               cdkTextareaAutosize
+              [id]="'description-' + selectLanguageCode"
               [(ngModel)]="task.translations[selectLanguageCode].description"
               [placeholder]="'survey.describe_this_task' | translate"
             >
@@ -265,9 +289,16 @@
         ></app-color-picker>
 
         <div class="form-row">
-          <mat-label>{{ 'translations.survey_select_default' | translate }}</mat-label>
+          <label
+            for="select-language"
+            class="form-label"
+            [attr.aria-label]="'translations.survey_select_default' | translate"
+            >{{ 'translations.survey_select_default' | translate }}</label
+          >
           <mat-form-field appearance="outline">
             <mat-select
+              id="select-language"
+              [aria-label]="'translations.survey_select_default' | translate"
               disableOptionCentering
               panelClass="language-field"
               [(value)]="selectedLanguage"

--- a/apps/web-mzima-client/src/app/shared/components/color-picker/color-picker.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/color-picker/color-picker.component.html
@@ -1,10 +1,13 @@
 <div class="form-row">
-  <mat-label *ngIf="label">{{ label }}</mat-label>
+  <label class="form-label" for="color-picker" aria-label="select color" *ngIf="label">{{
+    label
+  }}</label>
   <mat-form-field appearance="outline">
     <span matPrefix class="selected-color" [ngStyle]="{ backgroundColor: value || '#eee' }"></span>
     <input
       matInput
       readonly
+      id="color-picker"
       [(ngModel)]="value"
       [matMenuTriggerFor]="menu"
       [placeholder]="placeholder"

--- a/apps/web-mzima-client/src/styles/_forms.scss
+++ b/apps/web-mzima-client/src/styles/_forms.scss
@@ -11,6 +11,21 @@
   fill: var(--color-neutral-100);
 }
 
+.mat-form-field-label {
+  transform: none !important;
+  transition: none !important;
+  top: -2px !important;
+  color: var(--color-neutral-100) !important;
+}
+
+.mat-form-field-required-marker {
+  color: var(--color-neutral-100) !important;
+}
+
+// .form-row {
+//   margin-top: 34px;
+// }
+
 .mat-pseudo-checkbox {
   margin-top: 3.5px;
   margin-inline-start: 3.5px;


### PR DESCRIPTION
Should resolve [#4904](https://github.com/ushahidi/platform/issues/4904)

**Description**
Currently, most of all the form inputs fields on the Ushahidi platform are disconnected from their labels and this makes it difficult for screen readers to understand the purpose of the input field, so when the input is focused the screen reader just announces the html element and in some cases it relies on the input placeholder.
Given the Ushahidi's platform data-driven nature and heavy reliance on forms, it is of high priority to ensure that forms are fully accessible in order to create a more inclusive environment, facilitating seamless interaction for all users, regardless of their accessibility needs.

**How to reproduce?**
1. Go to any form on the Ushahidi platform e.g http://localhost:4200/settings/surveys/create
2. Inspect any input label element
3. Notice the mat-label is disconnected from the input? 
4. Inspect the input element
5. Notice no semantic `label` is linked to the input?

See image below 👇🏽 

![Screenshot 2024-03-30 at 15 54 47](https://github.com/ushahidi/platform/assets/46582086/3a7cc0a9-29b6-4b36-8685-9a86a3d7235d)

**Why does this happen?**
After digging very deep into this, I realized that the `mat-label`s are currently placed outside of the `mat-form-field` to prevent the default material form input animation that happens when the `mat-label` is placed inside the `mat-form-field`. This works fine aesthetically and matches the design but the disadvantage is that it disconnects the labels from their inputs, leaving these fields without labels and even aria-labels attributes thereby making it difficult for screen readers to understand.

**How to fix this**
There are two ways to fix this: 
1. Move the `mat-label` back inside the `mat-form-field` element and use the method described [here](https://v14.material.angular.io/components/form-field/overview#floating-label) in the angular material docs along some extra styling to keep the label fixed at the top of the input.
2. Use semantic html label to replace `mat-label`

I have chosen to go with option 2 to fix this issue because of the following reasons

1. less refactor on the post-edit component that's used for rendering dynamic forms
2. No need for css overwrite on the default `mat-label` component.. in other words less use of `!important` :)

The one caveat that comes with this approach is, semantic labels won't work on other material components like `mat-select`, `mat-selection-list` but for this I have chosen to rely on `aria-label` attribute which works perfectly and is also recommended in the [angular material ui v14 doc](https://v14.material.angular.io/components/select/overview#accessibility)

@angamanga This is another promising and very important pr as it'll involve making changes to all the forms on the Ushahidi web codebase and I'll need your feedback/approval to continue with this. 🙏🏽
