### PR TITLE
[USH-1316] Notify users that deleting Survey will delete all posts forever

### DIFF
--- a/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
@@ -90,9 +90,10 @@ export class SurveysComponent implements OnInit {
       description: `
         <p>${
           this.selectedSurveys.length > 1
-            ? 'Deleting these surveys will remove it from database. This action cannot be undone.'
+            ? 'Deleting these selected surveys will also delete all collected posts and all associated data. This step cannot be reversed.'
             : this.translate.instant('notify.survey.destroy_confirm_desc')
         }</p>
+        <p>${this.translate.instant('notify.survey.destroy_confirm_desc_end')}</p>
       `,
 
       confirmButtonText: this.translate.instant('app.yes_delete'),

--- a/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
@@ -85,12 +85,12 @@ export class SurveysComponent implements OnInit {
     const confirmed = await this.confirmModalService.open({
       title:
         this.selectedSurveys.length > 1
-          ? 'Are you sure you want to delete selected surveys?'
+          ? this.translate.instant('notify.survey.bulk_destroy_confirm')
           : this.translate.instant('notify.survey.destroy_confirm'),
       description: `
         <p>${
           this.selectedSurveys.length > 1
-            ? 'Deleting these selected surveys will also delete all collected posts and all associated data. This step cannot be reversed.'
+            ? this.translate.instant('notify.survey.bulk_destroy_confirm_desc')
             : this.translate.instant('notify.survey.destroy_confirm_desc')
         }</p>
         <p>${this.translate.instant('notify.survey.destroy_confirm_desc_end')}</p>

--- a/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
@@ -82,15 +82,16 @@ export class SurveysComponent implements OnInit {
   }
 
   async deleteSurvey() {
+    const surveyCountVariable = { count: this.selectedSurveys.length };
     const confirmed = await this.confirmModalService.open({
       title:
         this.selectedSurveys.length > 1
-          ? this.translate.instant('notify.survey.bulk_destroy_confirm')
+          ? this.translate.instant('notify.survey.bulk_destroy_confirm', surveyCountVariable)
           : this.translate.instant('notify.survey.destroy_confirm'),
       description: `
         <p>${
           this.selectedSurveys.length > 1
-            ? this.translate.instant('notify.survey.bulk_destroy_confirm_desc')
+            ? this.translate.instant('notify.survey.bulk_destroy_confirm_desc', surveyCountVariable)
             : this.translate.instant('notify.survey.destroy_confirm_desc')
         }</p>
         <p>${this.translate.instant('notify.survey.destroy_confirm_desc_end')}</p>

--- a/apps/web-mzima-client/src/app/shared/components/confirm-modal/confirm-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/confirm-modal/confirm-modal.component.html
@@ -45,7 +45,11 @@
       >
         {{ data.cancelButtonText || ('app.cancel' | translate) }}
       </mzima-client-button>
-      <mzima-client-button [mat-dialog-close]="true" [data-qa]="'btn-confirm-delete'">
+      <mzima-client-button
+        color="danger"
+        [mat-dialog-close]="true"
+        [data-qa]="'btn-confirm-delete'"
+      >
         {{ data.confirmButtonText || ('app.delete' | translate) }}
       </mzima-client-button>
     </ng-container>

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -1876,7 +1876,8 @@
       "upload_complete": "Upload complete. You should now see your tagged data in your HDX account."
     },
     "survey": {
-      "bulk_destroy_confirm": "Are you sure you want to delete {{count}} surveys?",
+      "bulk_destroy_confirm": "Are you sure you want to delete these surveys?",
+      "bulk_destroy_confirm_desc": "Deleting these selected surveys will also delete all collected posts and all associated data. This step cannot be reversed.",
       "destroy_confirm": "Are you sure you want to delete this survey?",
       "destroy_confirm_desc": "Deleting this survey will also delete all collected posts and all associated data. This step cannot be reversed.",
       "destroy_confirm_desc_end": "You can <a href=\"settings/data-import\">download and import</a> all your data before deleting."

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -1878,7 +1878,8 @@
     "survey": {
       "bulk_destroy_confirm": "Are you sure you want to delete {{count}} surveys?",
       "destroy_confirm": "Are you sure you want to delete this survey?",
-      "destroy_confirm_desc": "Deleting this survey will remove it from database. This action cannot be undone."
+      "destroy_confirm_desc": "Deleting this survey will also delete all collected posts and all associated data. This step cannot be reversed.",
+      "destroy_confirm_desc_end": "You can <a href=\"settings/data-import\">download and import</a> all your data before deleting."
     },
     "confirm_modal": {
       "add_post_success": {

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -1876,10 +1876,10 @@
       "upload_complete": "Upload complete. You should now see your tagged data in your HDX account."
     },
     "survey": {
-      "bulk_destroy_confirm": "Are you sure you want to delete these surveys?",
-      "bulk_destroy_confirm_desc": "Deleting these selected surveys will also delete all collected posts and all associated data. This step cannot be reversed.",
+      "bulk_destroy_confirm": "Are you sure you want to delete these {{count}} surveys?",
+      "bulk_destroy_confirm_desc": "Deleting these {{count}} selected surveys will also delete all collected posts and all associated data in the surveys. This step cannot be reversed.",
       "destroy_confirm": "Are you sure you want to delete this survey?",
-      "destroy_confirm_desc": "Deleting this survey will also delete all collected posts and all associated data. This step cannot be reversed.",
+      "destroy_confirm_desc": "Deleting this survey will also delete all collected posts and all associated data in the survey. This step cannot be reversed.",
       "destroy_confirm_desc_end": "You can <a href=\"settings/data-import\">download and import</a> all your data before deleting."
     },
     "confirm_modal": {


### PR DESCRIPTION
**Fixes the following**
- Update survey delete popup up modal text to show that all posts will be deleted along with the survey.
- Change confirm delete button to danger to match figma design