### PR TITLE
[Accessibility] Fixed localisation issue of the hardcoded strings in activity file

### DIFF
--- a/apps/web-mzima-client/src/app/activity/activity-timeline/activity-timeline.component.html
+++ b/apps/web-mzima-client/src/app/activity/activity-timeline/activity-timeline.component.html
@@ -21,7 +21,7 @@
       [rotateXAxisTicks]="false"
     >
       <ng-template #tooltipTemplate let-model="model">
-        This is the single point tooltip template
+        {{ 'activity.tooltip_template' | translate }}
         <pre>{{ model | json }}</pre>
       </ng-template>
     </ngx-charts-line-chart>

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -216,7 +216,8 @@
     "all_crowdsourced": "All Crowdsourced Surveys",
     "no_crowdsourced": "You don't have any Crowdsourced Survey data to show.",
     "targeted_activity": "Tageted Survey Activity",
-    "crowdsourced_activity": "Crowdsourced Survey Activity"
+    "crowdsourced_activity": "Crowdsourced Survey Activity",
+    "tooltip_template": "This is the single point tooltip template"
   },
   "form": {
     "add_field": "Add Field",


### PR DESCRIPTION
## Engineers Checklist

### Description
- This pull request fixes: https://github.com/ushahidi/platform/issues/4988

### Changes
1. Replaced the hardcoded "This is the single point tooltip template" string with a translation key in the `activity-timeline.component.html` file.
2. Added the translation key-value pair in the `en.json` file.

### Screenshots

Before:
<img width="1200" alt="Screenshot 2024-07-26 at 14 57 11" src="https://github.com/user-attachments/assets/07d84158-f474-4c60-9bef-6ea401f51b33">

After:
```html
      <ng-template #tooltipTemplate let-model="model">
        {{ 'activity.tooltip_template' | translate }}
        <pre>{{ model | json }}</pre>
      </ng-template>
```
<img width="1440" alt="Screenshot 2024-08-12 at 19 35 38" src="https://github.com/user-attachments/assets/ec31f55f-efea-497a-bc6c-a78f59d4de8f">

### Testing
Finding this string on the platform to test