### PR TITLE
USH-1365 - Posts do not appear in 'My Posts' page on the mobile app

### DIFF
--- a/apps/mobile-mzima-client/src/app/profile/posts/posts.page.ts
+++ b/apps/mobile-mzima-client/src/app/profile/posts/posts.page.ts
@@ -18,6 +18,7 @@ export class PostsPage {
     limit: 6,
     page: 1,
     q: '',
+    currentView: 'myposts',
   };
   public isPostsLoading = false;
   public posts: PostResult[] = [];

--- a/libs/sdk/src/lib/models/posts.interface.ts
+++ b/libs/sdk/src/lib/models/posts.interface.ts
@@ -22,7 +22,7 @@ export interface GeoJsonItem {
 
 export interface GeoJsonFilter {
   has_location?: string;
-  currentView?: 'map' | 'feed';
+  currentView?: 'map' | 'feed' | 'myposts';
   limit?: number;
   offset?: number;
   order?: 'desc' | 'asc';

--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -259,7 +259,7 @@ export class PostsService extends ResourceService<any> {
       postParams['form[]'] = ['none'];
     }
 
-    if (isStats) {
+    if (isStats || postParams.currentView === 'myposts') {
       delete postParams['form[]'];
     }
 


### PR DESCRIPTION
**Issue**:

In the mobile app, My Posts always returns 'Posts not found'.

**Solution**:

App was incorrectly filtering out all forms in the my posts query. It now passes 'myposts' as current view to the posts service which then creates the appropriate posts query.

**Testing**:

1. Open App
2. Select any deployment you created posts for
3. Login your credentials
4. Navigate to profile
5. Click on 'My Posts'
6. See correct listing of posts for the logged in user.