### PR TITLE
Ush 1193 - Filters should behave

### DIFF
--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -41,7 +41,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
   public override params: GeoJsonFilter = {
     limit: 20,
     page: 1,
-    include_unstructured_posts: false,
+    currentView: 'feed',
     // created_before_by_id: '',
   };
   private readonly getPostsSubject = new Subject<{

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -41,7 +41,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
   public override params: GeoJsonFilter = {
     limit: 20,
     page: 1,
-    // include_unstructured_posts: true,
+    include_unstructured_posts: false,
     // created_before_by_id: '',
   };
   private readonly getPostsSubject = new Subject<{

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -41,7 +41,7 @@ export class FeedComponent extends MainViewComponent implements OnInit {
   public override params: GeoJsonFilter = {
     limit: 20,
     page: 1,
-    include_unstructured_posts: true,
+    // include_unstructured_posts: true,
     // created_before_by_id: '',
   };
   private readonly getPostsSubject = new Subject<{

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -38,19 +38,13 @@ enum FeedMode {
 export class FeedComponent extends MainViewComponent implements OnInit {
   @ViewChild('feed') public feed: ElementRef;
   @ViewChild('masonry') public masonry: NgxMasonryComponent;
-  public override params: GeoJsonFilter = {
-    limit: 20,
-    page: 1,
-    currentView: 'feed',
-    // created_before_by_id: '',
-  };
   private readonly getPostsSubject = new Subject<{
     params: GeoJsonFilter;
     add?: boolean;
   }>();
   public pagination = {
-    page: 1,
-    size: this.params.limit,
+    page: 0,
+    limit: 20,
   };
   public posts: PostResult[] = [];
   public postCurrentLength = 0;
@@ -114,7 +108,9 @@ export class FeedComponent extends MainViewComponent implements OnInit {
       sessionService,
       breakpointService,
     );
+
     this.checkDesktop();
+    this.setupFeedDefaultFilters();
     this.initGetPostsListener();
 
     if (!this.isDesktop) {
@@ -216,6 +212,17 @@ export class FeedComponent extends MainViewComponent implements OnInit {
     this.getUserData();
     this.checkPermission();
     this.eventBusListeners();
+  }
+
+  private setupFeedDefaultFilters() {
+    if (this.params.include_unstructured_posts) this.params['form[]']?.push('0');
+    this.params.currentView = 'feed';
+    (this.params.limit = 20),
+      (this.params.page = 1),
+      (this.pagination = {
+        limit: this.params.limit,
+        page: this.params.page,
+      });
   }
 
   private eventBusListeners() {

--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -131,7 +131,6 @@ export class MapComponent extends MainViewComponent implements OnInit {
   }
 
   loadData(): void {
-    // this.reInitParams();
     this.getPostsGeoJson();
   }
 
@@ -141,7 +140,6 @@ export class MapComponent extends MainViewComponent implements OnInit {
         if (this.route.snapshot.data['view'] === 'search' && !this.searchId) return;
         if (this.route.snapshot.data['view'] === 'collection' && !this.collectionId) return;
 
-        // this.reInitParams();
         this.getPostsGeoJson();
       },
     });

--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -148,6 +148,7 @@ export class MapComponent extends MainViewComponent implements OnInit {
 
   private reInitParams() {
     this.params.page = 1;
+    this.params.currentView = 'map';
     this.mapLayers.map((layer) => {
       this.map.removeLayer(layer);
       this.markerClusterData.removeLayer(layer);

--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -80,6 +80,7 @@ export class MapComponent extends MainViewComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.reInitParams();
     this.route.params.subscribe(() => {
       this.initCollection();
     });
@@ -130,7 +131,7 @@ export class MapComponent extends MainViewComponent implements OnInit {
   }
 
   loadData(): void {
-    this.reInitParams();
+    // this.reInitParams();
     this.getPostsGeoJson();
   }
 
@@ -140,7 +141,7 @@ export class MapComponent extends MainViewComponent implements OnInit {
         if (this.route.snapshot.data['view'] === 'search' && !this.searchId) return;
         if (this.route.snapshot.data['view'] === 'collection' && !this.collectionId) return;
 
-        this.reInitParams();
+        // this.reInitParams();
         this.getPostsGeoJson();
       },
     });

--- a/apps/web-mzima-client/src/app/shared/components/main-view.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/main-view.component.ts
@@ -71,7 +71,7 @@ export abstract class MainViewComponent {
     }
   }
 
-  private normalizeFilter(values: GeoJsonFilter) {
+  private normalizeFilter(values: GeoJsonFilter): GeoJsonFilter {
     if (!values) return {};
 
     const filters = {

--- a/apps/web-mzima-client/src/app/shared/components/main-view.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/main-view.component.ts
@@ -18,11 +18,9 @@ export abstract class MainViewComponent {
   searchId = '';
   collectionId = '';
   params: GeoJsonFilter = {
-    include_unstructured_posts: false,
     limit: 500,
     offset: 0,
   };
-  filters;
   public user: UserInterface;
   public isDesktop: boolean = false;
 
@@ -35,7 +33,7 @@ export abstract class MainViewComponent {
     protected sessionService: SessionService,
     protected breakpointService: BreakpointService,
   ) {
-    this.filters = JSON.parse(
+    this.params = JSON.parse(
       localStorage.getItem(this.sessionService.getLocalStorageNameMapper('filters'))!,
     );
   }
@@ -47,7 +45,7 @@ export abstract class MainViewComponent {
       this.collectionId = this.route.snapshot.paramMap.get('id')!;
       this.params.set = this.collectionId;
       this.postsService.applyFilters({
-        ...this.normalizeFilter(this.filters),
+        ...this.normalizeFilter(this.params),
         set: this.collectionId,
       });
       this.searchId = '';
@@ -66,28 +64,24 @@ export abstract class MainViewComponent {
       } else {
         this.searchId = '';
         this.postsService.applyFilters({
-          ...this.normalizeFilter(this.filters),
+          ...this.normalizeFilter(this.params),
           set: [],
         });
       }
     }
   }
 
-  private normalizeFilter(values: any) {
+  private normalizeFilter(values: GeoJsonFilter) {
     if (!values) return {};
 
     const filters = {
       ...values,
-      'form[]': values.form,
-      'source[]': values.source,
-      'status[]': values.status,
-      'tags[]': values.tags,
+      'form[]': values['form[]'],
+      'source[]': values['source[]'],
+      'status[]': values['status[]'],
+      'tags[]': values['tags[]'],
     };
 
-    delete filters.form;
-    delete filters.source;
-    delete filters.status;
-    delete filters.tags;
     return filters;
   }
 

--- a/apps/web-mzima-client/src/app/shared/components/main-view.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/main-view.component.ts
@@ -18,6 +18,7 @@ export abstract class MainViewComponent {
   searchId = '';
   collectionId = '';
   params: GeoJsonFilter = {
+    include_unstructured_posts: false,
     limit: 500,
     offset: 0,
   };

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -144,7 +144,6 @@
                 fill="clear"
                 size="small"
                 class="filter-group__head__button"
-                (buttonClick)="clearFilter('form')"
                 [data-qa]="'clear'"
                 (buttonClick)="toggleSidebarFilters('form')"
               >

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -157,20 +157,22 @@
               formControlName="form"
               [data-qa]="'survey-selection-list'"
             >
-              <mat-list-option
-                *ngFor="let survey of surveyList"
-                [selected]="survey.checked"
-                color="primary"
-                [value]="survey.id"
-                checkboxPosition="before"
-                class="selection-list__option"
-                [ngStyle]="{ '--color': survey.color }"
-                [data-qa]="'survey-select-item' + survey.id"
-              >
-                <span class="selection-list__option__border"></span>
-                {{ survey.name }}
-                <span class="selection-list__option__total">{{ survey.total }}</span>
-              </mat-list-option>
+              <ng-container *ngFor="let survey of surveyList">
+                <mat-list-option
+                  *ngIf="!(survey.id === 0 && isMapView)"
+                  [selected]="survey.checked"
+                  color="primary"
+                  [value]="survey.id"
+                  checkboxPosition="before"
+                  class="selection-list__option"
+                  [ngStyle]="{ '--color': survey.color }"
+                  [data-qa]="'survey-select-item' + survey.id"
+                >
+                  <span class="selection-list__option__border"></span>
+                  {{ survey.name }}
+                  <span class="selection-list__option__total">{{ survey.total }}</span>
+                </mat-list-option>
+              </ng-container>
             </mat-selection-list>
 
             <div class="filter-group__info" *ngIf="isMapView">

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -159,7 +159,7 @@
             >
               <ng-container *ngFor="let survey of surveyList">
                 <mat-list-option
-                  *ngIf="!(survey.id === 0 && isMapView)"
+                  [hidden]="isMapView && survey.id === 0"
                   [selected]="survey.checked"
                   color="primary"
                   [value]="survey.id"

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.scss
@@ -486,6 +486,10 @@
       line-height: 14px;
     }
 
+    &[hidden] {
+      display: none;
+    }
+
     &:not(:first-child) {
       margin-top: 8px;
     }

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -125,6 +125,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
     this.router.events.pipe(filter((event) => event instanceof NavigationStart)).subscribe({
       next: (params: any) => {
         this.isMapView = params.url.includes('/map');
+        this.applyFilters(false);
       },
     });
 
@@ -492,7 +493,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
   }
 
   public getPostsStatistic(): Observable<any> {
-    return this.postsService.getPostStatistics(null, this.isMapView).pipe(
+    return this.postsService.getPostStatistics(this.activeFilters, this.isMapView).pipe(
       map((res) => {
         this.notMappedPostsCount = res.result.unmapped;
         const values = res.result.group_by_total_posts;

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -106,12 +106,13 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.getUserData();
+    this.isMapView = this.router.url.includes('/map');
     this.eventBusInit();
     this.getSavedFilters();
+    this.initFilters();
     this.getSurveys();
     this.getCategories();
-    this.initFilters();
+    this.getUserData();
 
     if (this.activeSaved) {
       this.activeSavedSearch = JSON.parse(this.activeSaved!);
@@ -120,8 +121,6 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
       this.checkSavedSearchNotifications();
     }
 
-    // TODO: There should be a better way to check if the context is a map view
-    this.isMapView = this.router.url.includes('/map');
     this.router.events.pipe(filter((event) => event instanceof NavigationStart)).subscribe({
       next: (params: any) => {
         this.isMapView = params.url.includes('/map');
@@ -429,7 +428,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
 
     forkJoin([
       this.surveysService.get('', { show_unknown_form: true }),
-      this.postsService.getPostStatistics(null),
+      this.getPostsStatistic(),
     ]).subscribe({
       next: (responses) => {
         const values = responses[1].result.group_by_total_posts;

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -333,6 +333,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
       'status[]': values.status,
       'form[]': values.form,
       'tags[]': values.tags,
+      currentView: this.isMapView ? 'map' : 'feed',
       include_unstructured_posts: fetchPostsWithoutFormId,
       set: values.set,
       date_after: values.date.start ? dayjs(values.date.start).toISOString() : undefined,
@@ -428,7 +429,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
 
     forkJoin([
       this.surveysService.get('', { show_unknown_form: true }),
-      this.postsService.getPostStatistics(null, this.isMapView),
+      this.postsService.getPostStatistics(null),
     ]).subscribe({
       next: (responses) => {
         const values = responses[1].result.group_by_total_posts;
@@ -493,7 +494,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
   }
 
   public getPostsStatistic(): Observable<any> {
-    return this.postsService.getPostStatistics(this.activeFilters, this.isMapView).pipe(
+    return this.postsService.getPostStatistics(this.activeFilters).pipe(
       map((res) => {
         this.notMappedPostsCount = res.result.unmapped;
         const values = res.result.group_by_total_posts;

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -331,7 +331,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
       'status[]': values.status,
       'form[]': values.form,
       'tags[]': values.tags,
-      include_unstructured_posts: !this.isMapView && fetchPostsWithoutFormId,
+      include_unstructured_posts: !(this.isMapView && fetchPostsWithoutFormId),
       set: values.set,
       date_after: values.date.start ? dayjs(values.date.start).toISOString() : null,
       date_before: values.date.end
@@ -680,7 +680,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
       tags: [],
       source: this.sources.map((s) => s.value),
       form: this.surveyList.map((s) => s.id),
-      include_unstructured_posts: !this.isMapView && fetchPostsWithoutFormId,
+      include_unstructured_posts: !(this.isMapView && fetchPostsWithoutFormId),
       date: {
         start: '',
         end: '',

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -331,7 +331,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
       'status[]': values.status,
       'form[]': values.form,
       'tags[]': values.tags,
-      include_unstructured_posts: fetchPostsWithoutFormId,
+      include_unstructured_posts: !this.isMapView && fetchPostsWithoutFormId,
       set: values.set,
       date_after: values.date.start ? dayjs(values.date.start).toISOString() : null,
       date_before: values.date.end
@@ -680,7 +680,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
       tags: [],
       source: this.sources.map((s) => s.value),
       form: this.surveyList.map((s) => s.id),
-      include_unstructured_posts: fetchPostsWithoutFormId,
+      include_unstructured_posts: !this.isMapView && fetchPostsWithoutFormId,
       date: {
         start: '',
         end: '',

--- a/libs/sdk/src/lib/models/posts.interface.ts
+++ b/libs/sdk/src/lib/models/posts.interface.ts
@@ -37,6 +37,8 @@ export interface GeoJsonFilter {
   'status[]'?: string[];
   'form[]'?: string[];
   created_before_by_id?: string;
+  center_point?: string;
+  within_km?: string;
   q?: string;
   page?: number;
 }

--- a/libs/sdk/src/lib/models/posts.interface.ts
+++ b/libs/sdk/src/lib/models/posts.interface.ts
@@ -22,6 +22,8 @@ export interface GeoJsonItem {
 
 export interface GeoJsonFilter {
   has_location?: string;
+  currentView?: 'map' | 'feed';
+  allSurveys?: boolean;
   limit?: number;
   offset?: number;
   order?: 'desc' | 'asc';

--- a/libs/sdk/src/lib/models/posts.interface.ts
+++ b/libs/sdk/src/lib/models/posts.interface.ts
@@ -23,7 +23,7 @@ export interface GeoJsonItem {
 export interface GeoJsonFilter {
   has_location?: string;
   currentView?: 'map' | 'feed';
-  allSurveys?: boolean;
+  // allSurveys?: boolean;
   limit?: number;
   offset?: number;
   order?: 'desc' | 'asc';

--- a/libs/sdk/src/lib/models/posts.interface.ts
+++ b/libs/sdk/src/lib/models/posts.interface.ts
@@ -23,7 +23,6 @@ export interface GeoJsonItem {
 export interface GeoJsonFilter {
   has_location?: string;
   currentView?: 'map' | 'feed';
-  // allSurveys?: boolean;
   limit?: number;
   offset?: number;
   order?: 'desc' | 'asc';

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -25,7 +25,6 @@ export class PostsService extends ResourceService<any> {
     set: '',
     order_unlocked_on_top: true,
     reactToFilters: true,
-    // include_unstructured_posts: true,
     'source[]': [],
     'tags[]': [],
     'form[]': [],
@@ -128,6 +127,7 @@ export class PostsService extends ResourceService<any> {
   public getPosts(url: string, filter?: GeoJsonFilter): Observable<PostApiResponse> {
     // const tmpParams = { ...this.postsFilters.value, has_location: 'all', ...filter };
     const tmpParams = { ...filter, ...this.postsFilters.value, has_location: 'all' };
+    tmpParams.include_unstructured_posts = tmpParams['form[]'].includes(0);
     return super.get(url, this.postParamsMapper(tmpParams)).pipe(
       map((response) => {
         response.results.map((post: PostResult) => {
@@ -248,7 +248,7 @@ export class PostsService extends ResourceService<any> {
         enable_group_by_source: true,
         has_location: isMapView ? 'mapped' : 'all',
         include_unmapped: true,
-        // include_unstructured_posts: true,
+        // include_unstructured_posts: false,
       },
     );
   }

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -30,7 +30,7 @@ export class PostsService extends ResourceService<any> {
     'form[]': [],
     'status[]': [],
   };
-  private postsFilters = new BehaviorSubject<any>(this.defaultPostsFilters);
+  private postsFilters = new BehaviorSubject<GeoJsonFilter>(this.defaultPostsFilters);
   public postsFilters$ = this.postsFilters.asObservable();
   private totalPosts = new Subject<number>();
   public totalPosts$ = this.totalPosts.asObservable();
@@ -113,58 +113,6 @@ export class PostsService extends ResourceService<any> {
     return super.delete(id);
   }
 
-  getGeojson(filter?: GeoJsonFilter): Observable<GeoJsonPostsResponse> {
-    const tmpParams = { ...this.postsFilters.value, has_location: 'mapped', ...filter };
-    delete tmpParams.order;
-    delete tmpParams.orderby;
-    return super.get('geojson', this.postParamsMapper(tmpParams)).pipe(
-      tap((res) => {
-        this.totalGeoPosts.next(res.meta.total);
-      }),
-    );
-  }
-
-  public getPosts(url: string, filter?: GeoJsonFilter): Observable<PostApiResponse> {
-    // const tmpParams = { ...this.postsFilters.value, has_location: 'all', ...filter };
-    const tmpParams = { ...filter, ...this.postsFilters.value, has_location: 'all' };
-
-    return super.get(url, this.postParamsMapper(tmpParams)).pipe(
-      map((response) => {
-        response.results.map((post: PostResult) => {
-          post.source =
-            post.source === 'sms'
-              ? 'SMS'
-              : post.source
-              ? post.source.charAt(0).toUpperCase() + post.source.slice(1)
-              : 'Web';
-        });
-
-        return response;
-      }),
-      tap((response) => {
-        this.totalPosts.next(response.meta.total);
-      }),
-    );
-  }
-
-  public getMyPosts(url: string, filter?: GeoJsonFilter): Observable<PostApiResponse> {
-    const tmpParams = { has_location: 'all', user: 'me', ...filter };
-    return super.get(url, this.postParamsMapper(tmpParams)).pipe(
-      map((response) => {
-        response.results.map((post: PostResult) => {
-          post.source =
-            post.source === 'sms'
-              ? 'SMS'
-              : post.source
-              ? post.source.charAt(0).toUpperCase() + post.source.slice(1)
-              : 'Web';
-        });
-
-        return response;
-      }),
-    );
-  }
-
   public searchPosts(url: string, query?: string, params?: any): Observable<PostApiResponse> {
     return super.get(url, { has_location: 'all', q: query, ...params }).pipe(
       tap((response) => {
@@ -173,92 +121,154 @@ export class PostsService extends ResourceService<any> {
     );
   }
 
-  private postParamsMapper(params: any) {
-    if (params.date?.start) {
-      params.date_after = params.date.start;
-      if (params.date.end) {
-        params.date_before = params.date.end;
-      }
-      delete params.date;
-    } else {
-      delete params.date;
-    }
+  getGeojson(filter?: GeoJsonFilter): Observable<GeoJsonPostsResponse> {
+    return super.get('geojson', this.postParamsMapper({ ...this.postsFilters.value }, filter)).pipe(
+      tap((res) => {
+        this.totalGeoPosts.next(res.meta.total);
+      }),
+    );
+  }
 
-    if (params.center_point?.location?.lat) {
-      params.within_km = params.center_point.distance;
-      params.center_point = `${params.center_point.location.lat},${params.center_point.location.lng}`;
-    } else if (!params.center_point?.length) {
-      delete params.center_point;
-    }
+  public getPosts(url: string, filter?: GeoJsonFilter): Observable<PostApiResponse> {
+    return super
+      .get(url, this.postParamsMapper({ ...this.postsFilters.value, has_location: 'all' }, filter))
+      .pipe(
+        map((response) => {
+          response.results.map((post: PostResult) => {
+            post.source =
+              post.source === 'sms'
+                ? 'SMS'
+                : post.source
+                ? post.source.charAt(0).toUpperCase() + post.source.slice(1)
+                : 'Web';
+          });
 
-    if (!params.set) {
-      delete params.set;
-    }
+          return response;
+        }),
+        tap((response) => {
+          this.totalPosts.next(response.meta.total);
+        }),
+      );
+  }
 
-    if (params.form && params.form.length === 0) {
-      params.form.push('none');
-    }
+  public getMyPosts(url: string, filter?: GeoJsonFilter): Observable<PostApiResponse> {
+    return super.get(url, this.postParamsMapper({ has_location: 'all', user: 'me' }, filter)).pipe(
+      map((response) => {
+        response.results.map((post: PostResult) => {
+          post.source =
+            post.source === 'sms'
+              ? 'SMS'
+              : post.source
+              ? post.source.charAt(0).toUpperCase() + post.source.slice(1)
+              : 'Web';
+        });
 
-    if (params.form?.length) {
-      params['form[]'] = params.form;
-      delete params.form;
-    }
-
-    if (params['form[]']?.length === 0) {
-      delete params['form[]'];
-      // params['form[]'].push('none');
-    }
-
-    if (params['source[]']?.length === 0) {
-      delete params['source[]'];
-    }
-
-    if (params.status?.length) {
-      params['status[]'] = params.status;
-    }
-    if (params.source?.length) {
-      params['source[]'] = params.source;
-    }
-
-    if (params.tags?.length) {
-      params['tags[]'] = params.tags;
-    }
-
-    if (params.currentView === 'map') {
-      params.has_location = 'mapped';
-      params.include_unstructured_posts = false;
-      params['form[]'] = params['form[]'].filter((formId: any) => formId !== 0);
-    } else if (params.currentView === 'feed') {
-      delete params.has_location;
-      delete params.within_km;
-      params.include_unmapped = true;
-      if (params['form[]'].includes(0)) {
-        params.include_unstructured_posts = true;
-      } else {
-        params.include_unstructured_posts = false;
-      }
-    }
-
-    delete params.currentView;
-    delete params.source;
-    delete params.tags;
-    delete params.status;
-    delete params.form;
-
-    return params;
+        return response;
+      }),
+    );
   }
 
   public getPostStatistics(queryParams?: any): Observable<PostStatsResponse> {
-    const filters = this.postParamsMapper(this.postsFilters.value);
+    const params = { ...queryParams, group_by: 'form', enable_group_by_source: true };
+    const filters = this.postParamsMapper(params, this.postsFilters.value);
 
-    return super.get(
-      'stats',
-      queryParams ?? {
-        ...filters,
-        group_by: 'form',
-        enable_group_by_source: true,
-      },
-    );
+    return super.get('stats', filters);
+  }
+
+  private postParamsMapper(params: any, filter?: GeoJsonFilter) {
+    // Combine new parameters with existing filter
+    const postParams: any = { ...filter, ...params };
+    postParams.currentView = filter?.currentView;
+
+    // Allocate start and end dates, and remove originals
+    if (postParams.date?.start) {
+      postParams.date_after = postParams.date.start;
+      if (postParams.date.end) {
+        postParams.date_before = postParams.date.end;
+      }
+      delete postParams.date;
+    } else {
+      delete postParams.date;
+    }
+
+    // Re-allocate location information
+    if (postParams.center_point?.location?.lat) {
+      postParams.within_km = postParams.center_point.distance;
+      postParams.center_point = `${postParams.center_point.location.lat},${postParams.center_point.location.lng}`;
+    } else if (!postParams.center_point?.length) {
+      delete postParams.center_point;
+    }
+
+    // Override existing filter arrays with param arrays if they exist.
+    // (Dereference the form array so we can remove 0 later)
+    if (postParams.form?.length) {
+      postParams['form[]'] = [...postParams.form];
+    } else {
+      postParams['form[]'] = [...postParams['form[]']];
+    }
+
+    if (postParams.status?.length) {
+      postParams['status[]'] = postParams.status;
+    }
+    if (postParams.source?.length) {
+      postParams['source[]'] = postParams.source;
+    }
+    if (postParams.tags?.length) {
+      postParams['tags[]'] = postParams.tags;
+    }
+
+    // Clean up new params based on which view is currently active
+    if (postParams.currentView === 'map') {
+      postParams.has_location = 'mapped';
+      postParams.include_unstructured_posts = false;
+      delete postParams.order;
+      delete postParams.orderby;
+    } else if (postParams.currentView === 'feed') {
+      postParams.include_unmapped = true;
+      if (postParams['form[]'].includes(0)) {
+        postParams.include_unstructured_posts = true;
+      } else {
+        postParams.include_unstructured_posts = false;
+      }
+      delete postParams.has_location;
+      delete postParams.within_km;
+      delete postParams.place;
+    }
+
+    // Clean up whatevers left, removing empty arrays and values
+    postParams['form[]'] = postParams['form[]'].filter((formId: any) => formId !== 0);
+    if (postParams['form[]']?.length === 0) {
+      delete postParams['form[]'];
+    }
+
+    if (postParams['source[]']?.length === 0) {
+      delete postParams['source[]'];
+    }
+
+    if (postParams['status[]']?.length === 0) {
+      delete postParams['status[]'];
+    }
+
+    if (postParams['tags[]']?.length === 0) {
+      delete postParams['tags[]'];
+    }
+    if (postParams.set?.length === 0) {
+      delete postParams.set;
+    }
+    if (postParams.query?.length === 0) {
+      delete postParams.query;
+    }
+    if (postParams.place?.length === 0) {
+      delete postParams.place;
+    }
+
+    delete postParams.currentView;
+    delete postParams.source;
+    delete postParams.tags;
+    delete postParams.status;
+    delete postParams.form;
+
+    return postParams;
   }
 
   public lockPost(id: string | number) {
@@ -272,8 +282,9 @@ export class PostsService extends ResourceService<any> {
   public applyFilters(filters: any, updated = true): void {
     const newFilters: any = {};
     for (const key in filters) {
-      if (filters[key] !== undefined || this.postsFilters.value[key]) {
-        newFilters[key] = filters[key] !== undefined ? filters[key] : this.postsFilters.value[key];
+      const postsFilterValue = this.postsFilters.value[key as keyof typeof this.postsFilters.value];
+      if (filters[key] !== undefined || postsFilterValue) {
+        newFilters[key] = filters[key] !== undefined ? filters[key] : postsFilterValue;
       }
     }
     if (updated) {

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -126,7 +126,8 @@ export class PostsService extends ResourceService<any> {
   }
 
   public getPosts(url: string, filter?: GeoJsonFilter): Observable<PostApiResponse> {
-    const tmpParams = { ...this.postsFilters.value, has_location: 'all', ...filter };
+    // const tmpParams = { ...this.postsFilters.value, has_location: 'all', ...filter };
+    const tmpParams = { ...filter, ...this.postsFilters.value, has_location: 'all' };
     return super.get(url, this.postParamsMapper(tmpParams)).pipe(
       map((response) => {
         response.results.map((post: PostResult) => {
@@ -263,8 +264,8 @@ export class PostsService extends ResourceService<any> {
   public applyFilters(filters: any, updated = true): void {
     const newFilters: any = {};
     for (const key in filters) {
-      if (filters[key] || this.postsFilters.value[key]) {
-        newFilters[key] = filters[key] || this.postsFilters.value[key];
+      if (filters[key] !== undefined || this.postsFilters.value[key]) {
+        newFilters[key] = filters[key] !== undefined ? filters[key] : this.postsFilters.value[key];
       }
     }
     if (updated) {

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -229,7 +229,7 @@ export class PostsService extends ResourceService<any> {
 
     // Clean up whatevers left, removing empty arrays and values
     postParams['form[]'] = postParams['form[]'].filter((formId: any) => formId !== 0);
-    if (postParams['form[]']?.length === 0) {
+    if (postParams['form[]']?.length === 0 || postParams['form[]'][0] === 'none') {
       delete postParams['form[]'];
     }
 

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -25,7 +25,7 @@ export class PostsService extends ResourceService<any> {
     set: '',
     order_unlocked_on_top: true,
     reactToFilters: true,
-    include_unstructured_posts: true,
+    // include_unstructured_posts: true,
     'source[]': [],
     'tags[]': [],
     'form[]': [],
@@ -248,7 +248,7 @@ export class PostsService extends ResourceService<any> {
         enable_group_by_source: true,
         has_location: isMapView ? 'mapped' : 'all',
         include_unmapped: true,
-        include_unstructured_posts: true,
+        // include_unstructured_posts: true,
       },
     );
   }

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -122,7 +122,7 @@ export class PostsService extends ResourceService<any> {
   }
 
   getGeojson(filter?: GeoJsonFilter): Observable<GeoJsonPostsResponse> {
-    return super.get('geojson', this.postParamsMapper({ ...this.postsFilters.value }, filter)).pipe(
+    return super.get('geojson', this.postParamsMapper(filter, { ...this.postsFilters.value })).pipe(
       tap((res) => {
         this.totalGeoPosts.next(res.meta.total);
       }),
@@ -197,14 +197,6 @@ export class PostsService extends ResourceService<any> {
       postParams.center_point = `${postParams.center_point.location.lat},${postParams.center_point.location.lng}`;
     } else if (!postParams.center_point?.length) {
       delete postParams.center_point;
-    }
-
-    // Override existing filter arrays with param arrays if they exist.
-    // (Dereference the form array so we can remove 0 later)
-    if (postParams.form?.length) {
-      postParams['form[]'] = [...postParams.form];
-    } else {
-      postParams['form[]'] = [...postParams['form[]']];
     }
 
     if (postParams.status?.length) {


### PR DESCRIPTION
**Problem**:

The filters being sent in requests to our backend API are inconsistent and in some cases nonsensical. Also, they often contain too much information, resulting in slower queries. 

- map view might request unstructured posts (which dont have any geo data),  (field: _include_unstructured_posts_)
- data view might request geolocated posts. (fields: _has_location_, _within_km_, _include_unmapped_)
- forms might include 0 (which represents "unknown form" on the frontend but has no meaning in the backend)
- arrays in the request might be included in the request even if empty.
- selected forms may alter when changing views


**Tickets**:

https://linear.app/ushahidi/issue/USH-1193/inconsistent-behavior-of-unknown-form-checkbox-and-include
https://linear.app/ushahidi/issue/USH-1194/unintended-visibility-of-unknown-form-checkbox-in-map-view
https://linear.app/ushahidi/issue/USH-1195/inconsistent-include-unstructured-posts-parameter-value-upon


**Solution**:

This PR attempts to move all the filter logic into the service, meaning any logical changes to filters are happening just before the request is sent. With all the logic in one place, it also attempts to remove meaningless fields from the filters.


**Testing**:

As this PR alters everything to do with filters, all filter behaviour should be observed while testing. However, the requests sent to the backend should be the specific focus of testing, with the following conditions:

All Requests:
- No empty arrays.
- _include_unstructured_posts_ should be present in every request.

Map View
- _include_unstructured_posts_ should always be false.
- _has_location_ should always be 'mapped'.

Data View
- _include_unstructured_posts_ should be true if "unknown form" is selected, false otherwise.
- _has_location_, _place_ and _within_km_ shouldnt be in the request.

In addition, each view has 2 requests associated with it. The above conditions should apply to both requests.

Map View
/api/v5/posts/stats
/api/v5/posts/geojson

Data View
/api/v5/posts/stats
/api/v5/posts
