### PR TITLE
Revert fix for USH-1247

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/collections/collections.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/collections/collections.component.ts
@@ -267,7 +267,7 @@ export class CollectionsComponent extends BaseComponent implements OnInit {
       collectionData['view_only'] = collectionData['view_only'] || {};
       collectionData['view_only']['only_me'] = true;
     } else if (visibleTo === 'everyone') {
-      collectionData.role = null;
+      collectionData.role = ['everyone'];
     } else {
       collectionData.role = collectionData.visible_to.options;
     }


### PR DESCRIPTION
Removing fix for https://linear.app/ushahidi/issue/USH-1247/creating-a-collection-with-visibility-of-everyone-shows-only-me-wh that needs another solution.

USH-1247 should now remain and https://linear.app/ushahidi/issue/USH-1272/collections-not-visible-for-non-logged-in-users should not be happening.