### PR TITLE
Add other-option when configuring a survey

### DIFF
--- a/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.html
+++ b/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.html
@@ -87,7 +87,9 @@
         </div>
         <div
           *ngIf="
-            selectedFieldType?.options?.length > 0 && !selectedFieldType?.options?.includes('Other')
+            selectedFieldType?.options?.length > 0 &&
+            !selectedFieldType?.options?.includes('Other') &&
+            selectedFieldType.input !== 'select'
           "
         >
           <mzima-client-button
@@ -98,6 +100,7 @@
             (buttonClick)="addOther()"
           >
             {{ 'form.field_add_other' | translate }}
+            {{ selectedFieldType.inpu }}
           </mzima-client-button>
           <p class="form-row__options__add-other">
             {{ 'form.field_add_other_desc' | translate }}

--- a/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.html
+++ b/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.html
@@ -100,7 +100,6 @@
             (buttonClick)="addOther()"
           >
             {{ 'form.field_add_other' | translate }}
-            {{ selectedFieldType.inpu }}
           </mzima-client-button>
           <p class="form-row__options__add-other">
             {{ 'form.field_add_other_desc' | translate }}

--- a/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.html
+++ b/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.html
@@ -40,7 +40,7 @@
       </div>
 
       <!-- Has options -->
-      <div class="form-row" *ngIf="hasOptions">
+      <div class="form-row form-row__options" *ngIf="hasOptions">
         <div class="form-head-panel">
           <mat-label class="form-label" [data-qa]="'field-options'"
             >{{ 'form.field_options' | translate }}
@@ -48,7 +48,9 @@
 
           <mzima-client-button
             fill="outline"
-            color="secondary"
+            color="gray"
+            size="medium"
+            class="form-row__options__button"
             (buttonClick)="addOption()"
             [data-qa]="'btn-add-option'"
           >
@@ -65,8 +67,8 @@
               (input)="onChange(i)"
               placeholder="{{ 'form.field_name_placeholder' | translate }}"
               [data-qa]="'option-' + i"
+              [disabled]="option.value === 'Other'"
             />
-
             <mzima-client-button
               matSuffix
               fill="clear"
@@ -74,7 +76,6 @@
               [iconOnly]="true"
               class="button-flat button-beta"
               (buttonClick)="removeOption(i)"
-              *ngIf="selectedFieldType.options.length > 1"
               [data-qa]="'btn-remove-option-' + i"
             >
               <mat-icon icon svgIcon="delete"></mat-icon>
@@ -83,6 +84,24 @@
           <mat-error role="alert" *ngIf="option.error">
             {{ option.error | translate }}
           </mat-error>
+        </div>
+        <div
+          *ngIf="
+            selectedFieldType?.options?.length > 0 && !selectedFieldType?.options?.includes('Other')
+          "
+        >
+          <mzima-client-button
+            fill="outline"
+            color="gray"
+            size="medium"
+            class="form-row__options__button"
+            (buttonClick)="addOther()"
+          >
+            {{ 'form.field_add_other' | translate }}
+          </mzima-client-button>
+          <p class="form-row__options__add-other">
+            {{ 'form.field_add_other_desc' | translate }}
+          </p>
         </div>
       </div>
 

--- a/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.scss
+++ b/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.scss
@@ -81,6 +81,35 @@ quill-editor {
   &__item {
     margin-bottom: 8px;
   }
+  &__options {
+    background-color: var(--color-neutral-10);
+    padding: 16px;
+    border-radius: 4px;
+    .form-label {
+      font-weight: 700;
+    }
+    &__button {
+      &::ng-deep {
+        .mzima-button {
+          background-color: transparent;
+          font-size: 14px;
+          min-height: 22px;
+          width: unset;
+        }
+      }
+    }
+    .form-row__item {
+      background-color: var(--color-light);
+      .mat-input-element {
+        padding: 12px;
+      }
+    }
+    &__add-other {
+      padding: 6px;
+      font-size: 12px;
+      color: var(--color-neutral-70);
+    }
+  }
 
   .form-head-panel {
     margin-bottom: 8px;

--- a/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.ts
@@ -259,6 +259,13 @@ export class CreateFieldModalComponent implements OnInit {
     this.fieldOptions.push({ value: '', error: '' });
   }
 
+  public addOther() {
+    if (!this.selectedFieldType.options) this.selectedFieldType.options = [];
+    if (this.selectedFieldType.options.includes('Other')) return;
+    this.selectedFieldType.options.push('Other');
+    this.fieldOptions.push({ value: 'Other', error: '' });
+  }
+
   private setTempSelectedFieldType() {
     this.fieldOptions = this.selectedFieldType.options.map((opt: string) => ({
       value: opt,

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -245,6 +245,8 @@
     "edit_post_type": "Edit Survey: {{form}}",
     "edit_post_types": "Edit Surveys",
     "field_add_option": "Add",
+    "field_add_other": "Add other",
+    "field_add_other_desc": "Allows entering a custom option that is not listed among the provided choices.",
     "field_default": "Field Default",
     "field_key": "Field Key",
     "field_type": "Field Type",


### PR DESCRIPTION
Adding configuration-option for "Other" in the survey-fields radio, checkboxes and select.
To test:

In survey-settings, add a new field for Radio and Checkboxes, in all those fields, test the following:
1. Before any options are added, the button "Add other" is not visisble
2. Click on "Add +"
- [x]  An empty input-field appears where the user can add an option and there is also a button "Add other"
3. Click on "Add other"
- [x] A disabled input-field appears with the value "Other"
- [x] The "Add other" button is not visible
4. Click on the trash-can for the other-option
- [x] The option is removed
- [x] The "Add other" button is visible again


-