### PR TITLE
[USH-1507] The language dropdown icon disappears when the language abbreviation is longer than 2 letters.

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/language/language.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/language/language.component.scss
@@ -44,7 +44,7 @@
     align-items: center;
     text-transform: uppercase;
     // padding-inline-start: 11px;
-    justify-content: space-between;
+    justify-content: center;
 
     &__arrow {
       flex-shrink: 0;

--- a/apps/web-mzima-client/src/app/shared/components/toolbar/toolbar.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/toolbar/toolbar.component.scss
@@ -53,7 +53,7 @@
   }
 
   &__language {
-    width: 50px;
+    width: 75px;
     display: block;
     margin-inline-start: 16px;
   }


### PR DESCRIPTION
CSS Adjustments to language dropdown