### PR TITLE
Map pin duplication bug & 

### DIFF
--- a/apps/web-mzima-client/src/app/core/helpers/search-form.ts
+++ b/apps/web-mzima-client/src/app/core/helpers/search-form.ts
@@ -18,6 +18,8 @@ export const statuses = [
   },
 ];
 
+export const loggedOutStatuses = [statuses[0]];
+
 export const sources = [
   {
     name: 'Web',
@@ -116,7 +118,7 @@ export const sortingOptions = [
 
 export const DEFAULT_FILTERS = {
   query: [''],
-  status: [['published', 'draft']],
+  status: [['published']],
   tags: [[]],
   source: [[]],
   form: [[]],

--- a/apps/web-mzima-client/src/app/core/helpers/search-form.ts
+++ b/apps/web-mzima-client/src/app/core/helpers/search-form.ts
@@ -118,7 +118,7 @@ export const sortingOptions = [
 
 export const DEFAULT_FILTERS = {
   query: [''],
-  status: [['published']],
+  status: [['published', 'draft']],
   tags: [[]],
   source: [[]],
   form: [[]],

--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -177,151 +177,152 @@ export class MapComponent extends MainViewComponent implements OnInit {
   }
 
   getPostsGeoJson() {
-    this.postsService
-      .getGeojson(this.params)
-      .pipe(untilDestroyed(this))
-      .subscribe({
-        next: (posts) => {
-          const oldGeoJson: any = posts.results.map((r) => {
-            return {
-              type: r.geojson?.type,
-              features:
-                r.geojson?.features.map((f) => {
-                  f.properties = {
-                    data_source_message_id: r.data_source_message_id,
-                    description: r.description,
-                    id: r.id,
-                    'marker-color': r['marker-color'],
-                    source: r.source,
-                    title: r.title,
-                  };
-                  return f;
-                }) ?? [],
-            };
-          });
-          const geoPosts = geoJSON(oldGeoJson, {
-            pointToLayer: mapHelper.pointToLayer,
-            onEachFeature: (feature, layer) => {
-              layer.on('mouseout', () => {
-                layer.unbindPopup();
-              });
-              layer.on('click', () => {
-                this.zone.run(() => {
-                  if (layer instanceof FeatureGroup) {
-                    layer = layer.getLayers()[0];
-                  }
+    if (this.mapLayers.length === 0) {
+      this.postsService
+        .getGeojson(this.params)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: (posts) => {
+            const oldGeoJson: any = posts.results.map((r) => {
+              return {
+                type: r.geojson?.type,
+                features:
+                  r.geojson?.features.map((f) => {
+                    f.properties = {
+                      data_source_message_id: r.data_source_message_id,
+                      description: r.description,
+                      id: r.id,
+                      'marker-color': r['marker-color'],
+                      source: r.source,
+                      title: r.title,
+                    };
+                    return f;
+                  }) ?? [],
+              };
+            });
+            const geoPosts = geoJSON(oldGeoJson, {
+              pointToLayer: mapHelper.pointToLayer,
+              onEachFeature: (feature, layer) => {
+                layer.on('mouseout', () => {
+                  layer.unbindPopup();
+                });
+                layer.on('click', () => {
+                  this.zone.run(() => {
+                    if (layer instanceof FeatureGroup) {
+                      layer = layer.getLayers()[0];
+                    }
 
-                  if (layer.getPopup()) {
-                    layer.openPopup();
-                  } else {
-                    const comp = this.view.createComponent(PostPreviewComponent);
-                    this.postsService.getById(feature.properties.id).subscribe({
-                      next: (post) => {
-                        comp.setInput('post', post);
-                        comp.setInput('user', this.user);
+                    if (layer.getPopup()) {
+                      layer.openPopup();
+                    } else {
+                      const comp = this.view.createComponent(PostPreviewComponent);
+                      this.postsService.getById(feature.properties.id).subscribe({
+                        next: (post) => {
+                          comp.setInput('post', post);
+                          comp.setInput('user', this.user);
 
-                        this.postsService.getById(feature.properties.id).subscribe({
-                          next: (postV5) => {
-                            comp.instance.details$.subscribe({
-                              next: () => {
-                                this.showPostDetailsModal(
-                                  postV5,
-                                  post.color,
-                                  post.data_source_message_id,
-                                );
-                              },
-                            });
-
-                            comp.instance.edit.subscribe({
-                              next: () => {
-                                this.showPostDetailsModal(
-                                  postV5,
-                                  post.color,
-                                  post.data_source_message_id,
-                                  true,
-                                );
-                              },
-                            });
-
-                            comp.instance.deleted$.subscribe({
-                              next: () => {
-                                layer.togglePopup();
-                                this.loadData();
-                              },
-                            });
-
-                            const mediaField = postV5.post_content?.[0].fields.find(
-                              (field: any) => field.type === 'media',
-                            );
-                            if (mediaField && mediaField.value?.value) {
-                              this.mediaService.getById(mediaField.value.value).subscribe({
-                                next: (media) => {
-                                  comp.setInput('media', media.result);
+                          this.postsService.getById(feature.properties.id).subscribe({
+                            next: (postV5) => {
+                              comp.instance.details$.subscribe({
+                                next: () => {
+                                  this.showPostDetailsModal(
+                                    postV5,
+                                    post.color,
+                                    post.data_source_message_id,
+                                  );
                                 },
                               });
-                            }
-                            const popup: Content = comp.location.nativeElement;
 
-                            layer.bindPopup(popup, {
-                              maxWidth: 360,
-                              minWidth: 360,
-                              maxHeight: window.innerHeight - 176,
-                              closeButton: false,
-                              className: 'pl-popup',
-                            });
+                              comp.instance.edit.subscribe({
+                                next: () => {
+                                  this.showPostDetailsModal(
+                                    postV5,
+                                    post.color,
+                                    post.data_source_message_id,
+                                    true,
+                                  );
+                                },
+                              });
 
-                            layer.openPopup(); // This one is for fit popup in view
-                          },
-                        });
-                      },
-                    });
-                  }
+                              comp.instance.deleted$.subscribe({
+                                next: () => {
+                                  layer.togglePopup();
+                                  this.loadData();
+                                },
+                              });
+
+                              const mediaField = postV5.post_content?.[0].fields.find(
+                                (field: any) => field.type === 'media',
+                              );
+                              if (mediaField && mediaField.value?.value) {
+                                this.mediaService.getById(mediaField.value.value).subscribe({
+                                  next: (media) => {
+                                    comp.setInput('media', media.result);
+                                  },
+                                });
+                              }
+                              const popup: Content = comp.location.nativeElement;
+
+                              layer.bindPopup(popup, {
+                                maxWidth: 360,
+                                minWidth: 360,
+                                maxHeight: window.innerHeight - 176,
+                                closeButton: false,
+                                className: 'pl-popup',
+                              });
+
+                              layer.openPopup(); // This one is for fit popup in view
+                            },
+                          });
+                        },
+                      });
+                    }
+                  });
                 });
-              });
-            },
-          });
-
-          if (this.mapConfig.clustering) {
-            this.markerClusterData.addLayer(geoPosts);
-            this.mapLayers.push(this.markerClusterData);
-          } else {
-            this.mapLayers.push(geoPosts);
-          }
-
-          if (
-            this.params.limit &&
-            this.params.page &&
-            posts.meta.total > this.params.limit * this.params.page
-          ) {
-            this.progress = ((this.params.limit * this.params.page) / posts.count) * 100;
-
-            this.params.page++;
-            this.getPostsGeoJson();
-          } else {
-            this.progress = 100;
-            if (posts.results.length) {
-              this.mapFitToBounds = geoPosts.getBounds();
-
-              // Save bounds to localstorage to fix flicker when map is ready
-              const bounds = {
-                fit: this.mapFitToBounds,
-                zoom: this.map.getBoundsZoom(this.mapFitToBounds),
-                center: this.map.getCenter(),
-              };
-              localStorage.setItem('bounds', JSON.stringify(bounds));
+              },
+            });
+            if (this.mapConfig.clustering) {
+              this.markerClusterData.addLayer(geoPosts);
+              this.mapLayers.push(this.markerClusterData);
+            } else {
+              this.mapLayers.push(geoPosts);
             }
-          }
 
-          // if (posts.results.length && this.params.page <= this.params.limit) {
-          //   this.mapFitToBounds = geoPosts.getBounds();
-          // }
-        },
-        error: (err) => {
-          if (err.message.match(/Http failure response for/)) {
-            setTimeout(() => this.getPostsGeoJson(), 5000);
-          }
-        },
-      });
+            if (
+              this.params.limit &&
+              this.params.page &&
+              posts.meta.total > this.params.limit * this.params.page
+            ) {
+              this.progress = ((this.params.limit * this.params.page) / posts.count) * 100;
+
+              this.params.page++;
+              this.getPostsGeoJson();
+            } else {
+              this.progress = 100;
+              if (posts.results.length) {
+                this.mapFitToBounds = geoPosts.getBounds();
+
+                // Save bounds to localstorage to fix flicker when map is ready
+                const bounds = {
+                  fit: this.mapFitToBounds,
+                  zoom: this.map.getBoundsZoom(this.mapFitToBounds),
+                  center: this.map.getCenter(),
+                };
+                localStorage.setItem('bounds', JSON.stringify(bounds));
+              }
+            }
+
+            // if (posts.results.length && this.params.page <= this.params.limit) {
+            //   this.mapFitToBounds = geoPosts.getBounds();
+            // }
+          },
+          error: (err) => {
+            if (err.message.match(/Http failure response for/)) {
+              setTimeout(() => this.getPostsGeoJson(), 5000);
+            }
+          },
+        });
+    }
   }
 
   private showPostDetailsModal(

--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -285,16 +285,21 @@ export class MapComponent extends MainViewComponent implements OnInit {
               });
             },
           });
-          // Do we have any posts at all?
+
+          // Do we have any markers (layers) at all?
           const isFirstLayerEmpty = this.mapLayers.length === 0;
 
+          // Do the number of markers equal what we expect?
           const isLayerCountMismatch =
             pageNumber > 1 &&
             !isFirstLayerEmpty &&
             this.mapLayers[0].getLayers().length !== geoPosts.getLayers().length;
+
+          // Is the client in the middle of retrieving multiple pages of markers?
           const isThisInProgress =
             pageNumber > 1 && posts.meta.total !== geoPosts.getLayers().length;
 
+          // Has the filter changed from when we last saw it?
           const currentFilter: string | undefined = filter
             ? JSON.stringify(filter)
             : this.cachedFilter;

--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -291,7 +291,7 @@ export class MapComponent extends MainViewComponent implements OnInit {
 
           // Do the number of markers equal what we expect?
           const isLayerCountMismatch =
-            pageNumber > 1 &&
+            // pageNumber > 1 &&
             !isFirstLayerEmpty &&
             this.mapLayers[0].getLayers().length !== geoPosts.getLayers().length;
 
@@ -300,11 +300,16 @@ export class MapComponent extends MainViewComponent implements OnInit {
             pageNumber > 1 && posts.meta.total !== geoPosts.getLayers().length;
 
           // Has the filter changed from when we last saw it?
-          const currentFilter: string | undefined = filter
-            ? JSON.stringify(filter)
-            : this.cachedFilter;
-          const hasTheFilterChanged = this.cachedFilter && currentFilter !== this.cachedFilter;
-          this.cachedFilter = currentFilter;
+          let hasTheFilterChanged = false;
+          if (filter === undefined) {
+            hasTheFilterChanged = true;
+          } else {
+            const currentFilter = JSON.stringify(filter);
+            if (this.cachedFilter && currentFilter !== this.cachedFilter) {
+              hasTheFilterChanged = true;
+              this.cachedFilter = currentFilter;
+            }
+          }
 
           if (
             isFirstLayerEmpty ||

--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -289,9 +289,11 @@ export class MapComponent extends MainViewComponent implements OnInit {
           const isLayerCountMismatch =
             !isFirstLayerEmpty &&
             this.mapLayers[0].getLayers().length !== geoPosts.getLayers().length;
+          const isThisInProgress =
+            this.params.page !== 1 && posts.meta.total > geoPosts.getLayers().length;
 
-          if (isFirstLayerEmpty || isLayerCountMismatch) {
-            if (!isFirstLayerEmpty) {
+          if (isFirstLayerEmpty || isLayerCountMismatch || isThisInProgress) {
+            if (!isFirstLayerEmpty && !isThisInProgress) {
               this.resetMapLayers();
             }
 

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -250,20 +250,20 @@
       <ng-container *ngIf="!isDesktop">
         <app-filter-control
           class="search-form__filters-panel__item"
-          formControlName="form"
+          formControlName="form[]"
           [options]="surveyList"
           [fields]="['id', 'name']"
-          (clear)="clearFilter('form')"
+          (clear)="clearFilter('form[]')"
           [type]="filterType.Multiselect"
           [title]="'app.surveys' | translate"
-          [badge]="form.controls['form'].value?.length || null"
+          [badge]="form.controls['form[]'].value?.length || null"
         >
           <div class="clear-button" suffix>
             <mzima-client-button
               fill="clear"
               size="small"
               class="filter-group__head__button"
-              (buttonClick)="toggleSidebarFilters('form')"
+              (buttonClick)="toggleSidebarFilters('form[]')"
             >
               {{ (showAllButton('form') ? 'nav.select_all' : 'nav.clear') | translate }}
             </mzima-client-button>

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -685,9 +685,12 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
       fetchPostsWithoutFormId = index !== -1;
     }
 
+    const defaultStatus = ['published'];
+    if (this.isLoggedIn) defaultStatus.push('draft');
+
     this.form.patchValue({
       query: '',
-      status: ['published', 'draft'],
+      status: defaultStatus,
       tags: [],
       source: this.sources.map((s) => s.value),
       form: this.surveyList.map((s) => s.id),

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -55,7 +55,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
   public activeFilters: any;
   public savedSearches: Savedsearch[];
   public surveyList: SurveyItem[] = [];
-  public statuses = searchFormHelper.statuses;
+  public statuses = searchFormHelper.loggedOutStatuses;
   public sources = searchFormHelper.sources;
   public categoriesData: MultilevelSelectOption[];
   public activeSavedSearch?: Savedsearch;
@@ -180,8 +180,13 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
   loadData(): void {
     this.getSavedFilters();
     this.getPostsStatistic();
-    if (this.isLoggedIn && this.collectionInfo) {
-      this.getNotification(String(this.collectionInfo.id));
+    if (this.isLoggedIn) {
+      this.statuses = searchFormHelper.statuses;
+      if (this.collectionInfo) {
+        this.getNotification(String(this.collectionInfo.id));
+      }
+    } else {
+      this.statuses = searchFormHelper.loggedOutStatuses;
     }
   }
 

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "http://localhost:8080/",
+  "backend_url": "https://mzima-dev-api.staging.ush.zone/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "https://mzima-dev-api.staging.ush.zone/",
+  "backend_url": "http://localhost:8080/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "http://localhost:8080/",
+  "backend_url": "https://ceasefire-mena.api.ushahidi.io/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "https://ceasefire-mena.api.ushahidi.io/",
+  "backend_url": "http://localhost:8080/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -232,7 +232,7 @@ export class PostsService extends ResourceService<any> {
       delete postParams.within_km;
       delete postParams.place;
     }
-
+    postParams['form[]'] = [...new Set([...postParams['form[]'], ...postParams['form']])];
     // Remove 'unknown form' from the form list if it exists.
     postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
 

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -232,8 +232,12 @@ export class PostsService extends ResourceService<any> {
       delete postParams.within_km;
       delete postParams.place;
     }
-    postParams['form[]'] = [...new Set([...postParams['form[]'], ...postParams['form']])];
+
+    // Squash the form arrays together removing duplicates
+    // postParams['form[]'] = [...new Set([...postParams['form[]'], ...postParams['form']])];
+
     // Remove 'unknown form' from the form list if it exists.
+    // postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
     postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
 
     // Clean up whatevers left, removing empty arrays and values

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -180,7 +180,9 @@ export class PostsService extends ResourceService<any> {
     const postParams: any = { ...filter, ...params };
 
     // Some parameters should always come from the filter (if they exist)
-    postParams.page = filter?.page ?? postParams.page;
+    if (filter?.page && filter.page > postParams.page) {
+      postParams.page = filter.page;
+    }
     postParams.currentView = filter?.currentView ?? postParams.currentView;
     postParams.limit = filter?.limit ?? postParams.limit;
 

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -180,11 +180,10 @@ export class PostsService extends ResourceService<any> {
     const postParams: any = { ...filter, ...params };
 
     // Some parameters should always come from the filter (if they exist)
-    if (filter?.page && filter.page > postParams.page) {
-      postParams.page = filter.page;
-    }
+    postParams.page = filter?.page ?? postParams.page;
     postParams.currentView = filter?.currentView ?? postParams.currentView;
     postParams.limit = filter?.limit ?? postParams.limit;
+    postParams['status[]'] = filter?.['status[]'] ?? postParams['status[]'];
 
     // Allocate start and end dates, and remove originals
     if (postParams.date?.start) {
@@ -205,12 +204,12 @@ export class PostsService extends ResourceService<any> {
       delete postParams.center_point;
     }
 
-    if (postParams.status?.length) {
-      postParams['status[]'] = postParams.status;
-    }
-    if (postParams.source?.length) {
-      postParams['source[]'] = postParams.source;
-    }
+    // if (postParams.status?.length) {
+    //   postParams['status[]'] = postParams.status;
+    // }
+    // if (postParams.source?.length) {
+    //   postParams['source[]'] = postParams.source;
+    // }
     if (postParams.tags?.length) {
       postParams['tags[]'] = postParams.tags;
     }
@@ -233,30 +232,20 @@ export class PostsService extends ResourceService<any> {
       delete postParams.place;
     }
 
-    // Squash the form arrays together removing duplicates
-    // postParams['form[]'] = [...new Set([...postParams['form[]'], ...postParams['form']])];
-
     // Remove 'unknown form' from the form list if it exists.
-    // postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
     postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
 
-    // The API deals with an empty form array the same as 'all' forms, so we need to send it 'none.
-    if (postParams['form[]']?.length === 0 || postParams['form[]'] === undefined) {
-      postParams['form[]'] = ['none'];
-    }
-
-    // Stats calls should always return the details of every form, so send an empty array
-    if (isStats) {
+    // Clean up whatevers left, removing empty arrays and values
+    if (postParams['form[]']?.length === 0 || postParams['form[]'] === undefined || isStats) {
       delete postParams['form[]'];
     }
 
-    // Clean up whatevers left, removing empty arrays and values
     if (postParams['source[]']?.length === 0) {
-      delete postParams['source[]'];
+      postParams['source[]'] = ['none'];
     }
 
     if (postParams['status[]']?.length === 0) {
-      delete postParams['status[]'];
+      postParams['status[]'] = ['none'];
     }
 
     if (postParams['tags[]']?.length === 0) {
@@ -279,6 +268,8 @@ export class PostsService extends ResourceService<any> {
     delete postParams.tags;
     delete postParams.status;
     delete postParams.form;
+    delete postParams.reactToFilter;
+    delete postParams.order_unlocked;
 
     for (const key in postParams) {
       if (postParams[key] === undefined) {

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -220,6 +220,8 @@ export class PostsService extends ResourceService<any> {
       postParams.include_unstructured_posts = false;
       delete postParams.order;
       delete postParams.orderby;
+      // Remove 'unknown form' from the form list if it exists.
+      postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
     } else if (postParams.currentView === 'feed') {
       postParams.include_unmapped = true;
       if (postParams['form[]'].includes(0)) {
@@ -231,9 +233,6 @@ export class PostsService extends ResourceService<any> {
       delete postParams.within_km;
       delete postParams.place;
     }
-
-    // Remove 'unknown form' from the form list if it exists.
-    postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
 
     // Clean up whatevers left, removing empty arrays and values
     if (postParams['form[]']?.length === 0 || postParams['form[]'] === undefined) {

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -184,6 +184,12 @@ export class PostsService extends ResourceService<any> {
     postParams.currentView = filter?.currentView ?? postParams.currentView;
     postParams.limit = filter?.limit ?? postParams.limit;
     postParams['status[]'] = filter?.['status[]'] ?? postParams['status[]'];
+    if (postParams['form[]'] !== undefined && postParams['form[]'].length === 0)
+      postParams['form[]'] = postParams['form'];
+    if (postParams['status[]'] !== undefined && postParams['status[]'].length === 0)
+      postParams['status[]'] = postParams['status'];
+    if (postParams['source[]'] !== undefined && postParams['source[]'].length === 0)
+      postParams['source[]'] = postParams['source'];
 
     // Allocate start and end dates, and remove originals
     if (postParams.date?.start) {
@@ -204,12 +210,6 @@ export class PostsService extends ResourceService<any> {
       delete postParams.center_point;
     }
 
-    // if (postParams.status?.length) {
-    //   postParams['status[]'] = postParams.status;
-    // }
-    // if (postParams.source?.length) {
-    //   postParams['source[]'] = postParams.source;
-    // }
     if (postParams.tags?.length) {
       postParams['tags[]'] = postParams.tags;
     }
@@ -236,7 +236,11 @@ export class PostsService extends ResourceService<any> {
     postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
 
     // Clean up whatevers left, removing empty arrays and values
-    if (postParams['form[]']?.length === 0 || postParams['form[]'] === undefined || isStats) {
+    if (postParams['form[]']?.length === 0 || postParams['form[]'] === undefined) {
+      postParams['form[]'] = ['none'];
+    }
+
+    if (isStats) {
       delete postParams['form[]'];
     }
 

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -240,11 +240,17 @@ export class PostsService extends ResourceService<any> {
     // postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
     postParams['form[]'] = postParams['form[]']?.filter((formId: any) => formId !== 0);
 
-    // Clean up whatevers left, removing empty arrays and values
-    if (postParams['form[]']?.length === 0 || postParams['form[]'] === undefined || isStats) {
+    // The API deals with an empty form array the same as 'all' forms, so we need to send it 'none.
+    if (postParams['form[]']?.length === 0 || postParams['form[]'] === undefined) {
+      postParams['form[]'] = ['none'];
+    }
+
+    // Stats calls should always return the details of every form, so send an empty array
+    if (isStats) {
       delete postParams['form[]'];
     }
 
+    // Clean up whatevers left, removing empty arrays and values
     if (postParams['source[]']?.length === 0) {
       delete postParams['source[]'];
     }


### PR DESCRIPTION
**Issues**:

This PR deals with 2 issues:

1. The Map View makes multiple calls to the geojson endpoint, and uses the response twice resulting in duplicated pins(posts) on the map.
2. Under specific conditions if a user selects no surveys, they will instead get all the posts from every survey returned.

Unfortunately the fix for the second issue built upon the changes in the first, which is why the issues are in one PR.

**Tickets**:

https://linear.app/ushahidi/issue/USH-1315/duplication-of-pins-in-map-view
https://linear.app/ushahidi/issue/USH-1275/incorrect-filtering-all-survey-forms-returned-when-no-survey-option

**Solutions**:

1. This is due to the way we are handling state management in our frontend. While that definitely needs to be addressed, this PR attempts to understand the state of the client to understand if it should use the response of the API call or ignore it. There is some voodoo involved in handling pagination, so I apologise in advance to the reviewer.
2. This is a relatively simple fix, sending 'none' in the form array.

**Testing**:

1.
    a) Open the Map View
    b) Check clusters of pins to see if there are any duplicates.

2. 
    a) Open the Map View.
    b) Clear the form filter. The map should have no pins on it.
    c) Select a specific form and then deselect it. The map should again have no pins on it.