### PR TITLE
Using only-parameters for surveys

### DIFF
--- a/apps/web-mzima-client/src/app/post/add-post-modal/add-post-modal.component.html
+++ b/apps/web-mzima-client/src/app/post/add-post-modal/add-post-modal.component.html
@@ -14,19 +14,18 @@
 <strong mat-dialog-title>{{ 'survey.choose_survey' | translate }}</strong>
 
 <div mat-dialog-content>
-  <app-spinner class="spinner" *ngIf="!types"></app-spinner>
-  <ul role="list" class="types-list" *ngIf="!!types" [data-qa]="'add-post-modal-surveys'">
-    <li *ngFor="let type of types">
+  <app-spinner class="spinner" *ngIf="!surveys"></app-spinner>
+  <ul role="list" class="types-list" [data-qa]="'add-post-modal-surveys'">
+    <li *ngFor="let survey of surveys | async">
       <div
         matRipple
-        *ngIf="type.visible"
         role="listitem"
-        [ngStyle]="{ '--color': type.color }"
-        [mat-dialog-close]="{ type: type.id }"
+        [ngStyle]="{ '--color': survey.color }"
+        [mat-dialog-close]="{ type: survey.id }"
         class="type-item"
-        [data-qa]="'add-post-modal-surveys-item' + type.id"
+        [data-qa]="'add-post-modal-surveys-item' + survey.id"
       >
-        {{ type.name }}
+        {{ survey.name }}
       </div>
     </li>
   </ul>

--- a/apps/web-mzima-client/src/app/post/add-post-modal/add-post-modal.component.ts
+++ b/apps/web-mzima-client/src/app/post/add-post-modal/add-post-modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { SurveysService, generalHelpers } from '@mzima-client/sdk';
+import { SurveysService, generalHelpers, apiHelpers } from '@mzima-client/sdk';
 import { Observable, of } from 'rxjs';
 @Component({
   selector: 'app-add-post-modal',
@@ -16,7 +16,7 @@ export class AddPostModalComponent implements OnInit {
 
   private getSurveys(): void {
     this.surveysService
-      .getSurveys('', { only: 'name,color,everyone_can_create,can_create' })
+      .getSurveys('', { only: apiHelpers.ONLY.NAME_COLOR_PERMISSIONS })
       .subscribe(({ results }) => {
         let surveys = this.mapVisibility(results);
         surveys = surveys.filter((survey: any) => survey.visible === true);

--- a/apps/web-mzima-client/src/app/post/add-post-modal/add-post-modal.component.ts
+++ b/apps/web-mzima-client/src/app/post/add-post-modal/add-post-modal.component.ts
@@ -1,30 +1,37 @@
-import { Component } from '@angular/core';
-import { SurveysService, SurveyItem, generalHelpers } from '@mzima-client/sdk';
-
+import { Component, OnInit } from '@angular/core';
+import { SurveysService, generalHelpers } from '@mzima-client/sdk';
+import { Observable, of } from 'rxjs';
 @Component({
   selector: 'app-add-post-modal',
   templateUrl: './add-post-modal.component.html',
   styleUrls: ['./add-post-modal.component.scss'],
 })
-export class AddPostModalComponent {
-  public types: SurveyItem[];
+export class AddPostModalComponent implements OnInit {
+  public surveys: Observable<any>;
 
-  constructor(private surveysService: SurveysService) {
-    this.getPostAllowedTypes();
+  constructor(private surveysService: SurveysService) {}
+  ngOnInit() {
+    this.getSurveys();
   }
 
-  private getPostAllowedTypes(): void {
-    this.surveysService.get().subscribe({
-      next: (types) => {
-        this.types = types.results || [];
-        this.types.map((el) => {
-          el.visible =
-            el.everyone_can_create ||
-            el.can_create.includes(
-              localStorage.getItem(`${generalHelpers.CONST.LOCAL_STORAGE_PREFIX}role`),
-            );
-        });
-      },
+  private getSurveys(): void {
+    this.surveysService
+      .getSurveys('', { only: 'name,color,everyone_can_create,can_create' })
+      .subscribe(({ results }) => {
+        let surveys = this.mapVisibility(results);
+        surveys = surveys.filter((survey: any) => survey.visible === true);
+        this.surveys = of(surveys);
+      });
+  }
+
+  private mapVisibility(surveys: any) {
+    return surveys.map((el: any) => {
+      el.visible =
+        el.everyone_can_create ||
+        el.can_create.includes(
+          localStorage.getItem(`${generalHelpers.CONST.LOCAL_STORAGE_PREFIX}role`),
+        );
+      return el;
     });
   }
 }

--- a/apps/web-mzima-client/src/app/settings/data-import/data-import.component.html
+++ b/apps/web-mzima-client/src/app/settings/data-import/data-import.component.html
@@ -26,12 +26,11 @@
     <mat-select
       [data-qa]="'select-survey'"
       disableOptionCentering
-      [(value)]="selectedForm"
       placeholder="{{ 'survey.choose_survey' | translate }}"
-      (selectionChange)="formChanged()"
+      (selectionChange)="formChanged($event.value)"
     >
-      <mat-option *ngFor="let option of surveys | async" [value]="option">
-        {{ option.name }}
+      <mat-option *ngFor="let survey of surveys" [value]="survey">
+        {{ survey.name }}
       </mat-option>
     </mat-select>
   </mat-form-field>
@@ -167,7 +166,7 @@
                 [placeholder]="'data_import.leave_empty' | translate"
               >
                 <mat-option selected="selected" value="">
-                  {{ 'data_import.leave_empty' | translate }} {{ field.key }}
+                  {{ 'data_import.leave_empty' | translate }}
                 </mat-option>
                 <mat-option *ngFor="let column of uploadedCSV.columns; let i = index" [value]="i">
                   {{ column }}

--- a/apps/web-mzima-client/src/app/settings/data-import/data-import.component.ts
+++ b/apps/web-mzima-client/src/app/settings/data-import/data-import.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { omit, clone, invert, keys, includes } from 'lodash';
 import { TranslateService } from '@ngx-translate/core';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import {
   DataImportService,
   FormsService,
@@ -43,11 +43,12 @@ export class DataImportComponent extends BaseComponent implements OnInit {
   uploadErrors: any[] = [];
   importErrors: boolean = false;
   fileChanged = false;
-  public surveys: Observable<any>;
+  public surveys: SurveyItem[] = [];
 
   statusOption: string;
   selectedStatus: PostStatus;
   displayedColumns: string[] = ['survey', 'csv'];
+  public isLoading = false;
 
   constructor(
     protected override sessionService: SessionService,
@@ -72,8 +73,12 @@ export class DataImportComponent extends BaseComponent implements OnInit {
   }
 
   getSurveys() {
-    this.surveysService.get().subscribe((result) => {
-      this.surveys = of(result.results);
+    this.isLoading = true;
+    this.surveysService.getSurveys('', { only: 'id,name' }).subscribe({
+      next: (result) => {
+        this.isLoading = false;
+        this.surveys = result.results;
+      },
     });
   }
   loadData(): void {}
@@ -197,7 +202,11 @@ export class DataImportComponent extends BaseComponent implements OnInit {
     return field.key;
   }
 
-  formChanged() {
+  formChanged(selectedSurvey: SurveyItem) {
+    this.selectedForm = selectedSurvey;
+    this.surveysService.getSurveyById(this.selectedForm.id).subscribe((result) => {
+      this.selectedForm = result.result;
+    });
     if (this.selectedFile && this.selectedForm) {
       this.checkFormAndFile();
     }

--- a/apps/web-mzima-client/src/app/settings/data-import/data-import.component.ts
+++ b/apps/web-mzima-client/src/app/settings/data-import/data-import.component.ts
@@ -10,6 +10,7 @@ import {
   FormInterface,
   SurveysService,
   SurveyItem,
+  apiHelpers,
 } from '@mzima-client/sdk';
 
 import { BaseComponent } from '../../base.component';
@@ -74,7 +75,7 @@ export class DataImportComponent extends BaseComponent implements OnInit {
 
   getSurveys() {
     this.isLoading = true;
-    this.surveysService.getSurveys('', { only: 'id,name' }).subscribe({
+    this.surveysService.getSurveys('', { only: apiHelpers.ONLY.NAME_ID }).subscribe({
       next: (result) => {
         this.isLoading = false;
         this.surveys = result.results;

--- a/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.html
+++ b/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.html
@@ -21,6 +21,7 @@
     (selectLanguageCall)="chooseTranslation($event)"
   >
   </app-settings-header>
+  <app-spinner class="spinner" *ngIf="isLoading"></app-spinner>
 
   <app-survey-task
     #configTask
@@ -29,7 +30,7 @@
     [isMain]="true"
     [survey]="surveyObject"
     (taskChange)="taskUpdate($event)"
-    *ngIf="mainPost"
+    *ngIf="mainPost && !isLoading"
     (colorSelected)="setNewColor($event)"
     (languageChange)="languageChange($event)"
     [isDefaultLanguageSelected]="isDefaultLanguageSelected"
@@ -107,7 +108,7 @@
   </app-survey-task>
 </form>
 
-<div class="form-head-panel">
+<div class="form-head-panel" *ngIf="!isLoading">
   <h1>{{ 'survey.tasks' | translate }}</h1>
   <mzima-client-button
     color="secondary"
@@ -134,7 +135,7 @@
 </ng-container>
 
 <ng-template #noTasks>
-  <div class="form-row empty">{{ 'survey.no_tasks' | translate }}</div>
+  <div class="form-row empty" *ngIf="!isLoading">{{ 'survey.no_tasks' | translate }}</div>
 </ng-template>
 
 <div class="form-controls-spacer" *ngIf="!isDesktop"></div>

--- a/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.ts
@@ -38,6 +38,7 @@ export class SurveyItemComponent extends BaseComponent implements OnInit {
   public name: string;
   public form: FormGroup;
   public isEdit = false;
+  public isLoading = false;
   roles: RoleResult[] = [];
   surveyId: string;
   additionalTasks: SurveyItemTask[] = [];
@@ -114,10 +115,12 @@ export class SurveyItemComponent extends BaseComponent implements OnInit {
     this.initRoles();
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
+      this.isLoading = true;
       this.surveyId = id;
       this.isEdit = !!id;
       this.surveysService.getSurveyById(id).subscribe({
         next: (response) => {
+          this.isLoading = false;
           this.updateForm(response.result);
           this.initLanguages(response.result.enabled_languages);
           this.initTasks();

--- a/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
@@ -49,16 +49,13 @@ export class SurveysComponent implements OnInit {
         page: this.params.page,
         order: this.params.order,
         limit: this.params.limit,
+        only: 'name,id,color',
       })
       .subscribe({
         next: (res) => {
           this.surveys = isAdd ? [...this.surveys, ...res.results] : res.results;
           const { current_page: currentPage, last_page: lastPage, total } = res.meta;
           this.params = { ...this.params, current_page: currentPage, last_page: lastPage, total };
-          this.isLoading = false;
-        },
-        error: (err) => {
-          console.log(err);
           this.isLoading = false;
         },
       });

--- a/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/surveys.component.ts
@@ -3,7 +3,7 @@ import { MatCheckboxChange } from '@angular/material/checkbox';
 import { TranslateService } from '@ngx-translate/core';
 import { BreakpointService } from '@services';
 import { forkJoin, Observable, take } from 'rxjs';
-import { SurveysService, SurveyItem } from '@mzima-client/sdk';
+import { SurveysService, SurveyItem, apiHelpers } from '@mzima-client/sdk';
 import { ConfirmModalService } from '../../core/services/confirm-modal.service';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
@@ -49,7 +49,7 @@ export class SurveysComponent implements OnInit {
         page: this.params.page,
         order: this.params.order,
         limit: this.params.limit,
-        only: 'name,id,color',
+        only: apiHelpers.ONLY.NAME_ID_COLOR,
       })
       .subscribe({
         next: (res) => {

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -36,6 +36,7 @@ import {
   SurveyItem,
   AccountNotificationsInterface,
   GeoJsonFilter,
+  apiHelpers,
 } from '@mzima-client/sdk';
 import dayjs from 'dayjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -465,7 +466,10 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
     this.surveysLoaded = false;
 
     forkJoin([
-      this.surveysService.getSurveys('', { only: 'id,name,color', show_unknown_form: true }),
+      this.surveysService.getSurveys('', {
+        only: apiHelpers.ONLY.NAME_ID_COLOR,
+        show_unknown_form: true,
+      }),
       this.getPostsStatistic(),
     ]).subscribe({
       next: (responses) => {

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -465,7 +465,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
     this.surveysLoaded = false;
 
     forkJoin([
-      this.surveysService.get('', { show_unknown_form: true }),
+      this.surveysService.getSurveys('', { only: 'id,name,color', show_unknown_form: true }),
       this.getPostsStatistic(),
     ]).subscribe({
       next: (responses) => {

--- a/libs/sdk/src/lib/helpers/api.ts
+++ b/libs/sdk/src/lib/helpers/api.ts
@@ -9,5 +9,11 @@ export const getApiUrlByDomain = (deploymentInfo: { domain: string; api_domain?:
   )}${location.port ? ':' + location.port : ''}`;
 };
 
+export const ONLY = {
+  NAME_ID: 'name,id',
+  NAME_ID_COLOR: 'name,id,color',
+  NAME_COLOR_PERMISSIONS: 'name,color,everyone_can_create,can_create',
+};
+
 export const API_V_3 = `api/v3/`;
 export const API_V_5 = `api/v5/`;


### PR DESCRIPTION
This PR changes to use only-parameters for surveys for:
- Add post-modal
- Survey-filters
- Edit/add surveys in settings (The survey-list)
- Data import

To test: Smoke-test on above functionalities, they should work as before 😬 