### PR TITLE
Small Fixes - Date and Init Errors

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/filter-control/filter-control.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/filter-control/filter-control.component.ts
@@ -126,7 +126,7 @@ export class FilterControlComponent implements ControlValueAccessor, OnChanges, 
       }
 
       const descendants = this.treeControl.dataNodes;
-      descendants.map((dataNode) => {
+      descendants?.map((dataNode) => {
         if (changes['selectedFields'].currentValue.indexOf(dataNode.id) > -1) {
           this.checklistSelection.select(dataNode);
         } else {

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -195,7 +195,10 @@ export class PostsService extends ResourceService<any> {
       postParams['source[]'] = postParams['source'];
 
     // Allocate start and end dates, and remove originals
-    if (postParams.date?.start) {
+    if (params.date_before || params.date_after) {
+      postParams.date_before = params.date_before;
+      postParams.date_after = params.date_after;
+    } else if (postParams.date?.start) {
       postParams.date_after = postParams.date.start;
       if (postParams.date.end) {
         postParams.date_before = postParams.date.end;


### PR DESCRIPTION
**Issues**:

There is some inconsistency with date handling on filters. Also, a few errors were present on first load of site.

**Solutions**:

- Altered the posts service handling of parameters specific to dates.
- Added some null safety during initialization. 

**Tickets**:

https://linear.app/ushahidi/issue/USH-1350/date-range-filter-does-not-return-posts-created-in-the-selected-range

**Testing**:

1. Go to the web application
2. Log in as an admin
3. Go to the Data View
4. Notice that there are posts created 15 days ago
5. Click on filters
6. Click on the Date range filter
7. Select date range for like 1 month ago for posts to search for.
8.  Check the results match those found in step 4.