### PR TITLE
remove stand-alone tests that verify posts review before publishing

### DIFF
--- a/e2e-testing/cypress/e2e/13-survey-configurations/survey-configurations.cy.js
+++ b/e2e-testing/cypress/e2e/13-survey-configurations/survey-configurations.cy.js
@@ -10,10 +10,6 @@ describe("Automated Tests for Survey Configurations", () => {
     cy.visit(Cypress.env('baseUrl'));
   });
 
-  it.skip("Verify posts go into Published state as configured", () => {
-    surveyConfigurationFunctions.require_posts_reviewed_before_published()
-  });
-
   it("Verifies author information stays hidden", () => {
     surveyConfigurationFunctions.hide_author_information_and_verify()
   });

--- a/e2e-testing/cypress/functions/SurveyConfigurationFunctions.js
+++ b/e2e-testing/cypress/functions/SurveyConfigurationFunctions.js
@@ -75,7 +75,6 @@ class SurveyConfigurationFunctions {
   check_for_accurate_author_name() {
     cy.get(SurveyConfigurationLocators.clearBtn).click();
     cy.get(SurveyConfigurationLocators.surveyToVerify).click();
-    // cy.wait(3000);
     cy.get(SurveyConfigurationLocators.postPreview)
       .children(SurveyConfigurationLocators.postItem)
       .contains('New Post Title');
@@ -86,7 +85,6 @@ class SurveyConfigurationFunctions {
     cy.get(SurveyConfigurationLocators.clearBtn).click();
     cy.get('[data-qa="btn-data"]').click();
     cy.get(SurveyConfigurationLocators.surveyToVerify).click();
-    // cy.wait(3000);
     cy.get(SurveyConfigurationLocators.postPreview)
       .children(SurveyConfigurationLocators.postItem)
       .contains('New Post Title');

--- a/e2e-testing/cypress/functions/SurveyConfigurationFunctions.js
+++ b/e2e-testing/cypress/functions/SurveyConfigurationFunctions.js
@@ -39,10 +39,6 @@ class SurveyConfigurationFunctions {
     cy.get('#mat-tab-label-6-1').click({ force: true });
   }
 
-  verify_button_toggled() {
-    cy.get('#mat-slide-toggle-20-input').should('not.be.checked');
-  }
-
   click_add_post_btn() {
     cy.get(SurveyConfigurationLocators.addPostBtn).click();
   }
@@ -76,19 +72,6 @@ class SurveyConfigurationFunctions {
     cy.get(SurveyConfigurationLocators.successBtn).click();
   }
 
-  check_for_added_post_being_published() {
-    cy.get(SurveyConfigurationLocators.clearBtn).click();
-    cy.get(SurveyConfigurationLocators.surveySelectionList)
-      .children(SurveyConfigurationLocators.surveyToVerify)
-      .eq(0)
-      .click({ force: true });
-    cy.wait(3000);
-    cy.get(SurveyConfigurationLocators.postPreview)
-      .children(SurveyConfigurationLocators.postItem)
-      .contains('New Post Title');
-    cy.get(SurveyConfigurationLocators.postStatus).contains('Published');
-  }
-
   check_for_accurate_author_name() {
     cy.get(SurveyConfigurationLocators.clearBtn).click();
     cy.get(SurveyConfigurationLocators.surveyToVerify).click();
@@ -108,20 +91,6 @@ class SurveyConfigurationFunctions {
       .children(SurveyConfigurationLocators.postItem)
       .contains('New Post Title');
     cy.get('.post-info__username').contains('Anonymous').should('be.visible');
-  }
-
-  require_posts_reviewed_before_published() {
-    this.open_settings();
-    this.open_surveys();
-    this.open_survey_to_configure();
-    this.open_survey_configurations();
-    this.toggle_survey_review_required();
-    this.save_survey_configurations();
-    this.open_survey_to_configure();
-    this.reopen_survey_configure_tab();
-    this.verify_button_toggled();
-    this.add_post();
-    this.check_for_added_post_being_published();
   }
 
   hide_author_information_and_verify() {


### PR DESCRIPTION
@shakirandagire in this commit, I removed the stand-alone test that checked for the permission to review a post before it is published. I did this because this step or action is also carried out in the test that already exists for checking the hide author.
I figure since that action is already checked in another test, no need to have more code that repeats a test. Less code is good code. We may however bring it back should we realize the need to. 
LMK what you think.