### PR TITLE
USH-1253: fixate humanitarian layer URL scheme

### DIFF
--- a/apps/mobile-mzima-client/src/app/core/helpers/map.ts
+++ b/apps/mobile-mzima-client/src/app/core/helpers/map.ts
@@ -52,7 +52,7 @@ export const getMapLayers = () => {
       MapQuest: mapboxStaticTiles('Streets', 'mapbox/streets-v11'),
       hOSM: {
         name: 'Humanitarian',
-        url: '//{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
+        url: 'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
         layerOptions: {
           attribution:
             '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a>, &copy; <a href="http://hot.openstreetmap.org/">Humanitarian OpenStreetMap</a> | <a href="https://www.mapbox.com/feedback/" target="_blank">Improve the underlying map</a>',


### PR DESCRIPTION
Upon debugging in safari connected to iOS simulator, I noticed that the tile requests are prefixed by "capacitor://"

This change makes the base layer scheme absolute.