### PR TITLE
1403 other options for web

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
@@ -304,21 +304,24 @@
                     <mat-radio-button
                       class="other__input__radio"
                       [value]="option"
-                      click="otherRadio.focus()"
+                      (change)="otherRadio.focus()"
                     >
                     </mat-radio-button>
                     <mat-form-field appearance="outline">
                       <input
                         class="other__input"
-                        #otherRadio
+                        #otherRadio="matInput"
                         matInput
                         type="text"
                         placeholder="Add other"
                         [formControlName]="'other' + field.key"
-                        (focus)="selectOther(field)"
+                        (focus)="selectOther($event, field)"
                       />
                     </mat-form-field>
                   </div>
+                  <mat-error *ngIf="option === 'Other' && hasEmptyOther(field.key)">
+                    Input cannot be empty
+                  </mat-error>
                 </div>
               </mat-radio-group>
             </ng-container>
@@ -352,20 +355,24 @@
                       [value]="option"
                       class="list-option other__input__checkbox"
                       checkboxPosition="before"
-                      (selected)="otherCheckbox.focus()"
+                      (click)="otherCheckbox.focus()"
                     >
                     </mat-list-option>
-                    <mat-form-field appearance="outline">
+                    <mat-form-field appearance="outline" #formfield>
                       <input
+                        (keydown)="$event.stopPropagation()"
                         class="other__input"
                         matInput
-                        #otherCheckbox
+                        #otherCheckbox="matInput"
                         type="text"
                         [formControlName]="'other' + field.key"
-                        (focus)="selectOther(field)"
+                        (focus)="selectOther($event, field)"
                       />
                     </mat-form-field>
                   </div>
+                  <mat-error *ngIf="option === 'Other' && hasEmptyOther(field.key)">
+                    Input cannot be empty
+                  </mat-error>
                 </ng-container>
               </mat-selection-list>
             </ng-container>

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
@@ -301,10 +301,22 @@
                     {{ option }}
                   </mat-radio-button>
                   <div class="other" *ngIf="option === 'Other'">
-                    <mat-radio-button class="other__input__radio" [value]="option">
+                    <mat-radio-button
+                      class="other__input__radio"
+                      [value]="option"
+                      click="otherRadio.focus()"
+                    >
                     </mat-radio-button>
                     <mat-form-field appearance="outline">
-                      <input class="other__input" matInput placeholder="Add other" />
+                      <input
+                        class="other__input"
+                        #otherRadio
+                        matInput
+                        type="text"
+                        placeholder="Add other"
+                        [formControlName]="'other' + field.key"
+                        (focus)="selectOther(field)"
+                      />
                     </mat-form-field>
                   </div>
                 </div>
@@ -340,10 +352,18 @@
                       [value]="option"
                       class="list-option other__input__checkbox"
                       checkboxPosition="before"
+                      (selected)="otherCheckbox.focus()"
                     >
                     </mat-list-option>
                     <mat-form-field appearance="outline">
-                      <input class="other__input" matInput />
+                      <input
+                        class="other__input"
+                        matInput
+                        #otherCheckbox
+                        type="text"
+                        [formControlName]="'other' + field.key"
+                        (focus)="selectOther(field)"
+                      />
                     </mat-form-field>
                   </div>
                 </ng-container>

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.html
@@ -296,9 +296,17 @@
                         '-' +
                         option.replaceAll(' ', '-') | lowercase
                     "
+                    *ngIf="option !== 'Other'"
                   >
                     {{ option }}
                   </mat-radio-button>
+                  <div class="other" *ngIf="option === 'Other'">
+                    <mat-radio-button class="other__input__radio" [value]="option">
+                    </mat-radio-button>
+                    <mat-form-field appearance="outline">
+                      <input class="other__input" matInput placeholder="Add other" />
+                    </mat-form-field>
+                  </div>
                 </div>
               </mat-radio-group>
             </ng-container>
@@ -311,20 +319,34 @@
                   field.label.replaceAll(' ', '-').replace('(', '').replace(')', '') | lowercase
                 "
               >
-                <mat-list-option
-                  color="primary"
-                  [value]="option"
-                  class="list-option"
-                  checkboxPosition="before"
-                  *ngFor="let option of field.options"
-                  [data-qa]="
-                    field.label.replaceAll(' ', '-').replace('(', '').replace(')', '') +
-                      '-' +
-                      option.replaceAll(' ', '-') | lowercase
-                  "
-                >
-                  {{ option }}
-                </mat-list-option>
+                <ng-container *ngFor="let option of field.options">
+                  <mat-list-option
+                    color="primary"
+                    [value]="option"
+                    class="list-option"
+                    checkboxPosition="before"
+                    *ngIf="option !== 'Other'"
+                    [data-qa]="
+                      field.label.replaceAll(' ', '-').replace('(', '').replace(')', '') +
+                        '-' +
+                        option.replaceAll(' ', '-') | lowercase
+                    "
+                  >
+                    {{ option }}
+                  </mat-list-option>
+                  <div class="other" *ngIf="option === 'Other'">
+                    <mat-list-option
+                      color="primary"
+                      [value]="option"
+                      class="list-option other__input__checkbox"
+                      checkboxPosition="before"
+                    >
+                    </mat-list-option>
+                    <mat-form-field appearance="outline">
+                      <input class="other__input" matInput />
+                    </mat-form-field>
+                  </div>
+                </ng-container>
               </mat-selection-list>
             </ng-container>
 

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.scss
@@ -20,6 +20,22 @@
       }
     }
   }
+
+  .other {
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    &__input {
+      width: 100%;
+      padding: 8px 12px;
+      &__radio {
+        width: 45px;
+      }
+      &__checkbox {
+        max-width: 55px;
+      }
+    }
+  }
 }
 
 .translate-container {

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -305,8 +305,18 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
       });
     }
   }
+  public hasEmptyOther(key: string) {
+    const emptyOther =
+      this.form.get(key)?.value?.includes('Other') &&
+      !this.form.get('other' + key)?.value &&
+      this.form.get('other' + key)?.touched;
+    this.form.controls[key].setErrors({ emptyOther });
+    if (!emptyOther) this.form.controls[key].updateValueAndValidity();
+    return emptyOther;
+  }
 
-  public selectOther(field: any) {
+  public selectOther(event: any, field: any) {
+    event.stopPropagation();
     if (field.input === 'radio') {
       this.form.patchValue({ [field.key]: 'Other' });
     } else {
@@ -316,6 +326,11 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
         this.form.patchValue({ [field.key]: newValue });
       }
     }
+  }
+
+  public toggleFocus(event: any, field: any) {
+    console.log(field);
+    event.stopPropagation();
   }
 
   public changeLocation(data: any, formKey: string) {


### PR DESCRIPTION
A small fix to add other-options in web.

This PR adds the possibility to add an own option when adding a post.

To test (prerequisite: Create a survey with radio and checkbox-fields with the other-option, see more here: 

In web, add a new post for a survey with other-options for checkboxes and radio-buttons.

 - [x] There should be a text-input-field for each of the fields with other-options
- Click on the radio-button/checkbox to the left of the other-option
- [x] The input field is focused
- Do not write something and move on to next field
 - [x] There should be an error-message saying the field cannot be empty
- Click in the input-field
 - [x]  The radio-button/checkbox becomes selected
- Write something in the input-field
- Submit the post
- [x] The new option is visible in the post
- Click edit
- Change the text and save changes
- [x]  New text is visible in the post