### PR TITLE
[Outreachy Task Submission] Add Hidden Button Value Text for main-filter toggle btn in Map and Data Screens

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -55,6 +55,7 @@
       class="search-form__main-filters__toggle-btn"
     >
       <mat-icon svgIcon="angle-right"></mat-icon>
+      <span class="visually-hidden">Toggle main filter</span>
     </button>
 
     <div class="search-form__main-filters__inner">

--- a/apps/web-mzima-client/src/styles.scss
+++ b/apps/web-mzima-client/src/styles.scss
@@ -193,3 +193,14 @@ a {
     bottom: 100px !important;
   }
 }
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  border: 0 !important;
+}

--- a/apps/web-mzima-client/src/styles.scss
+++ b/apps/web-mzima-client/src/styles.scss
@@ -195,12 +195,12 @@ a {
 }
 
 .visually-hidden {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  margin: -1px !important;
-  padding: 0 !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  border: 0 !important;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }


### PR DESCRIPTION
# Introduction
The "main-filter toggle" button icon in both the `Data` and `Map` views has a problem. The button has only an icon and has no value text. While this is just a stylistic choice, it raises an issue with any accessibility checking tool.  It does this because a button having no value text is a violation of WCAG Success Criterion 1.1.1 (Level A) - Non-text content. [See](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html). See a screenshot of the pertinent component:

![image](https://github.com/ushahidi/platform-client-mzima/assets/29470516/f372f047-30c1-4b19-84ff-fc6a94125d7c)
> ***Note the SVG icon***

# How to Test the PR
## Manually Testing
1. Open your browser and log into your running Ushahidi deployment (from localhost).
2. Navigate to either the `data` or `map` section.
3. Try right-clicking on the arrow by the side of the navigation and selecting 'inspect'.
4. View the properties. Notice you won't see any button value text.
5. You will not see any text in it.
6. Stop the running Ushahidi deployment in your terminal.
7. Checkout to this PR branch.
8. Re-run your Ushahidi deployment.
10. Repeat steps 1-3.
11. You will see a value in the `buttton` element this time around, and this text will be visually hidden.

## Using an Accessibility Checker
If you use a tool like [WAVE evaluation tool](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh), it's as simple as following steps 1 and 2 above, and then turning on the browser extension. It will flag the issue. Checkout to the PR and do this again, you will notice the issue is no longer flagged. 

## Dependency
This fix has a dependency on a previous [PR](https://github.com/ushahidi/platform-client-mzima/pull/860)

## Fixes
This fixes [#4905](https://github.com/ushahidi/platform/issues/4905)