### PR TITLE
Making sure the data-qa directive does not overwrite input-fields in form-controls

### DIFF
--- a/apps/web-mzima-client/src/app/core/directives/data-qa-input.directive.ts
+++ b/apps/web-mzima-client/src/app/core/directives/data-qa-input.directive.ts
@@ -10,7 +10,7 @@ export class DataQaInputDirective {
     @Attribute('formControlName') name: string,
   ) {
     const el = elementRef.nativeElement;
-    if (!el.hasAttribute('data-qa')) {
+    if (!el.hasAttribute('data-qa') && name) {
       el.setAttribute('data-qa', name);
     }
   }


### PR DESCRIPTION
This pr adds a check to the data-qa directive so that it is not adding the attribute if the name is not present. In the case of reactive forms, the directive overwrote the set data-qa attribute by mistake.

To test: 
- Visit the application and log into your account.
- Click on the Add new post button.
- Click on a survey to add the post.
- On the post form inspect any input field like title and notice that the data-qa attribute has a name