### PR TITLE
Select all children when selecting a parent in Settings USH-887

### DIFF
--- a/apps/web-mzima-client/src/app/settings/categories/categories.component.html
+++ b/apps/web-mzima-client/src/app/settings/categories/categories.component.html
@@ -18,6 +18,7 @@
           [isCheckbox]="isShowActions"
           (toggle)="toggleChildren($event)"
           [displayChildren]="displayChildren(category.id)"
+          [selectedCategories]="selectedCategories"
         >
         </app-category-item>
 
@@ -36,6 +37,7 @@
                   | lowercase
               "
               [customClass]="'category-item__title--lvl2'"
+              [selectedCategories]="selectedCategories"
             >
             </app-category-item>
           </li>

--- a/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
+++ b/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
@@ -67,7 +67,7 @@ export class CategoriesComponent {
           this.getCategories();
           this.selectedCategories = [];
           this.notificationService.showError(
-            this.translate.instant('bulk_destroy_success_countless'),
+            this.translate.instant('notify.category.bulk_destroy_success_countless'),
           );
         },
       },

--- a/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
+++ b/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
@@ -35,7 +35,11 @@ export class CategoriesComponent {
   }
 
   public displayChildren(id: number) {
-    return this.openedParents.includes(id);
+    if (this.isShowActions) {
+      return true;
+    } else {
+      return this.openedParents.includes(id);
+    }
   }
 
   public toggleChildren(id: number) {

--- a/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
+++ b/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
@@ -86,5 +86,17 @@ export class CategoriesComponent {
     } else {
       this.selectedCategories = this.selectedCategories.filter((sC) => sC.id !== cat.id);
     }
+    if (cat.children.length) {
+      cat.children.forEach((child) => {
+        if (i < 0) {
+          const c = this.selectedCategories.findIndex((sC) => sC.id === child.id);
+          if (c < 0) {
+            this.selectedCategories.push(child);
+          }
+        } else {
+          this.selectedCategories = this.selectedCategories.filter((sC) => sC.id !== child.id);
+        }
+      });
+    }
   }
 }

--- a/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.html
+++ b/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.html
@@ -3,8 +3,10 @@
     <mat-checkbox
       *ngIf="isCheckbox"
       class="category-item__checkbox"
+      [checked]="isChecked(category.id)"
       (click)="$event.stopPropagation()"
       (change)="selectCategory(category)"
+      [disabled]="isDisabled(category)"
     ></mat-checkbox>
     <h4 [routerLink]="category.id.toString()" [ngClass]="customClass">
       {{ category.tag }}

--- a/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.html
+++ b/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.html
@@ -1,13 +1,15 @@
 <div class="category-item" [routerLink]="['/settings/categories', category.id]">
-  <mat-checkbox
-    *ngIf="isCheckbox"
-    class="category-item__checkbox"
-    (click)="$event.stopPropagation()"
-    (change)="selectCategory(category)"
-  ></mat-checkbox>
-  <h4 class="category-item__title" [routerLink]="category.id.toString()" [ngClass]="customClass">
-    {{ category.tag }}
-  </h4>
+  <div class="category-item__title">
+    <mat-checkbox
+      *ngIf="isCheckbox"
+      class="category-item__checkbox"
+      (click)="$event.stopPropagation()"
+      (change)="selectCategory(category)"
+    ></mat-checkbox>
+    <h4 [routerLink]="category.id.toString()" [ngClass]="customClass">
+      {{ category.tag }}
+    </h4>
+  </div>
   <mzima-client-button
     *ngIf="category.children?.length"
     class="category-item--expand"

--- a/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.scss
+++ b/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.scss
@@ -23,10 +23,14 @@
   }
 
   &__title {
-    margin-bottom: 0;
-    font-size: 14px;
-    line-height: 28px;
-    font-weight: 700;
+    display: flex;
+    justify-content: flex-start;
+    h4 {
+      margin-bottom: 0;
+      font-size: 14px;
+      line-height: 28px;
+      font-weight: 700;
+    }
 
     &--lvl2 {
       font-weight: 400;

--- a/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.ts
+++ b/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.ts
@@ -11,11 +11,21 @@ export class CategoryItemComponent {
   @Input() public customClass: string;
   @Input() public isCheckbox: boolean;
   @Input() public displayChildren: boolean;
+  @Input() public selectedCategories: CategoryInterface[] = [];
   @Output() public selected = new EventEmitter<CategoryInterface>();
   @Output() public toggle = new EventEmitter();
 
   selectCategory(cat: CategoryInterface) {
     this.selected.emit(cat);
+  }
+
+  isChecked(id: number) {
+    return this.selectedCategories.findIndex((sC) => sC.id === id) >= 0;
+  }
+
+  isDisabled(category: CategoryInterface) {
+    if (category.parent_id && this.isChecked(category.parent_id)) return true;
+    return false;
   }
 
   public toggleChildren(id: number) {

--- a/apps/web-mzima-client/src/styles/_forms.scss
+++ b/apps/web-mzima-client/src/styles/_forms.scss
@@ -3,7 +3,7 @@
 .mat-checkbox-checked:not(.mat-checkbox-disabled).mat-accent .mat-ripple-element,
 .mat-checkbox:active:not(.mat-checkbox-disabled).mat-accent .mat-ripple-element,
 .mat-checkbox-indeterminate.mat-accent .mat-checkbox-background,
-.mat-checkbox-checked.mat-accent .mat-checkbox-background {
+.mat-checkbox-checked:not(.mat-checkbox-disabled).mat-accent .mat-checkbox-background {
   background-color: var(--color-primary-60);
 }
 


### PR DESCRIPTION
This PR automatically selects/deselects and disables children when a parent is selected when activating Bulk-actions in Settings.


To test
- Login and go to settings
- Select categories and activate "Bullk actions"
- [x] All children should automatically be expanded 
- Select a parent
- [x] All its children should automatically be selected
- [x] All the checkboxes for the children should become disabled
- Deselect a parent
- [x] All its children should automatically be de-selected
- [x] All the checkboxes for the children should become enabled again

- [x] Children can be deleted without deleting the parent
- [x] Parents cannot be deleted without all its children
- [x] Categories without children can be deleted

Bonus-fix: Adjustment of label-placement when bulk-actions is activated