### PR TITLE
USH-1267 - Fixed radio option wrapping bug

### DIFF
--- a/apps/mobile-mzima-client/src/app/shared/components/radio/radio.component.html
+++ b/apps/mobile-mzima-client/src/app/shared/components/radio/radio.component.html
@@ -30,7 +30,9 @@
       [labelPlacement]="type === 'default' ? 'end' : 'start'"
       [justify]="justify"
     >
-      <ng-content></ng-content>
+      <span class="radio-item-wrap">
+        <ng-content></ng-content>
+      </span>
     </ion-radio>
   </ion-item>
 </ng-template>

--- a/apps/mobile-mzima-client/src/app/shared/components/radio/radio.component.scss
+++ b/apps/mobile-mzima-client/src/app/shared/components/radio/radio.component.scss
@@ -70,6 +70,10 @@
     //margin: 10px 18px 10px 10px;
   }
 
+  .radio-item-wrap {
+    white-space: normal;
+  }
+
   &::ng-deep {
     .info {
       display: block;


### PR DESCRIPTION
**Issue:**
The radio button options in the mobile app would be truncated with ... added if they exceeded a certain length (device dependent).

**Solution:**
This fix allows the radio button options to wrap within the radio selection div.

**Testing:**
Long radio button options wrap effectively.