### PR TITLE
Hiding language-switcher for now

### DIFF
--- a/apps/mobile-mzima-client/src/app/core/constants/profile-menu.ts
+++ b/apps/mobile-mzima-client/src/app/core/constants/profile-menu.ts
@@ -67,11 +67,12 @@ export const profileMenu: ProfileMenuItem[] = [
 ];
 
 export const profileInformationMenu: ProfileMenuItem[] = [
-  {
-    label: 'Language',
-    icon: 'language',
-    route: '/profile/select-language',
-  },
+  // Uncomment when we have more translations available
+  //{
+  //   label: 'Language',
+  //   icon: 'language',
+  //   route: '/profile/select-language',
+  // },
   {
     label: 'Help and Support',
     description: 'Documentation, Report a bug',


### PR DESCRIPTION
This PR hides (comments out ) the language-switcher until we have more translations available.

To test: 
In mobile,
- Go to the Profile menu
- [ ] No language-switcher should be visible