### PR TITLE
[USH-1355] The 'Set new Photo' button sometimes requires multiple clicks for file input to function correctly

### DIFF
--- a/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.html
+++ b/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.html
@@ -5,10 +5,16 @@
   <ion-spinner name="circles" *ngIf="uploadingSpinner" class="spinner--positioned"></ion-spinner>
 </div>
 <ion-buttons class="controls">
-  <app-button class="controls-button" fill="clear" [disabled]="uploadingSpinner">
+  <app-button
+    class="controls-button"
+    fill="clear"
+    [disabled]="uploadingSpinner"
+    (buttonClick)="triggerFileInput()"
+  >
     <div class="controls-button__inner">
       <app-icon class="controls-button__icon" name="edit"></app-icon>
-      <label for="fileInput" class="file-input-label"> Set new photo </label>
+      <!-- <label for="fileInput" class="file-input-label"> Set new photo </label> -->
+      Set new photo
       <input type="file" id="fileInput" (change)="selectPhoto($event)" accept="image/*" hidden />
     </div>
   </app-button>

--- a/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
+++ b/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
@@ -55,6 +55,14 @@ export class ProfilePhotoComponent {
       });
   }
 
+  triggerFileInput(): void {
+    const fileInput = document.getElementById('fileInput') as HTMLInputElement;
+    //Ressetting the value of the file input
+    fileInput.value = '';
+    //trigerring the dialog to upload the file
+    fileInput.click();
+  }
+
   selectPhoto(event: Event): void {
     const input = event.target as HTMLInputElement;
     const file = input?.files?.[0];


### PR DESCRIPTION
**Ticket Description**
The profile photo sometimes requires the user to select the 'set new photo' button multiple times for the file input function to work correctly. Possible solution to this is resetting the file input after selection to ensure the input is ready for a new file

**Solution;**
Instead of relying on the previous label element to trigger the file input dialog, I created a separate function that programmatically triggers this. This function will then ensure the file input value is reset before the dialog is opened.