### PR TITLE
[USH-1183] Fix for deleting individual posts in 'My Posts' page

### DIFF
--- a/apps/mobile-mzima-client/src/app/profile/posts/posts.page.html
+++ b/apps/mobile-mzima-client/src/app/profile/posts/posts.page.html
@@ -40,7 +40,7 @@
     [permissions]="permissions"
     [isProfile]="true"
     (postChanged)="getMyPosts()"
-    (postDeleted)="handlePostDeleted($event)"
+    (postDeleted)="handlePostsDeleted($event)"
     footer
   >
   </app-post-controls>

--- a/apps/mobile-mzima-client/src/app/profile/posts/posts.page.ts
+++ b/apps/mobile-mzima-client/src/app/profile/posts/posts.page.ts
@@ -113,14 +113,15 @@ export class PostsPage {
     }
   }
 
-  // public handlePostDeleted(data: any): void {
-  //   this.posts.splice(
-  //     this.posts.findIndex((p) => p.id === data.post.id),
-  //     1,
-  //   );
-  //   this.totalPosts--;
-  // }
-  public handlePostDeleted(deletedPostIds: any): void {
+  public handlePostDeleted(data: any): void {
+    this.posts.splice(
+      this.posts.findIndex((p) => p.id === data.post.id),
+      1,
+    );
+    this.totalPosts--;
+  }
+
+  public handlePostsDeleted(deletedPostIds: any): void {
     this.posts = this.posts.filter((post) => !deletedPostIds.includes(post.id));
     this.totalPosts -= deletedPostIds.length;
     this.isEditMode = false;

--- a/apps/mobile-mzima-client/src/app/shared/components/post-controls/post-controls.component.ts
+++ b/apps/mobile-mzima-client/src/app/shared/components/post-controls/post-controls.component.ts
@@ -172,8 +172,8 @@ export class PostControlsComponent {
         complete: () => {
           this.toastService.presentToast({
             message: `${
-              this.posts.length > 1 ? count + ' posts' : 'Post'
-            } has been successfully deleted`,
+              this.posts.length > 1 ? count + ' posts have' : 'Post has'
+            } been successfully deleted`,
           });
           this.postDeleted.emit(postIds);
         },


### PR DESCRIPTION
This PR addresses two fixes as per the comments in this ticket:
https://linear.app/ushahidi/issue/USH-1183/app-redirects-to-profile-page-on-deleting-post-from-my-posts-page

- In the 'my posts' page, delete one post using the post action button and observe what happens. The post says it is successfully deleted but still shows on the list. I have rectified that now to automatically update the list once deleted (it was a minor fix).
- Also there is a typo in the toast message. When deleting two posts for example, it says "2 posts has been successfully deleted" instead of "2 posts have been successfully deleted". This is also fixed.