### PR TITLE
Ush 1220 - After initial load, the mobile app does not switch to a different tile layer on the map

### DIFF
--- a/apps/mobile-mzima-client/src/app/map/components/map-view/map-view.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/map-view/map-view.component.ts
@@ -90,17 +90,19 @@ export class MapViewComponent implements AfterViewInit {
               zoom: this.mapConfig.default_view!.zoom,
             };
           } else {
-            // So if we're changing an already created map, we need to manipulate the layers manually
-            this.map.eachLayer((layer) => {
-              if (layer instanceof TileLayer) this.map.removeLayer(layer);
-            });
-            this.mapConfig = mapConfig;
-            this.baseLayer = this.mapConfig.default_view!.baselayer;
-            const currentLayer = mapHelper.getMapLayer(this.baseLayer, this.isDarkMode);
-            this.offlineLayer = tileLayerOffline(currentLayer.url, currentLayer.layerOptions);
-            this.onlineLayer = tileLayer(currentLayer.url, currentLayer.layerOptions);
-            this.map.addLayer(this.offlineLayer);
-            this.map.addLayer(this.onlineLayer);
+            // So if the baseLayer has changed and its an already created map, we need to manipulate the layers manually
+            if (this.mapConfig.default_view!.baselayer !== mapConfig.default_view.baselayer) {
+              this.map.eachLayer((layer) => {
+                if (layer instanceof TileLayer) this.map.removeLayer(layer);
+              });
+              this.mapConfig = mapConfig;
+              this.baseLayer = this.mapConfig.default_view!.baselayer;
+              const currentLayer = mapHelper.getMapLayer(this.baseLayer, this.isDarkMode);
+              this.offlineLayer = tileLayerOffline(currentLayer.url, currentLayer.layerOptions);
+              this.onlineLayer = tileLayer(currentLayer.url, currentLayer.layerOptions);
+              this.map.addLayer(this.offlineLayer);
+              this.map.addLayer(this.onlineLayer);
+            }
           }
           this.markerClusterOptions.maxClusterRadius = this.mapConfig.cluster_radius;
         }

--- a/apps/mobile-mzima-client/src/app/map/components/map-view/map-view.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/map-view/map-view.component.ts
@@ -73,12 +73,28 @@ export class MapViewComponent implements AfterViewInit {
     this.sessionService.mapConfig$.subscribe({
       next: (mapConfig) => {
         if (mapConfig) {
+          console.log('LOGGY - In the Map Config Listener');
           this.mapConfig = mapConfig;
+          console.log('LOGGY - Map Config: ' + JSON.stringify(this.mapConfig));
+          console.log('LOGGY - BaseLayer: ' + this.baseLayer);
+          console.log('LOGGY - Online Layer: ' + this.onlineLayer);
+          console.log('LOGGY - Offline Layer: ' + this.offlineLayer);
+          if (this.baseLayer !== this.mapConfig.default_view!.baselayer) {
+            const currentLayer = mapHelper.getMapLayer(this.baseLayer, this.isDarkMode);
+            console.log('LOGGY - Current Layer: ' + JSON.stringify(currentLayer));
 
-          this.baseLayer = this.mapConfig.default_view!.baselayer;
-          const currentLayer = mapHelper.getMapLayer(this.baseLayer, this.isDarkMode);
-          this.offlineLayer = tileLayerOffline(currentLayer.url, currentLayer.layerOptions);
-          this.onlineLayer = tileLayer(currentLayer.url, currentLayer.layerOptions);
+            this.baseLayer = this.mapConfig.default_view!.baselayer;
+            const newLayer = mapHelper.getMapLayer(this.baseLayer, this.isDarkMode);
+            console.log('LOGGY - New Layer: ' + JSON.stringify(newLayer));
+
+            this.offlineLayer = tileLayerOffline(newLayer.url, newLayer.layerOptions);
+            this.onlineLayer = tileLayer(newLayer.url, newLayer.layerOptions);
+
+            this.map.eachLayer(function (layer) {
+              if (layer) console.log('LOGGY - Map Layers: ' + layer.getAttribution);
+              else console.log('LOGGY - Map Layers: null');
+            });
+          }
 
           this.leafletOptions = {
             minZoom: 4,
@@ -89,6 +105,7 @@ export class MapViewComponent implements AfterViewInit {
             center: [this.mapConfig.default_view!.lat, this.mapConfig.default_view!.lon],
             zoom: this.mapConfig.default_view!.zoom,
           };
+
           this.markerClusterOptions.maxClusterRadius = this.mapConfig.cluster_radius;
         }
       },


### PR DESCRIPTION
**Issue**:

After initially loading, the mobile app does not switch tile layers on the map even if a deployment is selected that would necessitate it.


**Solution**:

This PR alters the leaflet map handling code to allow for tile layers to change after the initial load.


**Testing**:

1. Open the mobile app
2. Note the tile layer
3. Select a different deployment with a different tile layer.
4. Note the changed tile layer