### PR TITLE
[USH-1487] Data export as a CSV file is not updated immediately in the Export History

### DIFF
--- a/apps/web-mzima-client/src/app/settings/data-export/data-export.component.ts
+++ b/apps/web-mzima-client/src/app/settings/data-export/data-export.component.ts
@@ -94,7 +94,14 @@ export class DataExportComponent implements OnInit {
   exportAll() {
     this.pollingService
       .startExport({ send_to_hdx: false, include_hxl: false, send_to_browser: true })
-      .subscribe();
+      .subscribe({
+        next: () => {
+          this.loadExportJobs();
+        },
+        error: (err) => {
+          console.error('Export failed: ', err);
+        },
+      });
   }
 
   selectAll(form: FormInterface) {
@@ -129,7 +136,14 @@ export class DataExportComponent implements OnInit {
     });
     this.pollingService
       .startExport({ fields, send_to_hdx: false, include_hxl: false, send_to_browser: true })
-      .subscribe();
+      .subscribe({
+        next: () => {
+          this.loadExportJobs();
+        },
+        error: (err) => {
+          console.error('Export failed: ', err);
+        },
+      });
   }
 
   selectFields() {


### PR DESCRIPTION
**Describe the bug**
Data export as a CSV file is not updated immediately in the Export History but rather after refreshing the page.

**Approach**
Calling the `loadExportJobs()` method every time a user exports 'all data' or 'selected fields' so as to refresh the list without requiring a page reload/refresh.