### PR TITLE
[USH-1500] Sign up form field placeholder and hint text is incorrect

### DIFF
--- a/apps/mobile-mzima-client/src/app/auth/login/login.page.html
+++ b/apps/mobile-mzima-client/src/app/auth/login/login.page.html
@@ -20,7 +20,7 @@
           label="Email"
           [required]="true"
           formControlName="email"
-          placeholder="Enter your email"
+          placeholder="{{'app.placeholder_enter_email' | translate}}"
           [errors]="fieldErrorMessages(form.controls['email'], 'email')"
         >
         </app-form-control>
@@ -30,7 +30,7 @@
           [required]="true"
           [togglePassword]="true"
           formControlName="password"
-          placeholder="Enter password"
+          placeholder="{{'app.placeholder_enter_password' | translate}}"
           [errors]="fieldErrorMessages(form.controls['password'], 'password')"
         >
           <div class="forgot-password-button" button>

--- a/apps/mobile-mzima-client/src/app/auth/signup/signup.page.html
+++ b/apps/mobile-mzima-client/src/app/auth/signup/signup.page.html
@@ -9,8 +9,7 @@
             label="Name"
             [required]="true"
             formControlName="name"
-            placeholder="{{'app.enter_name' | translate}}"
-            hint="{{'app.display_name_hint' | translate}}"
+            placeholder="{{'app.placeholder_enter_name' | translate}}"
             [errors]="fieldErrorMessages(form.controls['name'], 'name')"
           >
           </app-form-control>
@@ -19,7 +18,7 @@
             label="Email"
             [required]="true"
             formControlName="email"
-            placeholder="{{'app.enter_email' | translate}}"
+            placeholder="{{'app.placeholder_enter_email' | translate}}"
             [errors]="fieldErrorMessages(form.controls['email'], 'email')"
           >
           </app-form-control>
@@ -29,9 +28,9 @@
             [required]="true"
             [togglePassword]="true"
             formControlName="password"
-            placeholder="{{'app.enter_password' | translate}}"
+            placeholder="{{'app.placeholder_enter_password' | translate}}"
             [errors]="fieldErrorMessages(form.controls['password'], 'password')"
-            [hint]="!form.controls['password'].value?.length ? 'Password should have at least 8 characters, one lowercase letter, one uppercase letter, one number and one symbol.' : undefined"
+            [hint]="!form.controls['password'].value?.length ? 'app.password_hint' : undefined"
           >
             <app-password-strength
               additional

--- a/apps/mobile-mzima-client/src/app/shared/components/form-control/form-control.component.html
+++ b/apps/mobile-mzima-client/src/app/shared/components/form-control/form-control.component.html
@@ -69,9 +69,14 @@
     </span>
   </ion-item>
   <span *ngIf="hintHTML?.length" class="hint ion-padding-horizontal" [innerHTML]="hintHTML"></span>
-  <span *ngIf="hint?.length && (!errors?.length || isOnFocus)" class="hint ion-padding-horizontal">
-    {{ hint }}
-  </span>
+  <ng-container *ngIf="hint">
+    <span
+      *ngIf="hint?.length && (!errors?.length || isOnFocus)"
+      class="hint ion-padding-horizontal"
+    >
+      {{ hint | translate }}
+    </span>
+  </ng-container>
   <ng-container *ngIf="!isOnFocus && errors?.length">
     <ion-text *ngFor="let error of errors" color="danger" class="error-msg ion-padding-horizontal">
       {{ error }}

--- a/apps/mobile-mzima-client/src/assets/locales/en.json
+++ b/apps/mobile-mzima-client/src/assets/locales/en.json
@@ -2,6 +2,10 @@
     "app": {
       "activity_view_wip": "Activity View coming soon",
       "welcome_back": "Welcome Back!",
+      "placeholder_enter_name": "Enter your name",
+      "placeholder_enter_email": "Enter your email",
+      "placeholder_enter_password": "Enter password",
+      "password_hint": "Password should have at least 8 characters, one lowercase letter, one uppercase letter, one number and one symbol.",
       "login_private": "Log in to private Deployment",
       "login_details_desc": "Please enter your login details to access the deployment. Or contact the Admin",
       "forgot_password": "Forgot your password?",


### PR DESCRIPTION
**Fixes the following**
- Fix broken placeholder and hint signup/login input field texts, and translate them.