### PR TITLE
Ush 1340 - No map and no posts when site loaded with no local storage

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/main-view.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/main-view.component.ts
@@ -33,9 +33,10 @@ export abstract class MainViewComponent {
     protected sessionService: SessionService,
     protected breakpointService: BreakpointService,
   ) {
-    this.params = JSON.parse(
-      localStorage.getItem(this.sessionService.getLocalStorageNameMapper('filters'))!,
+    const cachedFilter = localStorage.getItem(
+      this.sessionService.getLocalStorageNameMapper('filters'),
     );
+    this.params = cachedFilter ? JSON.parse(cachedFilter) : this.params;
   }
 
   abstract loadData(): void;

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -335,7 +335,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
           return {
             id: category.id,
             name: category.tag,
-            children: category?.children.map((cat: CategoryInterface) => {
+            children: category?.children?.map((cat: CategoryInterface) => {
               return {
                 id: cat.id,
                 name: cat.tag,

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -184,7 +184,10 @@ export class PostsService extends ResourceService<any> {
     postParams.currentView = filter?.currentView ?? postParams.currentView;
     postParams.limit = filter?.limit ?? postParams.limit;
     postParams['status[]'] = filter?.['status[]'] ?? postParams['status[]'];
-    if (postParams['form[]'] === undefined && postParams['form'])
+    if (
+      postParams['form[]'] === undefined ||
+      (postParams['form[]'].length === 0 && postParams['form'])
+    )
       postParams['form[]'] = postParams['form'];
     if (postParams['status[]'] !== undefined && postParams['status[]'].length === 0)
       postParams['status[]'] = postParams['status'];


### PR DESCRIPTION
**Issues**:

On loading the site with no cache or local storage (eg. an Incognito Window), the map does not load and also no pins.

**Solution**:

1. The filter logic had assumed there would always be filters stored in local storage and would erase the defaults with null. Obviously this isnt always the case, so I have added a check to prevent this happening.
2. The logic that parses the filters immediately before sending to the API was assuming no forms selected for the above circumstance, even though there were forms selected.

**Testing**:

1. Open an incognito window
2. Open the site.
3. The map loads and also loads the pins for the selected deployment.
4. Refresh the window
5. The map again loads and also loads the pins for the selected deployment.