### PR TITLE
Removing duplicated, unused language-strings

### DIFF
--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -769,7 +769,6 @@
     "can_see_this": "can see this",
     "add_post_type": "Add {{form_name}}",
     "edit_post_type": "Edit {{form_name}}",
-    "messages": "Message Thread",
     "post": "Post",
     "message": "Message",
     "message_thread": "Message Thread",
@@ -1263,7 +1262,6 @@
       "saving_changes": "Saving",
       "unavailable": "The datasource {{value}} is unavailable. <a href=\"/settings/plan\">Upgrade your plan</a> to get it!",
       "email": {
-        "email_desc": "In order to receive posts by email, please input your email account settings below",
         "incoming_server_type": "Incoming Server Type",
         "incoming_server_type_pop": "POP",
         "incoming_server_type_imap": "IMAP",
@@ -1291,7 +1289,6 @@
         "outgoing_username": "Outgoing Username",
         "outgoing_password": "Outgoing Password",
         "email_address": "Email Address",
-        "email_desc": "This will be used to send outgoing emails",
         "email_sender_name": "Email Sender Name",
         "email_sender_name_desc": "Appears in the 'from:' field on outgoing emails"
       },
@@ -1763,7 +1760,6 @@
       "destroy_success": "Post {{name}} deleted",
       "destroy_success_bulk": "Posts deleted",
       "destroy_confirm": "Are you sure you want to delete this post?",
-      "destroy_success": "Post deleted",
       "destroy_error": "Unable to delete post, please try again",
       "bulk_destroy_confirm": "Are you sure you want to delete {{count}} posts?",
       "stage_save_success": "Updated {{stage}}",
@@ -2699,7 +2695,6 @@
     "notAnArray": "Post values for {{param1}} must be an array",
     "scalar": "Post values for {{param1}} must be scalar",
     "doesTranslationExist": "Translation {{value}} for post {{param2}} already exists",
-    "isSlugAvailable": "{{field}} {{value}} is already in use",
     "published_to": {
       "exists": "The role you are publishing to {{value}} does not exist"
     },
@@ -2725,7 +2720,6 @@
       "url": "The field {{param1}} must be a url, Given: {{param2}}",
       "video_type": "The field {{param1}} must be either a youtube or vimeo url, Given: {{param2}}"
     },
-    "isSlugAvailable": "field: {{value}} is already in use",
     "role": {
       "isRoleValid": "Role must match the parent category",
       "exists": "Role {{value}} does not exist"


### PR DESCRIPTION
Removing some strings from en.json, that had duplicates and also was unused in the web-client code.