### PR TITLE
USH-1179 - Broken Privacy and T&C links on mobile signup

### DIFF
--- a/apps/mobile-mzima-client/src/app/auth/signup/signup.page.html
+++ b/apps/mobile-mzima-client/src/app/auth/signup/signup.page.html
@@ -44,9 +44,13 @@
         <div class="agreement">
           <app-checkbox formControlName="agreement">
             I agree to Ushahidi
-            <a (click)="openLink($event, 'Privacy Policy')">Privacy Policy</a>
+            <a (click)="openLink($event, 'https://www.ushahidi.com/privacy-policy')"
+              >Privacy Policy</a
+            >
             the <br />
-            <a (click)="openLink($event, 'Privacy Policy')">Terms and Conditions</a>.
+            <a (click)="openLink($event, 'https://www.ushahidi.com/terms-of-service')"
+              >Terms and Conditions</a
+            >.
           </app-checkbox>
         </div>
         <ion-text *ngIf="signupError?.length" class="form-error ion-text-center" color="danger">

--- a/apps/mobile-mzima-client/src/app/auth/signup/signup.page.ts
+++ b/apps/mobile-mzima-client/src/app/auth/signup/signup.page.ts
@@ -92,7 +92,7 @@ export class SignupPage {
   public openLink(event: Event, link: string): void {
     event.preventDefault();
     event.stopPropagation();
-    console.log('open: ', link);
+    window.open(link);
   }
 
   public chooseDeployment(): void {


### PR DESCRIPTION
**Issue**:

The Privacy and Terms and Condition links on the sign up page of the mobile app do not do anything.

**Solution**:

Make them both active links that open outside of our app in the browser.

**Testing**:

Links should open successfully and in a new browser.