### PR TITLE
Fixes deployment details disappearing upon Changing and Saving

### DIFF
--- a/apps/web-mzima-client/src/app/settings/general/general.component.ts
+++ b/apps/web-mzima-client/src/app/settings/general/general.component.ts
@@ -150,8 +150,8 @@ export class GeneralComponent implements OnInit {
     this.langService.changeLanguage(siteConfig.language);
 
     return this.configService.update('site', siteConfig).pipe(
-      mergeMap((updatedSite) => {
-        this.sessionService.setConfigurations('site', updatedSite);
+      mergeMap((updatedSite: any) => {
+        this.sessionService.setConfigurations('site', updatedSite.result);
         return this.configService.update('map', this.mapSettings.mapConfig);
       }),
     );


### PR DESCRIPTION
As noticed in [issue#4898](https://github.com/ushahidi/platform/issues/4898) when attempting to modify and save the deployment name, logo, or description within the deployment settings, an unexpected issue occurs where all deployment details disappear. And only when the user refreshes the page the deployment details reappear.

this happened because in `general.component.ts` this was returned 
```typescript
return this.configService.update('site', siteConfig).pipe(
      mergeMap((updatedSite) => {
        this.sessionService.setConfigurations('site', updatedSite);
        return this.configService.update('map', this.mapSettings.mapConfig);
      }),
```
when infact it should've returned `updatedSite.result`
As you can notice in screenrecording below, the site deployment details does not vanish anymore

https://github.com/ushahidi/platform-client-mzima/assets/91622060/2291edf8-3c86-47ae-a4bf-3fc4ca9b54fc


