### PR TITLE
[USH-1183] App redirects to Profile page on deleting post from My Posts page

### DIFF
--- a/apps/mobile-mzima-client/src/app/profile/posts/posts.page.html
+++ b/apps/mobile-mzima-client/src/app/profile/posts/posts.page.html
@@ -40,7 +40,7 @@
     [permissions]="permissions"
     [isProfile]="true"
     (postChanged)="getMyPosts()"
-    (postDeleted)="back()"
+    (postDeleted)="handlePostDeleted($event)"
     footer
   >
   </app-post-controls>

--- a/apps/mobile-mzima-client/src/app/profile/posts/posts.page.ts
+++ b/apps/mobile-mzima-client/src/app/profile/posts/posts.page.ts
@@ -113,12 +113,17 @@ export class PostsPage {
     }
   }
 
-  public handlePostDeleted(data: any): void {
-    this.posts.splice(
-      this.posts.findIndex((p) => p.id === data.post.id),
-      1,
-    );
-    this.totalPosts--;
+  // public handlePostDeleted(data: any): void {
+  //   this.posts.splice(
+  //     this.posts.findIndex((p) => p.id === data.post.id),
+  //     1,
+  //   );
+  //   this.totalPosts--;
+  // }
+  public handlePostDeleted(deletedPostIds: any): void {
+    this.posts = this.posts.filter((post) => !deletedPostIds.includes(post.id));
+    this.totalPosts -= deletedPostIds.length;
+    this.isEditMode = false;
   }
 
   public showPost(id: string): void {

--- a/apps/mobile-mzima-client/src/app/shared/components/post-controls/post-controls.component.ts
+++ b/apps/mobile-mzima-client/src/app/shared/components/post-controls/post-controls.component.ts
@@ -167,6 +167,7 @@ export class PostControlsComponent {
 
     if (result.role === 'confirm') {
       const count = this.posts.length;
+      const postIds = this.posts.map((p) => p.id);
       forkJoin(this.posts.map((p) => this.postsService.delete(p.id))).subscribe({
         complete: () => {
           this.toastService.presentToast({
@@ -174,7 +175,7 @@ export class PostControlsComponent {
               this.posts.length > 1 ? count + ' posts' : 'Post'
             } has been successfully deleted`,
           });
-          this.postDeleted.emit();
+          this.postDeleted.emit(postIds);
         },
       });
     }


### PR DESCRIPTION
Fix for app redirection after bulk delete in 'My Posts'

**The Problem:**
Once you navigate to profile>my posts, select the posts you want to delete using 'bulk actions', and then delete them, the app redirects you to the profile page instead of staying on the same 'My Posts' screen.

**Expected behaviour.**
It should stay on that 'my posts' page and update automatically once bulk posts are deleted.

**Approach:**

- Emitting the event with the list of the deleted post IDs for the 'handlePostDeleted' method in `posts.page.ts` so as to remove them from the displayed list of posts
- I also added the function `this.isEditMode = false; ` to revert the bulk selection mode after deleting