### PR TITLE
Displaying privacy policy and t&c properly

### DIFF
--- a/apps/mobile-mzima-client/src/app/privacy-policy/privacy-policy.page.html
+++ b/apps/mobile-mzima-client/src/app/privacy-policy/privacy-policy.page.html
@@ -1,3 +1,3 @@
 <app-main-layout (back)="back()" title="Privacy Policy">
-  {{"app.privacy_policy_text" | translate}}
+  <span [innerHTML]="'app.privacy_policy_text' | translate"></span>
 </app-main-layout>

--- a/apps/mobile-mzima-client/src/app/terms-and-conditions/terms-and-conditions.page.html
+++ b/apps/mobile-mzima-client/src/app/terms-and-conditions/terms-and-conditions.page.html
@@ -1,3 +1,3 @@
 <app-main-layout (back)="back()" title="Terms of Service">
-  {{"app.toc_text" | translate}}
+  <span [innerHTML]="'app.toc_text' | translate"></span>
 </app-main-layout>


### PR DESCRIPTION
This PR uses innerHTML to display the Privacy Policy and T&C that contain html-tags.
To test:
- Go to profile-page
- Click on "Terms and Conditions" and "Privacy policy"
- [x] They should be displayed without html-tags.