### PR TITLE
[USH-1407] Disabled "Set Image" Button After Media Update Error pen_spark

### DIFF
--- a/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.html
+++ b/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.html
@@ -5,12 +5,7 @@
   <ion-spinner name="circles" *ngIf="uploadingSpinner" class="spinner--positioned"></ion-spinner>
 </div>
 <ion-buttons class="controls">
-  <app-button
-    class="controls-button"
-    fill="clear"
-    [disabled]="uploadingSpinner"
-    (buttonClick)="triggerFileInput()"
-  >
+  <app-button class="controls-button" fill="clear" (buttonClick)="triggerFileInput()">
     <div class="controls-button__inner">
       <app-icon class="controls-button__icon" name="edit"></app-icon>
       <!-- <label for="fileInput" class="file-input-label"> Set new photo </label> -->

--- a/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
+++ b/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
@@ -70,7 +70,7 @@ export class ProfilePhotoComponent {
       const validFileTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
       if (!validFileTypes.includes(file.type)) {
         this.alertService.presentAlert({
-          header: 'Invalid File Type',
+          header: 'Wrong type of file',
           message: 'Please select a valid image file',
         });
         return;

--- a/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
+++ b/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
@@ -175,7 +175,7 @@ export class ProfilePhotoComponent {
                   });
                 },
                 error: (error) => {
-                  console.error('Failed to update profile photo', error);
+                  console.error('Failed to update profile photo. Please try again', error);
                   this.uploadingInProgress = false;
                   this.uploadingSpinner = false;
                   this.uploadCompleted.emit();
@@ -212,7 +212,7 @@ export class ProfilePhotoComponent {
                   this.uploadingSpinner = false;
                   this.uploadCompleted.emit();
                   this.toastService.presentToast({
-                    message: 'Failed to add profile photo',
+                    message: 'Failed to add profile photo. Please try again',
                     duration: 3000,
                     position: 'bottom',
                   });

--- a/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
+++ b/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
@@ -67,7 +67,7 @@ export class ProfilePhotoComponent {
     const input = event.target as HTMLInputElement;
     const file = input?.files?.[0];
     if (file) {
-      const validFileTypes = ['image/jpeg', 'image.webp', 'image.jpg', 'image/png', 'image/gif'];
+      const validFileTypes = ['image/jpeg', 'image/webp', 'image/jpg', 'image/png', 'image/gif'];
       if (!validFileTypes.includes(file.type)) {
         this.alertService.presentAlert({
           header: 'Invalid File Type',

--- a/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
+++ b/apps/mobile-mzima-client/src/app/profile/information/components/profile-photo/profile-photo.component.ts
@@ -67,7 +67,7 @@ export class ProfilePhotoComponent {
     const input = event.target as HTMLInputElement;
     const file = input?.files?.[0];
     if (file) {
-      const validFileTypes = ['image/jpeg', 'image/webp', 'image/jpg', 'image/png', 'image/gif'];
+      const validFileTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
       if (!validFileTypes.includes(file.type)) {
         this.alertService.presentAlert({
           header: 'Invalid File Type',
@@ -112,6 +112,11 @@ export class ProfilePhotoComponent {
               this.uploadingInProgress = false;
               this.uploadingSpinner = false;
               this.uploadCompleted.emit();
+              this.toastService.presentToast({
+                message: 'Failed to upload image. Please try again',
+                duration: 3000,
+                position: 'bottom',
+              });
             },
           });
         });
@@ -163,12 +168,22 @@ export class ProfilePhotoComponent {
                   this.hasUploadedPhoto = true;
                   this.uploadingInProgress = false;
                   this.uploadCompleted.emit();
+                  this.toastService.presentToast({
+                    message: 'Profile photo updated successfully',
+                    duration: 3000,
+                    position: 'bottom',
+                  });
                 },
                 error: (error) => {
                   console.error('Failed to update profile photo', error);
                   this.uploadingInProgress = false;
                   this.uploadingSpinner = false;
                   this.uploadCompleted.emit();
+                  this.toastService.presentToast({
+                    message: 'Failed to add profile photo',
+                    duration: 3000,
+                    position: 'bottom',
+                  });
                 },
               });
             } else {
@@ -185,12 +200,22 @@ export class ProfilePhotoComponent {
                   this.hasUploadedPhoto = true;
                   this.uploadingInProgress = false;
                   this.uploadCompleted.emit();
+                  this.toastService.presentToast({
+                    message: 'Profile photo updated successfully',
+                    duration: 3000,
+                    position: 'bottom',
+                  });
                 },
                 (error) => {
                   console.error('Failed to add profile photo', error);
                   this.uploadingInProgress = false;
                   this.uploadingSpinner = false;
                   this.uploadCompleted.emit();
+                  this.toastService.presentToast({
+                    message: 'Failed to add profile photo',
+                    duration: 3000,
+                    position: 'bottom',
+                  });
                 },
               );
             }

--- a/apps/mobile-mzima-client/src/app/profile/information/information.page.ts
+++ b/apps/mobile-mzima-client/src/app/profile/information/information.page.ts
@@ -153,15 +153,16 @@ export class InformationPage {
   }
 
   public back(): void {
-    if (!this.isUploadInProgress) {
-      this.router.navigate(['profile']);
-    } else {
-      this.toastService.presentToast({
-        message: 'Profile photo is still uploading. Please wait...',
-        duration: 3000,
-      });
-      console.log('Upload in progress. Cannot navigate back.');
-    }
+    // if (!this.isUploadInProgress) {
+    //   this.router.navigate(['profile']);
+    // } else {
+    //   this.toastService.presentToast({
+    //     message: 'Profile photo is still uploading. Please wait...',
+    //     duration: 3000,
+    //   });
+    //   console.log('Upload in progress. Cannot navigate back.');
+    // }
+    this.router.navigate(['profile']);
   }
 
   private getRoles() {


### PR DESCRIPTION
(Still in Draft)
Problem: 

When an error occurs while updating the media associated with a post or profile, the "Set Image" button remains disabled and all page will be stoPped until uploading image is finished. This behavior can be confusing for users who might not understand why they cannot proceed after encountering an error.


Expected behavior:

The "Set Image" button should provide clear feedback based on the media update status

- [x] Successful Update: If the media update is successful
- [x] Update Error: Display a clear error message explaining the issue, consider enabling the button once the user has addressed the error (e.g., by selecting a different image file) 
- [x] * cancel and back button must keep working


Steps to Reproduce:

1- login with user

2- click on profile 

3- edit user profile

4-update the profile image with non-image file

5- check the results