### PR TITLE
Ush 1401 - Status filters on Android show Draft and Archived statuses for logged out user.

### DIFF
--- a/apps/mobile-mzima-client/src/app/core/helpers/search-form.ts
+++ b/apps/mobile-mzima-client/src/app/core/helpers/search-form.ts
@@ -18,6 +18,8 @@ export const statuses = [
   },
 ];
 
+export const loggedOutStatuses = [statuses[0]];
+
 export const sources = [
   {
     name: 'Web',
@@ -136,6 +138,11 @@ export const DEFAULT_FILTERS: Filter = {
     },
     distance: 1,
   },
+};
+
+export const DEFAULT_FILTERS_LOGGED_OUT = {
+  ...DEFAULT_FILTERS,
+  status: ['published'],
 };
 
 export const compareForms = (form1: any, form2: any) => {

--- a/apps/mobile-mzima-client/src/app/map/components/filter/filter.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/filter/filter.component.ts
@@ -178,10 +178,20 @@ export class FilterComponent implements ControlValueAccessor, OnInit {
   }
 
   private getStatuses(): void {
-    this.options = searchFormHelper.statuses.map((status) => ({
-      value: status.value,
-      label: status.name,
-    }));
+    const isLoggedIn = this.sessionService.isLogged();
+
+    if (isLoggedIn) {
+      this.options = searchFormHelper.statuses.map((status) => ({
+        value: status.value,
+        label: status.name,
+      }));
+    } else {
+      this.options = searchFormHelper.loggedOutStatuses.map((status) => ({
+        value: status.value,
+        label: status.name,
+      }));
+    }
+
     this.isOptionsLoading = false;
   }
 

--- a/apps/mobile-mzima-client/src/app/map/components/filters-form/filters-form.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/filters-form/filters-form.component.ts
@@ -154,6 +154,19 @@ export class FiltersFormComponent implements OnChanges, OnDestroy {
         this.isTotalLoading = false;
       },
     });
+
+    this.session.currentUserData$.pipe(takeUntil(this.destroy$)).subscribe({
+      next: (currentUser) => {
+        const statusFilter = this.filters.find((filter) => filter.name === 'status');
+        if (statusFilter) {
+          const isLoggedIn = !!currentUser.userId;
+          statusFilter.value = this.getFilterDefaultValue('status', isLoggedIn);
+          statusFilter.selectedCount = statusFilter.value.length;
+          statusFilter.selected = String(statusFilter.selectedCount);
+          this.updateFilterSelectedText(statusFilter);
+        }
+      },
+    });
   }
 
   ngOnDestroy(): void {
@@ -357,7 +370,7 @@ export class FiltersFormComponent implements OnChanges, OnDestroy {
     formFilter.selected = String(formFilter?.value?.length ?? 'none');
   }
 
-  private getFilterDefaultValue(filterName: string): any {
+  private getFilterDefaultValue(filterName: string, isLoggedIn: boolean = false): any {
     if (filterName === 'source') {
       return searchFormHelper.sources.map((s) => s.value);
     }
@@ -369,6 +382,13 @@ export class FiltersFormComponent implements OnChanges, OnDestroy {
     if (filterName === 'saved-filters') {
       return this.activatedSavedFilterId;
     }
+
+    if (filterName === 'status') {
+      return isLoggedIn
+        ? searchFormHelper.DEFAULT_FILTERS[filterName]
+        : searchFormHelper.DEFAULT_FILTERS_LOGGED_OUT[filterName];
+    }
+
     return searchFormHelper.DEFAULT_FILTERS[filterName] ?? null;
   }
 
@@ -573,6 +593,11 @@ export class FiltersFormComponent implements OnChanges, OnDestroy {
         } else {
           filter.selectedCount = 'All locations';
         }
+        break;
+
+      case 'status':
+        filter.selectedCount = filter.value.length;
+        filter.selected = filter.selectedCount ? String(filter.selectedCount) : 'none';
         break;
 
       case 'saved-filters':

--- a/apps/mobile-mzima-client/src/app/map/components/filters-form/filters-form.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/filters-form/filters-form.component.ts
@@ -161,7 +161,9 @@ export class FiltersFormComponent implements OnChanges, OnDestroy {
         if (statusFilter) {
           const isLoggedIn = !!currentUser.userId;
           statusFilter.value = this.getFilterDefaultValue('status', isLoggedIn);
-          statusFilter.selectedCount = statusFilter.value.length;
+          statusFilter.selectedCount = isLoggedIn
+            ? searchFormHelper.statuses.length
+            : searchFormHelper.loggedOutStatuses.length;
           statusFilter.selected = String(statusFilter.selectedCount);
           this.updateFilterSelectedText(statusFilter);
         }
@@ -596,8 +598,7 @@ export class FiltersFormComponent implements OnChanges, OnDestroy {
         break;
 
       case 'status':
-        filter.selectedCount = filter.value.length;
-        filter.selected = filter.selectedCount ? String(filter.selectedCount) : 'none';
+        filter.selected = filter.value.length ? String(filter.value.length) : 'none';
         break;
 
       case 'saved-filters':


### PR DESCRIPTION
**Issue:**

When a user is logged out on the mobile app, they can still select Draft and Archived in their filters.

**Solution:**

Subscribed to a change in the current user on the session service, and manipulate the available values depending on logged in status.

**Testing:**

1. Go to mobile application
2. Log out 
3. Click on Filters icon.
4. Click on Status, notice only Published is available.
5. Log into app
6. Click on Status, notice that the Published, Draft and Archived are shown.