### PR TITLE
[Outreachy Task Submission] Prevent Weak Passwords from Creating Accounts

### DIFF
--- a/apps/mobile-mzima-client/src/app/shared/components/password-strength/password-strength.component.ts
+++ b/apps/mobile-mzima-client/src/app/shared/components/password-strength/password-strength.component.ts
@@ -88,7 +88,7 @@ export class PasswordStrengthComponent implements OnChanges {
     force += 2 * password.length + (password.length >= 10 ? 1 : 0);
     force += passedMatches * 10;
 
-    force = password.length <= 6 ? Math.min(force, 10) : force;
+    force = password.length < 8 ? Math.min(force, 10) : force;
 
     force = passedMatches === 1 ? Math.min(force, 10) : force;
     force = passedMatches === 2 ? Math.min(force, 20) : force;

--- a/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.html
+++ b/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.html
@@ -42,7 +42,10 @@
       }}</mat-error>
       <mat-hint>{{ 'user.password_hint' | translate }}.</mat-hint>
     </mat-form-field>
-    <app-password-strength [passwordToCheck]="form.value.password"></app-password-strength>
+    <app-password-strength
+      [passwordToCheck]="form.value.password"
+      (passwordStrength)="onPasswordStrength($event)"
+    ></app-password-strength>
   </div>
 
   <div class="form-row">
@@ -58,7 +61,7 @@
 
     <mzima-client-button
       type="submit"
-      [disabled]="form.invalid || form.disabled || submitted"
+      [disabled]="form.invalid || form.disabled || submitted || !passwordStrong"
       [data-qa]="'btn-register'"
     >
       {{ 'nav.register' | translate }}

--- a/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.ts
+++ b/apps/web-mzima-client/src/app/auth/forms/registration-form/registration-form.component.ts
@@ -15,6 +15,7 @@ export class RegistrationFormComponent {
   public isPasswordVisible = false;
   public form: FormGroup;
   public submitted = false;
+  public passwordStrong: boolean = false;
 
   constructor(private authService: AuthService, private formBuilder: FormBuilder) {
     this.form = this.formBuilder.group({
@@ -91,5 +92,9 @@ export class RegistrationFormComponent {
       control.setValidators(validators);
       control.updateValueAndValidity();
     });
+  }
+
+  onPasswordStrength(isStrong: boolean) {
+    this.passwordStrong = isStrong;
   }
 }


### PR DESCRIPTION
# Introduction
This fixes [#4908](https://github.com/ushahidi/platform/issues/4908). It prevents weak passwords (despite achieving minimum length requirements) from being able to create accounts. It does this by disabling the signup button.

## How to Test this PR
1. Open the Ushahidi platform (either via a deployment or Localhost)
2. Click on `Login & Signup`.
3. Switch to the Signup view and fill in the form (except the password form).
4. For the password, fill in something that only meets the minimum length constraints but ignores other constraints (for example "adminooo"). Note: you can copy and paste the example.
5. You will notice that the password hint suggests that your password is very weak.
6. Agree to the terms and conditions.
7. You will notice that the **Signup** button is no longer disabled and can be clicked on.
8. Checkout to this PR.
9. Repeat steps 1-6.
10. You will notice that the **Signup** button is still disabled and can't be clicked on.
11. Try updating the password to meet another constraint such as adding a number. For example "adminooo1".
12. You will notice that the **Signup** button is no longer disabled and can be clicked on.