### PR TITLE
Ush 1275 & some pagination issues 

### DIFF
--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -251,6 +251,10 @@ export class PostsService extends ResourceService<any> {
       delete postParams['tags[]'];
     }
 
+    if (postParams.set?.length === 0) {
+      delete postParams.set;
+    }
+
     if (postParams.query?.length === 0) {
       delete postParams.query;
     }

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -179,8 +179,10 @@ export class PostsService extends ResourceService<any> {
     // Combine new parameters with existing filter
     const postParams: any = { ...filter, ...params };
 
+    // Some parameters should always come from the filter (if they exist)
     postParams.page = filter?.page;
     postParams.currentView = filter?.currentView;
+    postParams.limit = filter?.limit;
 
     // Allocate start and end dates, and remove originals
     if (postParams.date?.start) {
@@ -229,9 +231,25 @@ export class PostsService extends ResourceService<any> {
       delete postParams.place;
     }
 
-    // Clean up whatevers left, removing empty arrays and values
+    // Remove the 'Unknown Form' form
     postParams['form[]'] = postParams['form[]'].filter((formId: any) => formId !== 0);
-    if (isStats) delete postParams['form[]'];
+
+    // Clean up whatevers left, removing empty arrays and values
+    if (postParams['form[]']?.length === 0 || isStats) {
+      delete postParams['form[]'];
+    }
+
+    if (postParams['source[]']?.length === 0) {
+      delete postParams['source[]'];
+    }
+
+    if (postParams['status[]']?.length === 0) {
+      delete postParams['status[]'];
+    }
+
+    if (postParams['tags[]']?.length === 0) {
+      delete postParams['tags[]'];
+    }
 
     if (postParams.query?.length === 0) {
       delete postParams.query;

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -170,14 +170,16 @@ export class PostsService extends ResourceService<any> {
 
   public getPostStatistics(queryParams?: any): Observable<PostStatsResponse> {
     const params = { ...queryParams, group_by: 'form', enable_group_by_source: true };
-    const filters = this.postParamsMapper(params, this.postsFilters.value);
+    const filters = this.postParamsMapper(params, this.postsFilters.value, true);
 
     return super.get('stats', filters);
   }
 
-  private postParamsMapper(params: any, filter?: GeoJsonFilter) {
+  private postParamsMapper(params: any, filter?: GeoJsonFilter, isStats: boolean = false) {
     // Combine new parameters with existing filter
     const postParams: any = { ...filter, ...params };
+
+    postParams.page = filter?.page;
     postParams.currentView = filter?.currentView;
 
     // Allocate start and end dates, and remove originals
@@ -229,24 +231,8 @@ export class PostsService extends ResourceService<any> {
 
     // Clean up whatevers left, removing empty arrays and values
     postParams['form[]'] = postParams['form[]'].filter((formId: any) => formId !== 0);
-    if (postParams['form[]']?.length === 0 || postParams['form[]'][0] === 'none') {
-      delete postParams['form[]'];
-    }
+    if (isStats) delete postParams['form[]'];
 
-    if (postParams['source[]']?.length === 0) {
-      delete postParams['source[]'];
-    }
-
-    if (postParams['status[]']?.length === 0) {
-      delete postParams['status[]'];
-    }
-
-    if (postParams['tags[]']?.length === 0) {
-      delete postParams['tags[]'];
-    }
-    if (postParams.set?.length === 0) {
-      delete postParams.set;
-    }
     if (postParams.query?.length === 0) {
       delete postParams.query;
     }


### PR DESCRIPTION
**Problem**: 

When a user accesses the survey filter and leaves all options unselected (no specific forms chosen), the filter incorrectly returns all available survey forms.
The current behavior can be confusing for users who expect the filter to act as a refinement tool.

**Expected behavior**:

If a user leaves all filter options unselected, the platform should display nothing - or unstructured posts in case "unknown form" is selected-

**Steps to Reproduce**:

1. Open data view page of https://mzima-dev.staging.ush.zone/
2. Locate the survey filter options and click clear button (Leave all filter options unselected)
3. Check the results that shown

**Ticket**:

https://linear.app/ushahidi/issue/USH-1275/incorrect-filtering-all-survey-forms-returned-when-no-survey-option
<br/>
<br/>
also in this PR....
<br/>
<br/>
**Problem**:

Pagination does not work under certain conditions (Data View, in both modes but not after clearing filter)

**Expected behavior**: 

Pagination works like it should.

**Steps to Reproduce**:

1. Open data view page of https://mzima-dev.staging.ush.zone/
2. Change the page at the bottom of the screen.
3. Check that the page changes correctly.