### PR TITLE
Ush 1458 - Handle unknown deployment gracefully

### DIFF
--- a/apps/web-mzima-client/src/app/app.component.ts
+++ b/apps/web-mzima-client/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import {
   BreakpointService,
+  ConfirmModalService,
   EnvService,
   EventBusService,
   EventType,
@@ -50,10 +51,17 @@ export class AppComponent extends BaseComponent implements OnInit {
     private env: EnvService,
     private gtm: GtmTrackingService,
     private intercom: Intercom,
+    private confirmModalService: ConfirmModalService,
   ) {
     super(sessionService, breakpointService);
     this.checkDesktop();
 
+    if (!this.sessionService.hasSiteConfiguration()) {
+      this.confirmModalService.open({
+        title: 'No Deployment Found',
+        description: 'No Deployment Found',
+      });
+    }
     this.selectedLanguage$ = this.languageService.selectedLanguage$.pipe(untilDestroyed(this));
 
     this.loaderService.isActive$.pipe(untilDestroyed(this)).subscribe({

--- a/apps/web-mzima-client/src/app/app.component.ts
+++ b/apps/web-mzima-client/src/app/app.component.ts
@@ -70,7 +70,7 @@ export class AppComponent extends BaseComponent implements OnInit {
           if (confirm) {
             window.location.href = 'https://ushahidi.io/create';
           } else {
-            window.location.href = 'https://www.ushahidi.com/';
+            window.location.href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
           }
         });
     }

--- a/apps/web-mzima-client/src/app/app.component.ts
+++ b/apps/web-mzima-client/src/app/app.component.ts
@@ -57,10 +57,22 @@ export class AppComponent extends BaseComponent implements OnInit {
     this.checkDesktop();
 
     if (!this.sessionService.hasSiteConfiguration()) {
-      this.confirmModalService.open({
-        title: 'No Deployment Found',
-        description: 'No Deployment Found',
-      });
+      this.loaderService.hide();
+      this.confirmModalService
+        .open({
+          title: 'Deployment does not exist.',
+          description:
+            'Sorry. That deployment does not exist. Would you like to create a new deployment?',
+          confirmButtonText: 'Create New Deployment',
+          cancelButtonText: 'Exit',
+        })
+        .then((confirm) => {
+          if (confirm) {
+            window.location.href = 'https://ushahidi.io/create';
+          } else {
+            window.location.href = 'https://www.ushahidi.com/';
+          }
+        });
     }
     this.selectedLanguage$ = this.languageService.selectedLanguage$.pipe(untilDestroyed(this));
 

--- a/apps/web-mzima-client/src/app/core/services/config.service.ts
+++ b/apps/web-mzima-client/src/app/core/services/config.service.ts
@@ -45,9 +45,16 @@ export class ConfigService {
             });
             return data.result;
           },
-          error: (error) => {
-            console.log(error);
-            setTimeout(() => this.getConfig(), 5000);
+          error: (response) => {
+            const error = response?.error?.errors[0];
+            if (!error || !(error.message === 'Deployment not found')) {
+              setTimeout(() => this.getConfig(), 5000);
+            }
+            // if (error && error.status === 404 && error.message === 'Deployment not found') {
+            //   console.log(error.status + ' --- ' + error.message);
+            // }
+            // else {
+            // }
           },
         }),
       );

--- a/apps/web-mzima-client/src/app/core/services/config.service.ts
+++ b/apps/web-mzima-client/src/app/core/services/config.service.ts
@@ -45,7 +45,8 @@ export class ConfigService {
             });
             return data.result;
           },
-          error: () => {
+          error: (error) => {
+            console.log(error);
             setTimeout(() => this.getConfig(), 5000);
           },
         }),

--- a/apps/web-mzima-client/src/app/core/services/session.service.ts
+++ b/apps/web-mzima-client/src/app/core/services/session.service.ts
@@ -78,6 +78,10 @@ export class SessionService {
     this.currentConfig.site.donation = donation;
   }
 
+  hasSiteConfiguration(): boolean {
+    return this.currentConfig.site && Object.keys(this.currentConfig.site).length > 0;
+  }
+
   getFeatureConfigurations() {
     return this.currentConfig.features;
   }

--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -77,58 +77,62 @@ export class MapComponent extends MainViewComponent implements OnInit {
       sessionService,
       breakpointService,
     );
-    this.filtersSubscription$ = this.postsService.postsFilters$.pipe(takeUntilDestroy$());
+    if (this.sessionService.hasSiteConfiguration()) {
+      this.filtersSubscription$ = this.postsService.postsFilters$.pipe(takeUntilDestroy$());
+    }
   }
 
   ngOnInit() {
-    this.reInitParams();
-    this.route.params.subscribe(() => {
-      this.initCollection();
-    });
-    this.initFilterListener();
-    this.mapConfig = this.sessionService.getMapConfigurations();
+    if (this.sessionService.hasSiteConfiguration()) {
+      this.reInitParams();
+      this.route.params.subscribe(() => {
+        this.initCollection();
+      });
+      this.initFilterListener();
+      this.mapConfig = this.sessionService.getMapConfigurations();
 
-    const currentLayer =
-      mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
+      const currentLayer =
+        mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
 
-    this.leafletOptions = {
-      minZoom: 1,
-      maxZoom: 22,
-      scrollWheelZoom: true,
-      zoomControl: false,
-      layers: [tileLayer(currentLayer.url, currentLayer.layerOptions)],
-      center: [this.mapConfig.default_view!.lat, this.mapConfig.default_view!.lon],
-      zoom: this.mapConfig.default_view!.zoom,
-    };
-    this.markerClusterOptions.maxClusterRadius = this.mapConfig.cluster_radius;
+      this.leafletOptions = {
+        minZoom: 1,
+        maxZoom: 22,
+        scrollWheelZoom: true,
+        zoomControl: false,
+        layers: [tileLayer(currentLayer.url, currentLayer.layerOptions)],
+        center: [this.mapConfig.default_view!.lat, this.mapConfig.default_view!.lon],
+        zoom: this.mapConfig.default_view!.zoom,
+      };
+      this.markerClusterOptions.maxClusterRadius = this.mapConfig.cluster_radius;
 
-    this.mapReady = true;
+      this.mapReady = true;
 
-    this.eventBusService.on(EventType.SearchOptionSelected).subscribe({
-      next: (option) => {
-        this.map.setZoom(12);
-        this.map.panTo({ lat: option.lat, lng: option.lon });
-      },
-    });
+      this.eventBusService.on(EventType.SearchOptionSelected).subscribe({
+        next: (option) => {
+          this.map.setZoom(12);
+          this.map.panTo({ lat: option.lat, lng: option.lon });
+        },
+      });
 
-    this.sessionService.isFiltersVisible$.pipe(untilDestroyed(this)).subscribe({
-      next: (isFiltersVisible) => {
-        setTimeout(() => {
-          this.isFiltersVisible = isFiltersVisible;
-        }, 1);
-      },
-    });
+      this.sessionService.isFiltersVisible$.pipe(untilDestroyed(this)).subscribe({
+        next: (isFiltersVisible) => {
+          setTimeout(() => {
+            this.isFiltersVisible = isFiltersVisible;
+          }, 1);
+        },
+      });
 
-    this.sessionService.isMainFiltersHidden$.pipe(untilDestroyed(this)).subscribe({
-      next: (isMainFiltersHidden: boolean) => {
-        setTimeout(() => {
-          this.isMainFiltersOpen = !isMainFiltersHidden;
-        }, 1);
-      },
-    });
+      this.sessionService.isMainFiltersHidden$.pipe(untilDestroyed(this)).subscribe({
+        next: (isMainFiltersHidden: boolean) => {
+          setTimeout(() => {
+            this.isMainFiltersOpen = !isMainFiltersHidden;
+          }, 1);
+        },
+      });
 
-    this.initCollectionRemoveListener();
-    this.getUserData();
+      this.initCollectionRemoveListener();
+      this.getUserData();
+    }
   }
 
   loadData(): void {

--- a/apps/web-mzima-client/src/app/shared/components/toolbar/toolbar.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/toolbar/toolbar.component.ts
@@ -54,8 +54,9 @@ export class ToolbarComponent extends BaseComponent implements OnInit {
 
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
       const url = router.routerState.snapshot.url;
-      this.showSearchForm = url.indexOf('/map') > -1 || url.indexOf('/feed') > -1;
       this.isSettingsPage = url.indexOf('/settings') > -1;
+      if (!this.sessionService.hasSiteConfiguration()) this.showSearchForm = false;
+      else this.showSearchForm = url.indexOf('/map') > -1 || url.indexOf('/feed') > -1;
     });
 
     this.breadcrumbService.breadcrumbs$.pipe(untilDestroyed(this)).subscribe({


### PR DESCRIPTION
**Issue:**

On ushahidi.io, when a user goes to a deployment that doesnt exist or has been deleted, the multi-site handling does not prevent the frontend from continually trying the backend, and the user does not receive any information about what is happening.

**Solution:**

When the frontend receives the "No Deployment Found" response from the backend, it immediately blocks all subsequent backend requests and puts up an alert to the user. The alert allows the user to choose to create a new deployment or exit the site.

**Testing Plan:**

1. Go to a non existent deployment, eg. thisisntadeployment.ushahidi.io
2. Check that all backend requests are halted.
3. Note the alert dialog
4. Click "create new deployment" and be redirected to ushahidi.io/create, or click "exit" and be taken away from the site.

