### PR TITLE
[Accessibility]  Update Ushahidi logo alt text to provide more meaningful information

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/fragments/deployment-details/deployment-details.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/fragments/deployment-details/deployment-details.component.html
@@ -1,6 +1,6 @@
 <div class="menu__head">
   <span class="menu__logo">
-    <img src="../../../../assets/images/ushahidi-logo.svg" alt="ushahidi" />
+    <img src="../../../../assets/images/ushahidi-logo.svg" alt="Ushahidi Logo" />
   </span>
   <mzima-client-button
     *ngIf="!isDesktop"


### PR DESCRIPTION
## Description
This PR addresses the issue where the alt text for the Ushahidi logo is the same as the text "Ushahidi" displayed next to it. 

Providing redundant alt text can be unnecessary and repetitive for users of screen readers or when the image is unavailable.

Fixes: https://github.com/ushahidi/platform/issues/4960

## Changes
-  Updated the alt text for the Ushahidi logo to provide additional information about the image that is not already provided elsewhere on the page.

## Screenshots
Before:
![Screenshot from 2024-06-20 10-33-16](https://github.com/ushahidi/platform-client-mzima/assets/124133577/0b196b01-0c58-4827-98e0-121231d860ca)

After:
![Screenshot from 2024-06-20 10-49-38](https://github.com/ushahidi/platform-client-mzima/assets/124133577/9f15de9e-c375-449a-a09d-1f48199fb258)


## Testing
- Tested manually and using a screen reader to read out the purpose of the image and ensuring there is no redudancy