### PR TITLE
Ush 1338 - Inconsistent Behaviour with statuses and logged in users.

### DIFF
--- a/apps/web-mzima-client/src/app/core/helpers/search-form.ts
+++ b/apps/web-mzima-client/src/app/core/helpers/search-form.ts
@@ -147,6 +147,9 @@ export const DEFAULT_FILTERS_LOGGED_OUT = {
   status: [['published']],
 };
 
+export const DEFAULT_STATUSES_LOGGED_IN = ['published', 'draft'];
+export const DEFAULT_STATUSES_LOGGED_OUT = ['published'];
+
 export const compareForms = (form1: any, form2: any) => {
   return !_.isEqual(form1, form2);
 };


### PR DESCRIPTION
**Issue**:

When a user is not logged in, they should only be able to see (and select) "Published" posts in the filters.

When a user logs in, they should automatically get "Published" and "Draft" selected.

**Solution**:

Added some extra state management code (:cry:) to the filter code which will manipulate status in filters after login/logout events.

**Testing**:

1. Open site (logged out)
2. Check that "Published" is selected and there are no other options.
3. Log in
4. Check that "Published" and "Draft" are selected by default, and there is an additional "Archived" option.
5. Log out
6. Check that "Published" is the only status selected and there are no other options.