### PR TITLE
USH-1397 Filters do not work correctly in mobile app

### DIFF
--- a/libs/sdk/src/lib/services/posts.service.ts
+++ b/libs/sdk/src/lib/services/posts.service.ts
@@ -183,16 +183,26 @@ export class PostsService extends ResourceService<any> {
     postParams.page = filter?.page ?? postParams.page;
     postParams.currentView = filter?.currentView ?? postParams.currentView;
     postParams.limit = filter?.limit ?? postParams.limit;
+
     postParams['status[]'] = filter?.['status[]'] ?? postParams['status[]'];
     if (
       postParams['form[]'] === undefined ||
       (postParams['form[]'].length === 0 && postParams['form'])
     )
       postParams['form[]'] = postParams['form'];
-    if (postParams['status[]'] !== undefined && postParams['status[]'].length === 0)
+    if (
+      postParams['status[]'] === undefined ||
+      (postParams['status[]'].length === 0 && postParams['status'])
+    )
       postParams['status[]'] = postParams['status'];
-    if (postParams['source[]'] !== undefined && postParams['source[]'].length === 0)
+    if (
+      postParams['source[]'] === undefined ||
+      (postParams['source[]'].length === 0 && postParams['source'])
+    )
       postParams['source[]'] = postParams['source'];
+    if (postParams.tags?.length) {
+      postParams['tags[]'] = postParams.tags;
+    }
 
     // Allocate start and end dates, and remove originals
     if (params.date_before || params.date_after) {
@@ -227,10 +237,6 @@ export class PostsService extends ResourceService<any> {
       postParams.center_point = `${postParams.center_point.location.lat},${postParams.center_point.location.lng}`;
     } else if (!postParams.center_point?.length) {
       delete postParams.center_point;
-    }
-
-    if (postParams.tags?.length) {
-      postParams['tags[]'] = postParams.tags;
     }
 
     // Clean up new params based on which view is currently active


### PR DESCRIPTION
**Issue**:

The posts being returned to the user do not reflect the values in the filters.

**Solution**:

This PR slightly modifies the logic in the posts service to manipulate the filter values before sending the request to the API.

**Testing**:

1. Click on filters to reveal filters page
2. Note the post count (top right)
3. Make a change to a filter option for instance, click on Status and select a different combination of status
4. Click Apply to effect changes
5. Note that the post count changes to reflect the new filtered dataset.
6. In data view, the posts returned match the filtered dataset.