### PR TITLE
USH-815 - Inform the user they can't login because the app is offline.

### DIFF
--- a/apps/mobile-mzima-client/src/app/auth/auth.page.ts
+++ b/apps/mobile-mzima-client/src/app/auth/auth.page.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 import { Platform } from '@ionic/angular';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { SessionService } from '@services';
+import { TranslateService } from '@ngx-translate/core';
+import { SessionService, NetworkService, ToastService } from '@services';
 
 @UntilDestroy()
 @Component({
@@ -13,7 +14,13 @@ export class AuthPage {
   public isKeyboardOpen = false;
   public isSignupActive = false;
 
-  constructor(private platform: Platform, private sessionService: SessionService) {
+  constructor(
+    private platform: Platform,
+    private sessionService: SessionService,
+    private networkService: NetworkService,
+    private toastService: ToastService,
+    private translateService: TranslateService,
+  ) {
     this.platform.keyboardDidShow.subscribe(() => {
       this.isKeyboardOpen = true;
     });
@@ -30,6 +37,13 @@ export class AuthPage {
         this.isSignupActive = !config.private && !config.disable_registration;
       },
     });
+  }
+
+  ionViewDidEnter() {
+    if (!this.networkService.getCurrentNetworkStatus())
+      this.toastService.presentToast({
+        message: this.translateService.instant('app.info.auth_not_online'),
+      });
   }
 
   ionViewDidLeave() {

--- a/apps/mobile-mzima-client/src/app/core/services/network.service.ts
+++ b/apps/mobile-mzima-client/src/app/core/services/network.service.ts
@@ -8,7 +8,7 @@ const CONNECTION_TYPES = ['wifi', 'cellular'];
   providedIn: 'root',
 })
 export class NetworkService {
-  private readonly _networkStatus = new BehaviorSubject<boolean>(false);
+  private readonly _networkStatus = new BehaviorSubject<boolean>(true);
   readonly networkStatus$ = this._networkStatus.asObservable();
 
   constructor() {

--- a/apps/mobile-mzima-client/src/app/map/map.page.ts
+++ b/apps/mobile-mzima-client/src/app/map/map.page.ts
@@ -47,18 +47,8 @@ export class MapPage extends MainViewComponent implements OnDestroy {
       },
     });
 
-    this.initFilterListener();
-    this.initNetworkListener();
-
     this.getUserData();
 
-    this.getPost$.pipe(debounceTime(500), takeUntil(this.destroy$)).subscribe({
-      next: () => {
-        this.feed.updatePosts();
-        this.map.reInitParams();
-        this.map.getPostsGeoJson();
-      },
-    });
     if (this.user) this.intercomService.registerUser(this.user);
   }
 
@@ -73,6 +63,18 @@ export class MapPage extends MainViewComponent implements OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  ngAfterViewInit(): void {
+    this.initNetworkListener();
+    this.initFilterListener();
+    this.getPost$.pipe(debounceTime(500), takeUntil(this.destroy$)).subscribe({
+      next: () => {
+        this.feed.updatePosts();
+        this.map.reInitParams();
+        this.map.getPostsGeoJson();
+      },
+    });
   }
 
   private initNetworkListener() {

--- a/apps/mobile-mzima-client/src/assets/locales/en.json
+++ b/apps/mobile-mzima-client/src/assets/locales/en.json
@@ -71,6 +71,7 @@
       "skip": "Skip",
       "loading":"Getting data...",
       "info" : {
+        "auth_not_online" : "Sorry. You're offline…please check your internet connection",
         "post_submitted_online" : "Thank you for submitting your report. The post is being reviewed by our team and soon will appear on the platform.",
         "post_submitted_offline" : "Thank you for your report. A message will be sent when the connection is restored.",
         "posts_not_uploaded" : "<b>{num_posts} Posts not Uploaded!</b><br/>The posts were not uploaded due to bad internet connection or you were offline. They will be automatically uploaded as soon as you connect to the internet",


### PR DESCRIPTION
**Issue:**

If the user tries to login to the mobile app, but there is no network connectivity, there is nothing to inform the user that this is why they cant login.

**Ticket:**

https://linear.app/ushahidi/issue/USH-815/mobile-offline-lets-tell-the-user-they-cant-login-because-they-are

**Solution:**

Added a toast message that pops up when entering the login screen informing the user of their lack of connectivity. Also rearranged a few networking pieces that were causing silent exceptions.

**Testing:**

1. Open app
2. Select deployment
3. Enter flight mode (or disconnect somehow)
4. Go to login
5. Notice toast message