### PR TITLE
USH-1280 Remove/Amend incorrect filter parameters for posts 

### DIFF
--- a/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/feed-view/feed-view.component.ts
@@ -113,7 +113,9 @@ export class FeedViewComponent extends MainViewComponent {
   private async getPosts(params: any, add = false): Promise<void> {
     this.isPostsLoading = true;
     try {
-      const response = await lastValueFrom(this.postsService.getPosts('', { ...params }));
+      const response = await lastValueFrom(
+        this.postsService.getPosts('', { currentView: 'feed', ...params }),
+      );
       await this.updateObjectsWithUploadInput(response);
 
       const currentPosts = await this.databaseService.get(STORAGE_KEYS.POSTS);

--- a/apps/mobile-mzima-client/src/app/map/components/map-view/map-view.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/map-view/map-view.component.ts
@@ -245,7 +245,7 @@ export class MapViewComponent implements AfterViewInit {
 
   public getPostsGeoJson() {
     this.postsService
-      .getGeojson({ limit: 100000, offset: 0, page: 1 })
+      .getGeojson({ limit: 500, offset: 0, page: 1, currentView: 'map' })
       .pipe(untilDestroyed(this))
       .subscribe({
         next: async (postsResponse) => {

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -267,6 +267,8 @@ export class PostsService extends ResourceService<any> {
     delete postParams.tags;
     delete postParams.status;
     delete postParams.form;
+    delete postParams.reactToFilter;
+    delete postParams.order_unlocked;
 
     for (const key in postParams) {
       if (postParams[key] === undefined) {


### PR DESCRIPTION
**Issue**:
Some API calls coming from the mobile app had incorrect parameters that were resulting in errors.

**Ticket**:
https://linear.app/ushahidi/issue/USH-1280/remove-unnecessary-parameters-when-call-postsgeojson-from-mobile

**Solution**:
The mobile app now communicates its state better to the shared service and erroneous parameters have been removed or corrected.

**Testing**:
The requests coming from the app should not have the following parameters:

1- order
2- orderby
3- order_unlocked 
4- reactToFilter

also, limit was 100000 but has been modified to 500 as it is in the web client.