### PR TITLE
Ush 1458 Deployment not found issues

### DIFF
--- a/apps/web-mzima-client/src/app/app.component.html
+++ b/apps/web-mzima-client/src/app/app.component.html
@@ -1,5 +1,11 @@
 <app-onboarding
-  *ngIf="!isOnboardingDone && isDesktop && checkAllowedAccessToSite() && showOnboarding"
+  *ngIf="
+    !isOnboardingDone &&
+    deploymentFound &&
+    isDesktop &&
+    checkAllowedAccessToSite() &&
+    showOnboarding
+  "
 ></app-onboarding>
 
 <mat-sidenav-container
@@ -32,6 +38,6 @@
   </mat-sidenav-content>
 </mat-sidenav-container>
 
-<app-cookies-notification></app-cookies-notification>
+<app-cookies-notification *ngIf="deploymentFound"></app-cookies-notification>
 
 <app-spinner fullscreen="true" *ngIf="isShowLoader"></app-spinner>

--- a/apps/web-mzima-client/src/app/app.component.ts
+++ b/apps/web-mzima-client/src/app/app.component.ts
@@ -16,7 +16,7 @@ import {
   LoaderService,
   SessionService,
 } from '@services';
-import { filter } from 'rxjs';
+import { debounceTime, filter } from 'rxjs';
 import { BaseComponent } from './base.component';
 import { EnumGtmEvent } from './core/enums/gtm';
 import { Intercom } from '@supy-io/ngx-intercom';
@@ -35,6 +35,7 @@ export class AppComponent extends BaseComponent implements OnInit {
   public isRTL?: boolean;
   public isOnboardingDone = false;
   public showOnboarding = true;
+  public deploymentFound = false;
 
   constructor(
     protected override sessionService: SessionService,
@@ -98,6 +99,17 @@ export class AppComponent extends BaseComponent implements OnInit {
     this.eventBusService.on(EventType.ShowOnboarding).subscribe({
       next: () => (this.isOnboardingDone = false),
     });
+
+    this.sessionService.configLoaded$
+      .pipe(
+        debounceTime(500),
+        filter((configLoaded) => configLoaded === true),
+      )
+      .subscribe(() => {
+        if (this.sessionService.siteFound) {
+          this.deploymentFound = true;
+        }
+      });
 
     const isOnboardingDone = localStorage.getItem(
       this.sessionService.getLocalStorageNameMapper('is_onboarding_done')!,

--- a/apps/web-mzima-client/src/app/core/guards/deployment-found.guard.ts
+++ b/apps/web-mzima-client/src/app/core/guards/deployment-found.guard.ts
@@ -11,7 +11,7 @@ export class DeploymentFoundGuard implements CanActivate {
 
   canActivate(): Observable<boolean | UrlTree> {
     return this.service.configLoaded$.pipe(
-      filter((configLoaded) => configLoaded !== undefined),
+      filter((configLoaded) => configLoaded !== false),
       take(1),
       switchMap((configLoaded) => {
         const siteFound: boolean = this.service.siteFound;

--- a/apps/web-mzima-client/src/app/core/services/config.service.ts
+++ b/apps/web-mzima-client/src/app/core/services/config.service.ts
@@ -47,7 +47,7 @@ export class ConfigService {
           },
           error: (error) => {
             if (error.status === 404 && error.error.errors[0].message === 'Deployment not found')
-              this.sessionService.configLoaded = false;
+              this.sessionService.configLoaded = true;
             else setTimeout(() => this.getConfig(), 5000);
           },
         }),


### PR DESCRIPTION
**Issues:**

- If the backend returns config too slowly, the deployment will be incorrectly "not found".
- The not found page should block the loading of the onboarding and cookie modals.

**Solution:**

This PR changes the deployment not found guard logic to not pass until it has gotten a response from the backend for the initial config call. It also adds checks for the aforementioned modals to prevent them from displaying until it has a response from the backend and found a deployment.

**Testing:**

- An unknown deployment will display the not found page, with no cookie or onboarding displayed.
- The not found page doesnt display for deployments that exist.