### PR TITLE
[Outreachy Task Submission] Add Unique and Simple Titles to Every Page

### DIFF
--- a/apps/web-mzima-client/src/app/core/services/page-title.service.ts
+++ b/apps/web-mzima-client/src/app/core/services/page-title.service.ts
@@ -17,12 +17,12 @@ export class UshahidiPageTitleStrategy extends TitleStrategy {
   }
 
   override updateTitle(routerState: RouterStateSnapshot) {
-    const title = this.buildTitle(routerState);
+    const route = routerState.url.split('/')[1];
+    const currentRoute = route.charAt(0).toUpperCase() + route.slice(1); // To capitalize first letter
 
-    if (title) {
-      this.title.setTitle(
-        `${this.translateService.instant(title)} | ${this.session.getSiteConfigurations().name}`,
-      );
+    if (currentRoute) {
+      const translatedRoute = this.translateService.instant(currentRoute);
+      this.title.setTitle(`${translatedRoute} | ${this.session.getSiteConfigurations().name}`);
     } else {
       this.title.setTitle(`${this.session.getSiteConfigurations().name}`);
     }


### PR DESCRIPTION
# Introduction
This fixes [#4909](https://github.com/ushahidi/platform/issues/4909). It adds a unique and simple title to each page, instead of the generic "Localhost:4200" when running locally, or the site deployment name when on web.

## How to Test this PR
1. Login to your running Ushahidi deployment (preferably on the web).
2. Navigate to the pages on the platform and look at the titles that show in your browser tab.
3. For the web, notice how all titles are the same as the site deployment name. For local deployments, you will notice it's all Localhost.
4. Checkout to this PR.
5. Repeat steps 1 and 2.
6. You will notice that now, the titles are specific to each route, and they get their name from the URL.

## Video Reference
Here's a video of what it looks like before this PR. Note the top part of the browser that shows the tab.

https://github.com/ushahidi/platform-client-mzima/assets/29470516/201db47f-00c0-4ba0-9a79-a9107bf8762d

Here's a video of what it looks like after this PR. Note the top part of the browser that shows the tab.

https://github.com/ushahidi/platform-client-mzima/assets/29470516/0af19ea1-cf43-4194-a2a9-1126170f15dd

