### PR TITLE
USH-1278 Yet more filters

### DIFF
--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -180,9 +180,9 @@ export class PostsService extends ResourceService<any> {
     const postParams: any = { ...filter, ...params };
 
     // Some parameters should always come from the filter (if they exist)
-    postParams.page = filter?.page;
-    postParams.currentView = filter?.currentView;
-    postParams.limit = filter?.limit;
+    postParams.page = filter?.page ?? postParams.page;
+    postParams.currentView = filter?.currentView ?? postParams.currentView;
+    postParams.limit = filter?.limit ?? postParams.limit;
 
     // Allocate start and end dates, and remove originals
     if (postParams.date?.start) {
@@ -231,13 +231,11 @@ export class PostsService extends ResourceService<any> {
       delete postParams.place;
     }
 
-    // Clean up whatevers left, removing empty arrays and values
+    // Remove 'unknown form' from the form list if it exists.
     postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
-    if (
-      postParams['form[]']?.length === 0 ||
-      postParams['form[]'] === undefined ||
-      isStats
-    ) {
+
+    // Clean up whatevers left, removing empty arrays and values
+    if (postParams['form[]']?.length === 0 || postParams['form[]'] === undefined || isStats) {
       delete postParams['form[]'];
     }
 


### PR DESCRIPTION
**Issue**:

Under certain circumstances the mobile app can generate incorrect filters which result in 500 errors in the backend.

**Solution**:

Added some sanity clauses in to prevent this from occurring. 

**Testing**:

In the mobile app:

1. Use deployment https://annatest1000.ushahidi.io/
2. Clear the filters
3. Refresh the map and you should see some results.