### PR TITLE
[Outreachy Task Submission ] The HTML-embedded icon for copying does not gain focus when navigating through tabs using the keyboard in the Share Deployment Modal.

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.html
@@ -41,11 +41,15 @@
             [(ngModel)]="htmlEmbed"
           >
           </textarea>
-          <mat-icon
-            (click)="copyToClipboard()"
+          <mzima-client-button
+            fill="outline"
+            color="transparent-style-1"
+            [iconOnly]="true"
             class="fab-button__icon copy"
-            svgIcon="copy"
-          ></mat-icon>
+            [ariaLabel]="'Toggle company details' | translate"
+          >
+            <mat-icon (click)="copyToClipboard()" svgIcon="copy"></mat-icon>
+          </mzima-client-button>
         </mat-form-field>
       </div>
     </div>

--- a/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.html
@@ -46,9 +46,10 @@
             color="transparent-style-1"
             [iconOnly]="true"
             class="fab-button__icon copy"
-            [ariaLabel]="'Toggle company details' | translate"
+            [ariaLabel]="'Copy HTML' | translate"
+            (click)="copyToClipboard()"
           >
-            <mat-icon (click)="copyToClipboard()" svgIcon="copy"></mat-icon>
+            <mat-icon svgIcon="copy"></mat-icon>
           </mzima-client-button>
         </mat-form-field>
       </div>

--- a/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/share-modal/share-modal.component.scss
@@ -14,11 +14,26 @@
 
   .copy {
     position: absolute;
-    inset-inline-end: 16px;
+    inset-inline-end: 4px;
     top: 50%;
     transform: translate(0, -50%);
     cursor: pointer;
 
+    ::ng-deep {
+      .mzima-button {
+        &--outline {
+          --background-color: var(--color-neutral-70);
+          --hover-background-color: var(--color-neutral-10);
+          --active-background-color: var(--color-neutral-20);
+        }
+
+        &--icon-only {
+          width: var(--size, 36px);
+          height: var(--size, 36px);
+          font-size: var(--icon-size, 24px);
+        }
+      }
+    }
     &-success {
       position: absolute;
       width: 100%;
@@ -52,7 +67,7 @@
     justify-content: space-between;
 
     mzima-client-button {
-      margin: 0 8px 8px;
+      margin: 0 8px 12px;
       width: calc(50% - 16px);
     }
   }


### PR DESCRIPTION
This PR addresses this [issue](https://github.com/ushahidi/platform/issues/4907).

**Fix:**
The HTML-embedded icon for copying is now reachable via keyboard tab navigation, enabling users to execute the "copy code" action using keyboard input.

1. The HTML-embedded icon is now focusable.
2. Users can now copy the code using the Enter key on the keyboard.
3. Margin bottom has been included for both the "share on Twitter" and "share on Facebook" buttons.

**Steps To Reproduce The Fix:**
See the screencast below for reference:

Go to the Ushahidi client platform.
1. Click the Share button, and a modal will pop up.
2. Navigate the Share deployment modal using the Tab button to traverse the elements.
3. You will notice the copy icon receives tab focus.
4. Click enter to copy the code. Expected results: The HTML code to be copied.

Environment:
Browser: Chrome & Firefox

[Steps To Reproduce HTML-embedded copy icon fix.webm](https://github.com/ushahidi/platform-client-mzima/assets/49617104/760e7512-1690-496b-bc14-45f8cb74c192)


