### PR TITLE
Added an aria label for the search icon

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -14,7 +14,7 @@
       [iconOnly]="true"
       fill="clear"
       color="secondary"
-      aria-label="Search icon"
+      [ariaLabel]="'Search icon' | translate"
     >
       <mat-icon icon svgIcon="search-small"></mat-icon>
     </mzima-client-button>
@@ -33,7 +33,6 @@
       color="secondary"
       *ngIf="searchQuery?.length"
       (buttonClick)="clearPostsResults()"
-      [ariaLabel]="'Search icon' | translate"
     >
       <mat-icon icon svgIcon="close"></mat-icon>
     </mzima-client-button>

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -33,6 +33,7 @@
       color="secondary"
       *ngIf="searchQuery?.length"
       (buttonClick)="clearPostsResults()"
+      [ariaLabel]="'Search icon' | translate"
     >
       <mat-icon icon svgIcon="close"></mat-icon>
     </mzima-client-button>

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.html
@@ -9,7 +9,13 @@
   }"
 >
   <mat-form-field appearance="outline" class="search-form__control">
-    <mzima-client-button matPrefix [iconOnly]="true" fill="clear" color="secondary">
+    <mzima-client-button
+      matPrefix
+      [iconOnly]="true"
+      fill="clear"
+      color="secondary"
+      aria-label="Search icon"
+    >
       <mat-icon icon svgIcon="search-small"></mat-icon>
     </mzima-client-button>
     <input


### PR DESCRIPTION
## Engineers Checklist
### Description
This PR addresses the issue where the search icon does not have an aria label. 

Fixes: https://github.com/ushahidi/platform/issues/4977

### Changes
-  Updated the aria label for the icon to provide clear information about the icon and even its purpose

### Screenshots
Before:
<img width="1178" alt="Screenshot 2024-07-15 at 12 59 20" src="https://github.com/user-attachments/assets/f6e2109e-01d6-4797-8ace-3b32c8f8d64d">


After:


### Testing
- Tested manually on dev tool and using a screen reader to read out the purpose of the icon 