### PR TITLE
update login credentials

### DIFF
--- a/e2e-testing/cypress.env.json
+++ b/e2e-testing/cypress.env.json
@@ -1,9 +1,9 @@
 {
   "baseUrl": "http://localhost:4200/",
-  "ush_admin_email": "",
-  "ush_admin_pwd": "",
-  "ush_admin_name": "",
-  "ush_user_name": "",
-  "ush_user_email": "",
-  "ush_user_pwd": ""
+  "ush_admin_email": "automation_admin@ushahidi.com",
+  "ush_admin_pwd": "1234567",
+  "ush_admin_name": "Automation User Admin Role",
+  "ush_user_email": "automation_member@ushahidi.com",
+  "ush_user_pwd": "1234567",
+  "ush_user_name": "Automation User Member Role"
 }


### PR DESCRIPTION
This change from having the e2e tests as secrets to having them out in the open was necessitated by the fact that contributors would have the tests failing in (external) forks. This change will allow tests from any forks to run with the correct credentials.