### PR TITLE
Ush 1417 & 1267 - Questions in the mobile app

### DIFF
--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
@@ -72,10 +72,10 @@
             *ngIf="field.input === 'text' && (field.type === 'title' || field.type === 'varchar')"
           >
             <div class="form-control--section">
+              <ion-label class="field-label">{{field?.label}}</ion-label>
               <app-form-control
                 color="light"
                 [clearable]="true"
-                [label]="field?.label"
                 [required]="field?.required"
                 [formControlName]="field.key"
                 [hintHTML]="field?.instructions"
@@ -86,10 +86,10 @@
           <!-- description -->
           <ng-container *ngIf="field.input === 'text' && field.type === 'description'">
             <div class="form-control--section">
+              <ion-label class="field-label">{{field?.label}}</ion-label>
               <app-textarea-control
                 color="light"
                 [clearable]="true"
-                [label]="field?.label"
                 [required]="field?.required"
                 [formControlName]="field.key"
                 [hintHTML]="field?.instructions"
@@ -100,11 +100,11 @@
 
           <ng-container *ngIf="field.input === 'textarea'">
             <div class="form-control--section">
+              <ion-label class="field-label">{{field?.label}}</ion-label>
               <app-textarea-control
                 color="light"
                 [rounded]="false"
                 [clearable]="true"
-                [label]="field?.label"
                 [required]="field?.required"
                 [formControlName]="field.key"
                 [hintHTML]="field?.instructions"
@@ -116,7 +116,7 @@
           <!-- tags -->
           <ng-container *ngIf="field.input === 'tags'">
             <div class="form-control--section">
-              <ion-label>
+              <ion-label class="field-label">
                 {{ field?.label }}
                 <span class="color-accent" *ngIf="field?.required">*</span>
               </ion-label>
@@ -160,10 +160,10 @@
           <!-- date -->
           <ng-container *ngIf="field.input === 'date'">
             <div class="form-control--section">
+              <ion-label class="field-label">{{field?.label}}</ion-label>
               <app-form-control
                 [id]="'open-date'+i"
                 color="light"
-                [label]="field?.label"
                 [required]="field?.required"
                 [clearable]="true"
                 [formControlName]="field.key"
@@ -202,6 +202,7 @@
           <!-- datetime -->
           <ng-container *ngIf="field.input === 'datetime'">
             <div class="form-control--section">
+              <ion-label class="field-label">{{field?.label}}</ion-label>
               <app-form-control
                 [id]="'open-datetime'+i"
                 color="light"
@@ -245,7 +246,7 @@
           <ng-container *ngIf="field.input === 'radio'">
             <div class="form-control--section">
               <div>
-                <ion-label>
+                <ion-label class="field-label">
                   {{ field?.label }}
                   <span class="color-accent" *ngIf="field?.required">*</span>
                 </ion-label>
@@ -273,7 +274,7 @@
           <ng-container *ngIf="field.input === 'checkbox'">
             <div class="form-control--section">
               <div>
-                <ion-label>
+                <ion-label class="field-label">
                   {{ field?.label }}
                   <span class="color-accent" *ngIf="field?.required">*</span>
                 </ion-label>
@@ -302,9 +303,9 @@
           <!-- select -->
           <ng-container *ngIf="field.input === 'select'">
             <div class="form-control--section">
+              <ion-label class="field-label">{{field?.label}}</ion-label>
               <app-select
                 [hintHTML]="field?.instructions"
-                [label]="field?.label"
                 [formControlName]="field.key"
                 *ngIf="field.options?.length; else noOptions"
                 [options]="field.options"
@@ -316,10 +317,10 @@
           <!-- number -->
           <ng-container *ngIf="field.input === 'number'">
             <div class="form-control--section">
+              <ion-label class="field-label">{{field?.label}}</ion-label>
               <app-form-control
                 color="light"
                 [clearable]="true"
-                [label]="field?.label"
                 [required]="field?.required"
                 [formControlName]="field.key"
                 [type]="'number'"
@@ -333,7 +334,7 @@
           <ng-container *ngIf="field.input === 'upload'">
             <div class="form-control--section">
               <div>
-                <ion-label>
+                <ion-label class="field-label">
                   {{ field?.label }}
                   <span class="color-accent" *ngIf="field?.required">*</span>
                 </ion-label>
@@ -359,11 +360,11 @@
           <!-- video -->
           <ng-container *ngIf="field.input === 'video'">
             <div class="form-control--section">
+              <ion-label class="field-label">{{field?.label}}</ion-label>
               <app-form-control
                 #videoInput
                 color="light"
                 [clearable]="true"
-                [label]="field?.label"
                 [required]="field?.required"
                 [formControlName]="field.key"
                 [hintHTML]="field?.instructions"
@@ -387,7 +388,7 @@
           <!-- location -->
           <ng-container *ngIf="field.input === 'location'">
             <div class="form-row__label-instruction">
-              <ion-label>
+              <ion-label class="field-label">
                 {{ field?.label }}
                 <span class="color-accent" *ngIf="field?.required">*</span>
               </ion-label>
@@ -412,7 +413,7 @@
           <!-- relation -->
           <ng-container *ngIf="field.input === 'relation'">
             <div class="form-control--section">
-              <ion-label>
+              <ion-label class="field-label">
                 {{ field?.label }}
                 <span class="color-accent" *ngIf="field?.required">*</span>
               </ion-label>
@@ -433,7 +434,6 @@
                 <app-form-control
                   color="light"
                   [clearable]="true"
-                  [label]="field?.label"
                   [required]="field?.required"
                   [(ngModel)]="relationSearch"
                   [ngModelOptions]="{ standalone: true }"
@@ -468,10 +468,10 @@
           <!-- markdown -->
           <ng-container *ngIf="field.input === 'markdown'">
             <div class="form-control--section">
+              <ion-label class="field-label">{{field?.label}}</ion-label>
               <app-textarea-control
                 color="light"
                 [clearable]="true"
-                [label]="field?.label"
                 [required]="field?.required"
                 [formControlName]="field.key"
                 [placeholder]="field.default"

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
@@ -221,7 +221,6 @@
               <app-form-control
                 [id]="'open-datetime'+i"
                 color="light"
-                [label]="field?.label"
                 [required]="field?.required"
                 [clearable]="true"
                 [formControlName]="field.key"

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
@@ -72,7 +72,10 @@
             *ngIf="field.input === 'text' && (field.type === 'title' || field.type === 'varchar')"
           >
             <div class="form-control--section">
-              <ion-label class="field-label">{{field?.label}}</ion-label>
+              <ion-label class="field-label"
+                >{{field?.label}}
+                <span class="color-accent" *ngIf="field?.required">*</span>
+              </ion-label>
               <app-form-control
                 color="light"
                 [clearable]="true"
@@ -86,7 +89,10 @@
           <!-- description -->
           <ng-container *ngIf="field.input === 'text' && field.type === 'description'">
             <div class="form-control--section">
-              <ion-label class="field-label">{{field?.label}}</ion-label>
+              <ion-label class="field-label"
+                >{{field?.label}}
+                <span class="color-accent" *ngIf="field?.required">*</span>
+              </ion-label>
               <app-textarea-control
                 color="light"
                 [clearable]="true"
@@ -100,7 +106,10 @@
 
           <ng-container *ngIf="field.input === 'textarea'">
             <div class="form-control--section">
-              <ion-label class="field-label">{{field?.label}}</ion-label>
+              <ion-label class="field-label"
+                >{{field?.label}}
+                <span class="color-accent" *ngIf="field?.required">*</span>
+              </ion-label>
               <app-textarea-control
                 color="light"
                 [rounded]="false"
@@ -160,7 +169,10 @@
           <!-- date -->
           <ng-container *ngIf="field.input === 'date'">
             <div class="form-control--section">
-              <ion-label class="field-label">{{field?.label}}</ion-label>
+              <ion-label class="field-label"
+                >{{field?.label}}
+                <span class="color-accent" *ngIf="field?.required">*</span>
+              </ion-label>
               <app-form-control
                 [id]="'open-date'+i"
                 color="light"
@@ -202,7 +214,10 @@
           <!-- datetime -->
           <ng-container *ngIf="field.input === 'datetime'">
             <div class="form-control--section">
-              <ion-label class="field-label">{{field?.label}}</ion-label>
+              <ion-label class="field-label"
+                >{{field?.label}}
+                <span class="color-accent" *ngIf="field?.required">*</span>
+              </ion-label>
               <app-form-control
                 [id]="'open-datetime'+i"
                 color="light"
@@ -303,7 +318,10 @@
           <!-- select -->
           <ng-container *ngIf="field.input === 'select'">
             <div class="form-control--section">
-              <ion-label class="field-label">{{field?.label}}</ion-label>
+              <ion-label class="field-label"
+                >{{field?.label}}
+                <span class="color-accent" *ngIf="field?.required">*</span>
+              </ion-label>
               <app-select
                 [hintHTML]="field?.instructions"
                 [formControlName]="field.key"
@@ -317,7 +335,10 @@
           <!-- number -->
           <ng-container *ngIf="field.input === 'number'">
             <div class="form-control--section">
-              <ion-label class="field-label">{{field?.label}}</ion-label>
+              <ion-label class="field-label"
+                >{{field?.label}}
+                <span class="color-accent" *ngIf="field?.required">*</span>
+              </ion-label>
               <app-form-control
                 color="light"
                 [clearable]="true"
@@ -360,7 +381,10 @@
           <!-- video -->
           <ng-container *ngIf="field.input === 'video'">
             <div class="form-control--section">
-              <ion-label class="field-label">{{field?.label}}</ion-label>
+              <ion-label class="field-label"
+                >{{field?.label}}
+                <span class="color-accent" *ngIf="field?.required">*</span>
+              </ion-label>
               <app-form-control
                 #videoInput
                 color="light"
@@ -468,7 +492,10 @@
           <!-- markdown -->
           <ng-container *ngIf="field.input === 'markdown'">
             <div class="form-control--section">
-              <ion-label class="field-label">{{field?.label}}</ion-label>
+              <ion-label class="field-label"
+                >{{field?.label}}
+                <span class="color-accent" *ngIf="field?.required">*</span>
+              </ion-label>
               <app-textarea-control
                 color="light"
                 [clearable]="true"

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.scss
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.scss
@@ -9,20 +9,18 @@
 .field-label {
   font-weight: bold;
 }
-
 :host {
-  ion-item {
-    border-color: #e2e2e3;
-    @media (prefers-color-scheme: light) {
-      --border-color: #e2e2e3;
-    }
+  .form-row {
+    border-color: #e2e2e3 !important;
+    // @media (prefers-color-scheme: light) {
+    //   --border-color: #e2e2e3;
+    // }
 
-    @media (prefers-color-scheme: dark) {
-      --border-color: var(--ion-border-color);
-    }
+    // @media (prefers-color-scheme: dark) {
+    //   --border-color: var(--ion-border-color);
+    // }
   }
 }
-
 .checkbox {
   &-list {
     list-style: none;
@@ -31,6 +29,20 @@
     &__item {
       .lvl-2 {
         margin-left: 16px;
+      }
+    }
+  }
+}
+:host {
+  ::ng-deep {
+    .form-post-create {
+      ion-item.form-row {
+        @media (prefers-color-scheme: light) {
+          border-color: #e2e2e3;
+          border-width: 1px;
+          border-style: solid;
+          border-radius: 4px;
+        }
       }
     }
   }

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.scss
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.scss
@@ -6,6 +6,10 @@
   margin-top: 24px;
 }
 
+.field-label {
+  font-weight: bold;
+}
+
 .checkbox {
   &-list {
     list-style: none;

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.scss
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.scss
@@ -10,6 +10,19 @@
   font-weight: bold;
 }
 
+:host {
+  ion-item {
+    border-color: #e2e2e3;
+    @media (prefers-color-scheme: light) {
+      --border-color: #e2e2e3;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      --border-color: var(--ion-border-color);
+    }
+  }
+}
+
 .checkbox {
   &-list {
     list-style: none;

--- a/apps/mobile-mzima-client/src/app/shared/components/form-control/form-control.component.html
+++ b/apps/mobile-mzima-client/src/app/shared/components/form-control/form-control.component.html
@@ -1,5 +1,6 @@
 <div class="ion-margin-bottom">
   <ion-item
+    lines="none"
     class="form-row"
     [ngClass]="{
       'form-row--rounded': rounded,

--- a/apps/mobile-mzima-client/src/app/shared/components/form-control/form-control.component.html
+++ b/apps/mobile-mzima-client/src/app/shared/components/form-control/form-control.component.html
@@ -1,6 +1,5 @@
 <div class="ion-margin-bottom">
   <ion-item
-    lines="none"
     class="form-row"
     [ngClass]="{
       'form-row--rounded': rounded,


### PR DESCRIPTION
**Issues:**

This PR solves 2 issues in the mobile app:

- Have survey questions on top of the text field box instead of inside the text field box
- If a survey is created with a long-text field name, the entire text of the field name is not displayed in full on the mobile app but rather truncated with 3 ellipses

**Solution:**

The solution is to move all the field labels to sit above the inputs. There were also a few style changes to match the design ticket, but maybe this needs revisiting as it feels a bit inconsistent.

**Tickets:**

https://linear.app/ushahidi/issue/USH-1417/have-survey-questions-on-top-of-the-text-field-box-instead-of-inside
https://linear.app/ushahidi/issue/USH-1267/long-survey-questions-are-cut-off-in-the-mobile-app

**Testing:**

1. Using the mobile app create a post
2. Notice all the field labels (questions) are above the field inputs.