### PR TITLE
[USH-1189] Submitting post with multiple image upload saves same image for all fields

### DIFF
--- a/apps/mobile-mzima-client/src/app/post/helpers/upload-file.ts
+++ b/apps/mobile-mzima-client/src/app/post/helpers/upload-file.ts
@@ -36,4 +36,28 @@ export class UploadFileHelper {
       throw new Error(`Error uploading file: ${error.message}`);
     }
   }
+
+  async uploadFileField(field: any, { data, name, caption, path }: any) {
+    console.log('uploadFile > photo', data, name, caption, path);
+    const fetchPhoto = await fetch(data);
+    const blob = await fetchPhoto.blob();
+    console.log('uploadFile > blob', blob);
+    const file = new File([blob], name);
+    console.log('uploadFile > file ', file);
+    try {
+      const uploadObservable = this.mediaService.uploadFile(file, caption);
+      const response: any = await lastValueFrom(uploadObservable);
+      console.log(response);
+      if (field.input === 'upload') {
+        field.value.value = response.result.id;
+      }
+
+      await Filesystem.deleteFile({
+        directory: Directory.Data,
+        path: path,
+      });
+    } catch (error: any) {
+      throw new Error(`Error uploading file: ${error.message}`);
+    }
+  }
 }

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
@@ -580,12 +580,27 @@ export class PostEditPage {
     const pendingPosts: any[] = await this.dataBaseService.get(STORAGE_KEYS.PENDING_POST_KEY);
     console.log('uploadPosts > pendingPosts', pendingPosts);
     for (let postData of pendingPosts) {
-      if (postData?.file?.upload) {
-        postData = await new UploadFileHelper(this.mediaService).uploadFile(
-          postData,
-          postData.file,
-        );
+      console.log(postData);
+
+      for (const task of postData.post_content) {
+        console.log(postData.post_content);
+        for (const field of task.fields) {
+          if (field.file?.upload) {
+            field.id = await new UploadFileHelper(this.mediaService).uploadFileField(
+              field,
+              field.file,
+            );
+          }
+          console.log(field);
+        }
       }
+
+      // if (postData?.file?.upload) {
+      //   postData = await new UploadFileHelper(this.mediaService).uploadFile(
+      //     postData,
+      //     postData.file,
+      //   );
+      // }
 
       if (postData?.file?.delete) {
         postData = await this.deleteFile(postData, postData.file);


### PR DESCRIPTION
Problem: When creating a post of a survey with uploading multiple images, the platform currently saves the same image selected for all image fields. Right now, if you choose unique image fields when the post is submitted they will saved as one the same image.

Expected Behavior: The platform should allow users to select and upload a unique image for each image field and when submitting the post must save them as they are submitted.