### PR TITLE
Adjusting modal to work for add-post-to-collection-view

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/collection-item/collection-item.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/collection-item/collection-item.component.html
@@ -2,6 +2,7 @@
   matRipple
   class="collection-item"
   (click)="selectable && changeChecked($event)"
+  (keydown.space)="selectable && changeChecked($event)"
   [ngClass]="{ 'collection-item--has-checkbox': selectable }"
   [attr.data-qa]="'collection-item'"
 >

--- a/apps/web-mzima-client/src/app/shared/components/collection-item/collection-item.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/collection-item/collection-item.component.scss
@@ -30,6 +30,10 @@
     }
   }
 
+  .cdk-keyboard-focused {
+    border: 2px solid var(--color-black);
+  }
+
   &__control {
     --size: 20px;
     margin: 0 4px;

--- a/apps/web-mzima-client/src/app/shared/components/collections/collections.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/collections/collections.component.html
@@ -76,13 +76,13 @@
 
   <ng-container *ngIf="!isLoading; else loader">
     <div mat-dialog-content>
-      <div class="collection-list">
+      <div class="collection-list" *ngIf="!post">
         <a
           *ngFor="let item of collectionList"
           [routerLink]="['/collections', item.id]"
           class="collection-list__item"
-          [class.checked]="isPostInCollection(item)"
           (click)="goToCollection(item)"
+          (keydown.space)="goToCollection(item)"
           [data-qa]="'collection-item'"
         >
           <app-collection-item
@@ -90,11 +90,22 @@
             [actions]="item.my_collection || isManageCollections"
             (edit)="editCollection(item, $event)"
             (delete)="deleteCollection(item, $event)"
-            [selectable]="post && !!post.id"
-            [checked]="isPostInCollection(item)"
           >
           </app-collection-item>
         </a>
+      </div>
+      <div class="collection-list" *ngIf="post">
+        <app-collection-item
+          *ngFor="let item of collectionList"
+          [collection]="item"
+          [actions]="item.my_collection || isManageCollections"
+          [selectable]="post && !!post.id"
+          class="collection-list__item"
+          [data-qa]="'collection-item'"
+          [checked]="isPostInCollection(item)"
+          (checkedChange)="onCheckChange($event, item)"
+        >
+        </app-collection-item>
       </div>
     </div>
   </ng-container>


### PR DESCRIPTION
Small adjustments to make the collection-modal work for both when selecting "Collections" in the navbar and and "Add to collection" in the post-header.
To test:

1. Navigate to the Collection-link with the keyboard
2. Use the tab-key to focus on a collection-box
- [ ] The collection box, the pen icon and the trash icon should all be focusable and selectable from the keyboard (with the space-key)
3. Go to data-view
4. Navigate to ... in the post-header and select "Add to collection"
5. Use the tab-key to focus on a collection-box
- [ ] The collection-box should only have a checkbox
- [ ] The checkbox is focusable and there is an outline around the checkbox