### PR TITLE
[USH-826] Disruptive pop-up notifications

### DIFF
--- a/apps/mobile-mzima-client/src/app/app.component.ts
+++ b/apps/mobile-mzima-client/src/app/app.component.ts
@@ -38,6 +38,7 @@ export class AppComponent extends BaseComponent {
   private toastMessage$ = new Subject<string>();
   public languages: LanguageInterface[];
   public selectedLanguage$: any;
+  private isInitialized = false;
 
   constructor(
     override router: Router,
@@ -74,6 +75,7 @@ export class AppComponent extends BaseComponent {
     this.getSurveys(false).subscribe();
     this.getCollections(false).subscribe();
     this.loadLanguageInformation();
+    this.isInitialized = true;
   }
 
   public loadLanguageInformation() {
@@ -91,7 +93,7 @@ export class AppComponent extends BaseComponent {
     this.networkService.networkStatus$
       .pipe(
         distinctUntilChanged(),
-        filter((value) => value === true),
+        filter((value) => value === true && this.isInitialized),
         untilDestroyed(this),
         concatMap(() => this.getCollections().pipe(delay(2000))),
         concatMap(() => this.getSurveys().pipe(delay(2000))),
@@ -103,7 +105,7 @@ export class AppComponent extends BaseComponent {
     this.networkService.networkStatus$
       .pipe(
         distinctUntilChanged(),
-        filter((value) => value === true),
+        filter((value) => value === true && this.isInitialized),
         untilDestroyed(this),
         concatMap(() => from(this.checkPendingCollections()).pipe(delay(2000))),
       )

--- a/apps/mobile-mzima-client/src/app/base.component.ts
+++ b/apps/mobile-mzima-client/src/app/base.component.ts
@@ -15,6 +15,7 @@ import { Location } from '@angular/common';
 
 export class BaseComponent {
   tap = 0;
+  private isNetworkInitialized = false;
 
   constructor(
     protected router: Router,
@@ -31,6 +32,7 @@ export class BaseComponent {
         this.exitAppOnDoubleTap();
       }
       this.logDeviceInfo();
+      this.isNetworkInitialized = true;
     });
 
     if (this.platform.is('capacitor')) {
@@ -77,9 +79,11 @@ export class BaseComponent {
       .pipe(distinctUntilChanged(), untilDestroyed(this))
       .subscribe({
         next: async (value) => {
-          await this.showConnectionInfo(
-            value ? 'The connection was restored' : 'The connection is lost',
-          );
+          if (this.isNetworkInitialized) {
+            await this.showConnectionInfo(
+              value ? 'The connection was restored' : 'The connection is lost',
+            );
+          }
         },
       });
   }


### PR DESCRIPTION
The toast message used to appear every time the app was launched. 
This solution addresses this issue by only displaying the toast messages when the internet is disconnected and reconnected while the app is still in use.