### PR TITLE
[Accessibility]  Provided a descriptive alt text for the company info image

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/company-info/company-info.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/company-info/company-info.component.html
@@ -9,7 +9,7 @@
     <mat-panel-title class="company-info__header" [data-qa]="'panel-title'">
       <img
         [src]="logo"
-        [alt]="'Logo for ' + title + ' deployment'"
+        [alt]="title + ' deployment Logo'"
         class="company-info__logo"
         *ngIf="logo"
       />

--- a/apps/web-mzima-client/src/app/shared/components/company-info/company-info.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/company-info/company-info.component.html
@@ -7,7 +7,12 @@
 >
   <mat-expansion-panel-header>
     <mat-panel-title class="company-info__header" [data-qa]="'panel-title'">
-      <img [src]="logo" [alt]="title" class="company-info__logo" *ngIf="logo" />
+      <img
+        [src]="logo"
+        [alt]="'Logo for ' + title + ' deployment'"
+        class="company-info__logo"
+        *ngIf="logo"
+      />
       <span class="company-info__title">{{ title }}</span>
       <mat-icon svgIcon="arrow-down" class="company-info__header__arrow"></mat-icon>
     </mat-panel-title>


### PR DESCRIPTION
## Engineer's Checklist
- This PR addresses the issue of the redundant alt text for the Company-info Image. The current alt text is the same as the text "Company's info" displayed next to it, which is unnecessary and repetitive for users of screen readers or when the image is unavailable.

Fixes: https://github.com/ushahidi/platform/issues/4962

## Changes Made
- The `[alt]` attribute of the `<img>` element has been changed from **`[alt]="title"`** to **`[alt]="'Company logo'"`**. This ensures that the alt text provides additional information about the image that is not already available in the "Company info" text next to the image, improving the accessibility of the content for users who are unable to see the image.

**Concern:**    @Ifycode and @Angamanga  A question on the change: Is it better to call it the deployment's logo or image. Which do you think is the best for this case?



## How to test the changes
- This change has been tested manually by launching the local host, navigating to the company info section, and observing the alt text used for the image. The updated alt text accurately describes the image as the "Company logo" and no longer repeats the title text. 

- It has also been tested using screen reader to read out the purpose of the image

## Changes
![Screenshot from 2024-06-20 10-22-03](https://github.com/ushahidi/platform-client-mzima/assets/124133577/f766fcad-91c1-41ba-acb1-9387f62fbfba)
