### PR TITLE
[Accessibility] Improve category expand/collapse button accessibility with aria-label

### DIFF
--- a/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.html
+++ b/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.html
@@ -18,6 +18,7 @@
     fill="clear"
     color="secondary"
     [iconOnly]="true"
+    aria-label="Expand or collapse category"
     [data-qa]="'toggle-children'"
     (buttonClick)="toggleChildren(category.id)"
     (click)="$event.stopPropagation()"

--- a/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.html
+++ b/apps/web-mzima-client/src/app/settings/categories/category-item/category-item.component.html
@@ -18,7 +18,7 @@
     fill="clear"
     color="secondary"
     [iconOnly]="true"
-    aria-label="Expand or collapse category"
+    [ariaLabel]="'Expand or collapse ' + category.tag | translate"
     [data-qa]="'toggle-children'"
     (buttonClick)="toggleChildren(category.id)"
     (click)="$event.stopPropagation()"

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "http://localhost:8080/",
+  "backend_url": "https://mzima-dev-api.staging.ush.zone/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "http://localhost:8080/",  
+  "backend_url": "http://localhost:8080/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",

--- a/apps/web-mzima-client/src/env.json
+++ b/apps/web-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
   "production": true,
-  "backend_url": "https://mzima-dev-api.staging.ush.zone/",
+  "backend_url": "http://localhost:8080/",  
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",


### PR DESCRIPTION
## Engineers Checklist

### Description
- This pull request fixes: https://github.com/ushahidi/platform/issues/4979
- For the changes, localisation is also put into consideration

### Changes

- Added `aria-label` attribute to the `<mzima-client-button>` element with the value "Expand or collapse category"
- This provides a clear and concise description of the button's purpose for screen reader users

### Screenshots

Before:
<img width="1200" alt="Screenshot 2024-07-23 at 09 16 11" src="https://github.com/user-attachments/assets/1fdf7fe3-6057-4f7b-b36d-64affc125ab3">


After:
<img width="1200" alt="Screenshot 2024-07-23 at 09 15 05" src="https://github.com/user-attachments/assets/125499f3-b1f6-409f-bd98-9de9426541fb">

### Testing
- Verified the button is still functioning correctly
- Tested with a screen reader to ensure the `aria-label` is read aloud correctly
- Manually inspected the button to ensure the visual design remains consistent