### PR TITLE
[Outreachy Task Submission] Add Keyboard Support For Location Field in General Settings

### DIFF
--- a/apps/web-mzima-client/src/app/settings/general/general.module.ts
+++ b/apps/web-mzima-client/src/app/settings/general/general.module.ts
@@ -6,6 +6,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { LeafletModule } from '@asymmetrik/ngx-leaflet';
 import { MzimaUiModule } from '@mzima-client/mzima-ui';
 import { TranslateModule } from '@ngx-translate/core';
@@ -31,6 +32,7 @@ import { SettingsMapComponent } from './settings-map/settings-map.component';
     MatButtonModule,
     MatIconModule,
     DirectiveModule,
+    MatAutocompleteModule,
     FormsModule,
     MzimaUiModule,
     FilterVisibleLayersModule,

--- a/apps/web-mzima-client/src/app/settings/general/settings-map/settings-map.component.html
+++ b/apps/web-mzima-client/src/app/settings/general/settings-map/settings-map.component.html
@@ -1,34 +1,47 @@
 <ng-container *ngIf="mapConfig">
-  <div class="form-row">
+  <div cdkScrollable class="form-row">
     <mat-label>{{ 'survey.location' | translate }}</mat-label>
     <mat-form-field appearance="outline">
       <input
         matInput
         [(ngModel)]="queryLocation"
         (ngModelChange)="searchLocation()"
-        (focusout)="searchLocation()"
         placeholder="{{ 'settings.general_settings.placeholder.pick_location' | translate }}"
         [data-qa]="'query-location'"
+        [matAutocomplete]="cities"
       />
 
-      <mzima-client-button [iconOnly]="true" fill="clear" matSuffix color="secondary">
+      <mzima-client-button
+        [iconOnly]="true"
+        fill="clear"
+        matSuffix
+        color="secondary"
+        *ngIf="!queryLocation"
+      >
         <mat-icon icon svgIcon="search-small"></mat-icon>
       </mzima-client-button>
-    </mat-form-field>
-    <ul
-      class="geocoder-list"
-      *ngIf="isShowGeocodingResults && geocodingResults.length"
-      [data-qa]="'geocoder-list'"
-    >
-      <li
-        class="geocoder-list__item"
-        *ngFor="let result of geocodingResults"
-        (click)="selectLocation(result)"
-        [data-qa]="'geocoder-list-item'"
+      <mzima-client-button
+        matSuffix
+        fill="clear"
+        [iconOnly]="true"
+        color="secondary"
+        *ngIf="queryLocation"
+        (buttonClick)="clearSearch()"
       >
-        {{ result.name }}
-      </li>
-    </ul>
+        <mat-icon icon svgIcon="close"></mat-icon>
+      </mzima-client-button>
+      <mat-autocomplete autoActiveFirstOption #cities="matAutocomplete" [data-qa]="'geocoder-list'">
+        <mat-option
+          *ngFor="let result of citiesOptions | async"
+          [value]="result"
+          (click)="selectLocation(result)"
+          (onSelectionChange)="selectLocation(result)"
+          [data-qa]="'geocoder-list-item'"
+        >
+          {{ result.name }}
+        </mat-option>
+      </mat-autocomplete>
+    </mat-form-field>
   </div>
 
   <div class="form-row map-holder">

--- a/apps/web-mzima-client/src/app/settings/general/settings-map/settings-map.component.html
+++ b/apps/web-mzima-client/src/app/settings/general/settings-map/settings-map.component.html
@@ -24,6 +24,7 @@
         matSuffix
         fill="clear"
         [iconOnly]="true"
+        [ariaLabel]="'clear current search'"
         color="secondary"
         *ngIf="queryLocation"
         (buttonClick)="clearSearch()"

--- a/apps/web-mzima-client/src/app/settings/general/settings-map/settings-map.component.ts
+++ b/apps/web-mzima-client/src/app/settings/general/settings-map/settings-map.component.ts
@@ -15,7 +15,7 @@ import {
   tileLayer,
 } from 'leaflet';
 import Geocoder from 'leaflet-control-geocoder';
-import { debounceTime, Subject } from 'rxjs';
+import { BehaviorSubject, debounceTime, Subject } from 'rxjs';
 import { pointIcon } from '../../../core/helpers/map';
 
 @UntilDestroy()
@@ -41,6 +41,7 @@ export class SettingsMapComponent implements OnInit {
   public queryLocation: string = '';
   private searchSubject = new Subject<string>();
   public geocodingResults: any[] = [];
+  public citiesOptions: BehaviorSubject<any[]>;
   public isShowGeocodingResults = false;
   locationPrecisionEnabled: any;
   currentPrecision = 9;
@@ -51,6 +52,7 @@ export class SettingsMapComponent implements OnInit {
     this.searchSubject.pipe(debounceTime(600), untilDestroyed(this)).subscribe((query) => {
       this.performSearch(query);
     });
+    this.citiesOptions = new BehaviorSubject<any[]>([]);
 
     this.mapConfig = this.sessionService.getMapConfigurations();
     this.currentPrecision = this.getPrecision();
@@ -116,6 +118,7 @@ export class SettingsMapComponent implements OnInit {
     });
 
     this.geocoderControl.on('finishgeocode', (e: any) => {
+      this.citiesOptions.next(e.results);
       this.geocodingResults = e.results;
     });
   }
@@ -160,7 +163,14 @@ export class SettingsMapComponent implements OnInit {
     this.map.fitBounds(item.bbox);
     this.setCoordinates(coordinates.lat, coordinates.lng);
     this.geocodingResults = [];
+    this.citiesOptions.next([]);
     this.searchSubject.next('');
+  }
+
+  public clearSearch() {
+    this.queryLocation = '';
+    this.geocodingResults = [];
+    this.citiesOptions.next([]);
   }
 
   private setCoordinates(lat: number, lon: number) {


### PR DESCRIPTION
**Description**
While working on the accessibility of forms on the Ushahidi platform in #985 I realized the search results in the location field dropdown in general settings isn't fully navigable using keyboard.

**Fix**

- I have replaced the ul element in this code to use mat-autocomplete as it's best suitable for this purpose and supports keyboard navigation.
- I have also added a clear icon to clear the current search result to reduce the extra effort of deleting the current location manually

**How to test**
Using your keyboard only
1. Go to http://localhost:4200/settings/general
2. Search for a location
3. Navigate through the search results list using `up` and `down` arrow keys
4. Press `enter` to select
5. Press `tab` to navigate to clear button
6. Press `enter` to clear current search

@Angamanga This pr is ready for review 🙏🏽 