### PR TITLE
Ush 1458 - Handle unknown deployment gracefully

### DIFF
--- a/apps/web-mzima-client/src/app/app-routing.module.ts
+++ b/apps/web-mzima-client/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes, TitleStrategy } from '@angular/router';
 import {
   HostGuard,
   AccessDeniedGuard,
+  DeploymentFoundGuard,
   ResetTokenGuard,
   AccessAllowGuard,
   RedirectGuard,
@@ -13,6 +14,7 @@ import { AccessDeniedComponent } from './shared/components/access-denied/access-
 import { PostNotFoundComponent } from './post/post-not-found/post-not-found.component';
 import { PostNotAllowedComponent } from './post/post-not-allowed/post-not-allowed.component';
 import { RedirectByPostIdGuard } from './core/guards/redirect.post-id.guard';
+import { DeploymentNotFoundComponent } from './shared/components/deployment-not-found/deployment-not-found.component';
 
 const routes: Routes = [
   {
@@ -23,7 +25,7 @@ const routes: Routes = [
   {
     path: 'map',
     loadChildren: () => import('./map/map.module').then((m) => m.MapModule),
-    canActivate: [AccessDeniedGuard],
+    canActivate: [AccessDeniedGuard, DeploymentFoundGuard],
     data: {
       breadcrumb: 'nav.map',
       ogTitle: 'nav.map',
@@ -32,7 +34,7 @@ const routes: Routes = [
   {
     path: 'feed',
     loadChildren: () => import('./feed/feed.module').then((m) => m.FeedModule),
-    canActivate: [AccessDeniedGuard],
+    canActivate: [AccessDeniedGuard, DeploymentFoundGuard],
     data: {
       breadcrumb: 'nav.feed',
       ogTitle: 'nav.feed',
@@ -41,7 +43,7 @@ const routes: Routes = [
   {
     path: 'activity',
     loadChildren: () => import('./activity/activity.module').then((m) => m.ActivityModule),
-    canActivate: [AccessDeniedGuard],
+    canActivate: [AccessDeniedGuard, DeploymentFoundGuard],
     data: {
       breadcrumb: 'nav.activity',
       ogTitle: 'nav.activity',
@@ -50,7 +52,7 @@ const routes: Routes = [
   {
     path: 'settings',
     loadChildren: () => import('./settings/settings.module').then((m) => m.SettingsModule),
-    canActivate: [HostGuard, AccessDeniedGuard],
+    canActivate: [HostGuard, AccessDeniedGuard, DeploymentFoundGuard],
     data: {
       breadcrumb: 'nav.settings',
       ogTitle: 'nav.settings',
@@ -80,6 +82,15 @@ const routes: Routes = [
     },
   },
   {
+    path: 'notfound',
+    component: DeploymentNotFoundComponent,
+    canActivate: [DeploymentFoundGuard],
+    data: {
+      breadcrumb: 'nav.deployment_not_found',
+      ogTitle: 'nav.deployment_not_found',
+    },
+  },
+  {
     path: 'views',
     children: [
       {
@@ -95,7 +106,7 @@ const routes: Routes = [
   {
     path: 'post',
     loadChildren: () => import('./post/post.module').then((m) => m.PostModule),
-    canActivate: [AccessDeniedGuard],
+    canActivate: [AccessDeniedGuard, DeploymentFoundGuard],
     data: {
       breadcrumb: 'nav.posts',
       ogTitle: 'nav.posts',
@@ -104,7 +115,7 @@ const routes: Routes = [
   {
     path: 'posts', // For support legacy URL routes
     loadChildren: () => import('./post/post.module').then((m) => m.PostModule),
-    canActivate: [AccessDeniedGuard],
+    canActivate: [AccessDeniedGuard, DeploymentFoundGuard],
     data: {
       breadcrumb: 'nav.posts',
       ogTitle: 'nav.posts',

--- a/apps/web-mzima-client/src/app/app-routing.module.ts
+++ b/apps/web-mzima-client/src/app/app-routing.module.ts
@@ -84,7 +84,7 @@ const routes: Routes = [
   {
     path: 'notfound',
     component: DeploymentNotFoundComponent,
-    canActivate: [DeploymentFoundGuard],
+    canActivate: [AccessAllowGuard],
     data: {
       breadcrumb: 'nav.deployment_not_found',
       ogTitle: 'nav.deployment_not_found',

--- a/apps/web-mzima-client/src/app/app-routing.module.ts
+++ b/apps/web-mzima-client/src/app/app-routing.module.ts
@@ -84,7 +84,7 @@ const routes: Routes = [
   {
     path: 'notfound',
     component: DeploymentNotFoundComponent,
-    canActivate: [AccessAllowGuard],
+    // canActivate: [AccessAllowGuard],
     data: {
       breadcrumb: 'nav.deployment_not_found',
       ogTitle: 'nav.deployment_not_found',

--- a/apps/web-mzima-client/src/app/core/guards/access-allow.guard.ts
+++ b/apps/web-mzima-client/src/app/core/guards/access-allow.guard.ts
@@ -8,14 +8,13 @@ import { SessionService } from '@services';
 export class AccessAllowGuard implements CanActivate {
   constructor(private router: Router, private service: SessionService) {}
 
-  canActivate(): boolean {
+  canActivate() {
     const access: boolean = this.service.accessToSite;
 
-    if (access) {
-      this.router.navigate([`/map`]);
-    } else {
+    if (!access) {
       return true;
     }
-    return false;
+
+    return this.router.parseUrl(`/map`);
   }
 }

--- a/apps/web-mzima-client/src/app/core/guards/access-denied.guard.ts
+++ b/apps/web-mzima-client/src/app/core/guards/access-denied.guard.ts
@@ -14,7 +14,7 @@ export class AccessDeniedGuard implements CanActivate {
     if (access) {
       return true;
     } else {
-      this.router.navigate([`/forbidden`]);
+      this.router.navigate(['/forbidden']);
     }
     return false;
   }

--- a/apps/web-mzima-client/src/app/core/guards/access-denied.guard.ts
+++ b/apps/web-mzima-client/src/app/core/guards/access-denied.guard.ts
@@ -8,14 +8,11 @@ import { SessionService } from '@services';
 export class AccessDeniedGuard implements CanActivate {
   constructor(private router: Router, private service: SessionService) {}
 
-  canActivate(): boolean {
+  canActivate() {
     const access: boolean = this.service.accessToSite;
-
     if (access) {
       return true;
-    } else {
-      this.router.navigate(['/forbidden']);
     }
-    return false;
+    return this.router.parseUrl('/forbidden');
   }
 }

--- a/apps/web-mzima-client/src/app/core/guards/deployment-found.guard.ts
+++ b/apps/web-mzima-client/src/app/core/guards/deployment-found.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { SessionService } from '@services';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DeploymentFoundGuard implements CanActivate {
+  constructor(private router: Router, private service: SessionService) {}
+
+  canActivate(): boolean {
+    const siteFound: boolean = this.service.siteFound;
+
+    if (siteFound) {
+      return true;
+    } else {
+      this.router.navigate([`/notfound`]);
+    }
+    return false;
+  }
+}

--- a/apps/web-mzima-client/src/app/core/guards/deployment-found.guard.ts
+++ b/apps/web-mzima-client/src/app/core/guards/deployment-found.guard.ts
@@ -8,14 +8,11 @@ import { SessionService } from '@services';
 export class DeploymentFoundGuard implements CanActivate {
   constructor(private router: Router, private service: SessionService) {}
 
-  canActivate(): boolean {
+  canActivate() {
     const siteFound: boolean = this.service.siteFound;
-
     if (siteFound) {
       return true;
-    } else {
-      this.router.navigate([`/notfound`]);
     }
-    return false;
+    return this.router.parseUrl('/notfound');
   }
 }

--- a/apps/web-mzima-client/src/app/core/guards/index.ts
+++ b/apps/web-mzima-client/src/app/core/guards/index.ts
@@ -8,3 +8,4 @@ export { DataImportExportGuard } from './data-import-export.guard';
 export { AccessDeniedGuard } from './access-denied.guard';
 export { AccessAllowGuard } from './access-allow.guard';
 export { RedirectGuard } from './redirect.guard';
+export { DeploymentFoundGuard } from './deployment-found.guard';

--- a/apps/web-mzima-client/src/app/core/services/session.service.ts
+++ b/apps/web-mzima-client/src/app/core/services/session.service.ts
@@ -137,7 +137,11 @@ export class SessionService {
   }
 
   get siteFound(): boolean {
-    return this.currentConfig !== undefined;
+    return (
+      this.currentConfig &&
+      this.currentConfig.site &&
+      Object.keys(this.currentConfig.site).length > 0
+    );
   }
 
   get currentAuthTokenType() {

--- a/apps/web-mzima-client/src/app/core/services/session.service.ts
+++ b/apps/web-mzima-client/src/app/core/services/session.service.ts
@@ -136,6 +136,10 @@ export class SessionService {
     return !this.currentConfig.site.private || !!this.currentAuthToken;
   }
 
+  get siteFound(): boolean {
+    return this.currentConfig !== undefined;
+  }
+
   get currentAuthTokenType() {
     return this.currentSessionData.tokenType;
   }

--- a/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.html
@@ -2,9 +2,13 @@
   <div class="deployment-not-found__container">
     <h2 class="deployment-not-found__title">{{ 'nav.deployment_not_found' | translate }}</h2>
     <p>{{ 'app.deployment_not_found.text' | translate }}</p>
-    <a href="ushahidi.io/create">{{
-      'app.deployment_not_found.button_create_deployment' | translate
-    }}</a>
-    <a href="www.ushahidi.com">{{ 'app.deployment_not_found.button_exit' | translate }}</a>
+    <div class="deployment-not-found__buttons">
+      <mzima-client-button matSuffix href="http://www.ushahidi.com/">
+        {{ 'app.deployment_not_found.button_exit' | translate }}
+      </mzima-client-button>
+      <mzima-client-button matSuffix href="http://www.ushahidi.io/create">
+        {{ 'app.deployment_not_found.button_create_deployment' | translate }}
+      </mzima-client-button>
+    </div>
   </div>
 </div>

--- a/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.html
@@ -1,0 +1,10 @@
+<div class="deployment-not-found">
+  <div class="deployment-not-found__container">
+    <h2 class="deployment-not-found__title">{{ 'nav.deployment_not_found' | translate }}</h2>
+    <p>{{ 'app.deployment_not_found.text' | translate }}</p>
+    <a href="ushahidi.io/create">{{
+      'app.deployment_not_found.button_create_deployment' | translate
+    }}</a>
+    <a href="www.ushahidi.com">{{ 'app.deployment_not_found.button_exit' | translate }}</a>
+  </div>
+</div>

--- a/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.scss
@@ -1,0 +1,16 @@
+.access-denied {
+  height: 100vh;
+
+  &__container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: calc(100% - 64px);
+  }
+
+  &__title {
+    font-weight: bold;
+    font-size: 24px;
+  }
+}

--- a/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.scss
@@ -1,16 +1,29 @@
-.access-denied {
-  height: 100vh;
+.deployment-not-found {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   &__container {
+    width: 20vw;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
-    height: calc(100% - 64px);
+    min-height: 200px;
+    background-color: #fff;
+    padding: 1rem;
   }
 
   &__title {
     font-weight: bold;
     font-size: 24px;
+  }
+
+  &__buttons {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
   }
 }

--- a/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/deployment-not-found/deployment-not-found.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-deployment-not-found',
+  templateUrl: './deployment-not-found.component.html',
+  styleUrls: ['./deployment-not-found.component.scss'],
+})
+export class DeploymentNotFoundComponent {}

--- a/apps/web-mzima-client/src/app/shared/shared.module.ts
+++ b/apps/web-mzima-client/src/app/shared/shared.module.ts
@@ -62,6 +62,7 @@ import { DirectiveModule } from './directive.module';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { AddPostModalComponent } from '@post';
 import { MzimaUiModule } from '@mzima-client/mzima-ui';
+import { DeploymentNotFoundComponent } from './components/deployment-not-found/deployment-not-found.component';
 
 const components = [
   SidebarComponent,
@@ -93,6 +94,7 @@ const components = [
   AccessDeniedComponent,
   SafePipe,
   DeleteContactModalComponent,
+  DeploymentNotFoundComponent,
 ];
 
 const modules = [

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -25,7 +25,7 @@
     "add_all_fields": "Add all fields",
     "insert_text_here": "Insert text here...",
     "deployment_not_found" : {
-      "text" : "There is no deployment by that name. Would you like to create one?",
+      "text" : "Sorry, that deployment does not exist. Would you like to create a new deployment?",
       "button_exit" : "Exit",
       "button_create_deployment" : "Create Deployment"
     },

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -24,6 +24,11 @@
     "choose": "Choose...",
     "add_all_fields": "Add all fields",
     "insert_text_here": "Insert text here...",
+    "deployment_not_found" : {
+      "text" : "There is no deployment by that name. Would you like to create one?",
+      "button_exit" : "Exit",
+      "button_create_deployment" : "Create Deployment"
+    },
     "documentation": {
       "title": "Documentation",
       "description": "Learn how to set up, configure, and manage your Ushahidi deployment."
@@ -664,6 +669,7 @@
     "comments": "Comments",
     "data_sources": "Data Sources",
     "data_import": "Data Import",
+    "deployment_not_found": "Deployment Not Found",
     "deselect": "Deselect",
     "edit_profile": "Edit Profile",
     "edit_post_type": "Edit Survey",


### PR DESCRIPTION
Issue:

On ushahidi.io, when a user goes to a deployment that doesnt exist or has been deleted, the multi-site handling does not prevent the frontend from continually trying the backend, and the user does not receive any information about what is happening.

Solution:

When the frontend receives the "No Deployment Found" response from the backend, it immediately blocks all subsequent backend requests and puts up an alert to the user. The alert allows the user to choose to create a new deployment or exit the site.

Testing Plan:

Go to a non existent deployment, eg. thisisntadeployment.ushahidi.io
Check that all backend requests are halted.
Note the alert dialog
Click "create new deployment" and be redirected to ushahidi.io/create, or click "exit" and be taken away from the site.