### PR TITLE
[USH-1443] First page of posts not seen on navigating back to My posts page from viewing a post

### DIFF
--- a/apps/mobile-mzima-client/src/app/profile/posts/posts.page.ts
+++ b/apps/mobile-mzima-client/src/app/profile/posts/posts.page.ts
@@ -83,9 +83,12 @@ export class PostsPage {
         },
       });
   }
+  // reset: boolean determines if the posts should reset to first page and clear current list
+  // reloadAll: boolean decides if the function should fetch all posts in a single API call
 
   public async getMyPosts(reset = false, reloadAll = false): Promise<void> {
     this.isPostsLoading = true;
+    //resetting the page to 1 and clearing current posts if true
     if (reset) {
       this.params.page = 1;
       this.posts = [];
@@ -94,6 +97,7 @@ export class PostsPage {
     const originalPage = this.params.page ?? 1;
     const originalLimit = this.params.limit ?? 6;
 
+    //Ensuring all posts upto the current page are fetched in one go once true
     if (reloadAll) {
       this.params.limit = (this.params.page ?? 1) * (this.params.limit ?? 6);
       this.params.page = 1;
@@ -109,6 +113,7 @@ export class PostsPage {
       if (response) {
         this.postDisplayProcessing(response, !reset && !reloadAll);
       }
+      //resetting the parameters if reloadAll is true
     } finally {
       if (reloadAll) {
         this.params.limit = originalLimit;


### PR DESCRIPTION
**Ticket Issue**

When a user selects any posts from ‘my posts’ and then navigates back to the list of posts, not all posts will show up from the top, only posts that belong to the current pagination state onwards.

**Approach**

Introducing two new parameters `reset` and `reloadAll`

- `reset `resets the pagination and clears the post list before fetching new posts from the beginning
- `reload` fetches all posts at once while bypassing pagination. After fetching, the original pagination values are then restored