### PR TITLE
USH-1347 - Deleted Posts do not get removed in Map View

### DIFF
--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -250,8 +250,19 @@ export class MapComponent extends MainViewComponent implements OnInit {
 
                             comp.instance.deleted$.subscribe({
                               next: () => {
-                                layer.togglePopup();
+                                comp.destroy();
+                                this.map.closePopup();
+                                this.mapLayers.forEach((outerLayer: any) => {
+                                  outerLayer.eachLayer((innerLayer: any) => {
+                                    if (innerLayer.feature.properties.id === postV5.id)
+                                      outerLayer.removeLayer(innerLayer);
+                                  });
+                                });
                                 this.loadData();
+                                this.eventBusService.next({
+                                  type: EventType.RefreshSurveysCounters,
+                                  payload: true,
+                                });
                               },
                             });
 


### PR DESCRIPTION
**Issue:**

When a post is deleted on the map view, the pin on the map persists. For the map to be updated, the page has to be reloaded.

**Solution:**

When a post is deleted, it should be removed from the map without the need to reload the page for the map(or the posts on the map) to be updated.

**Testing**:

1. Log into site as admin
2. Goto map view
3. Click on a post and delete it
4. Post will be removed from the map and the totals updated.