### PR TITLE
Ush 1415 - bug fixes

### DIFF
--- a/apps/web-mzima-client/src/app/core/helpers/media-helper.ts
+++ b/apps/web-mzima-client/src/app/core/helpers/media-helper.ts
@@ -1,8 +1,6 @@
-import { SafeUrl } from '@angular/platform-browser';
-import { ɵunwrapSafeValue as unwrapSafeValue } from '@angular/core';
 import { MediaFile } from '@mzima-client/sdk';
 
-export function getDocumentThumbnail(mediaFile: MediaFile) {
+export function getDocumentThumbnail(mediaFile: MediaFile): string {
   const path = '/assets/images/logos/';
   let thumbnail = 'unknown_document.png';
   switch (mediaFile.mimeType) {
@@ -17,21 +15,4 @@ export function getDocumentThumbnail(mediaFile: MediaFile) {
       break;
   }
   return path + thumbnail;
-}
-
-// Our media api returns a relative url with a filename that has an id prepended, instead of the original filename.
-// This function attempts to take that url, and return the original filename.
-export function getFileNameFromUrl(url: string | SafeUrl): string {
-  const urlToCheck = unwrapSafeValue(url);
-
-  // Try to use a regex to strip out what we add to the filename and the path
-  const regex = /.*\/[0-9a-fA-F]{13}-(.*)/;
-  const match = urlToCheck.match(regex);
-  if (match && match[1]) return match[1];
-
-  // The url doesnt have the expected filename, so return everything after the final slash
-  const lastSlashIndex = urlToCheck.lastIndexOf('/');
-  const newFilename = lastSlashIndex !== -1 ? urlToCheck.substring(lastSlashIndex + 1) : urlToCheck;
-  const firstHyphenIndex = newFilename.indexOf('-') + 1;
-  return newFilename.substring(firstHyphenIndex);
 }

--- a/apps/web-mzima-client/src/app/core/helpers/media-helper.ts
+++ b/apps/web-mzima-client/src/app/core/helpers/media-helper.ts
@@ -19,25 +19,6 @@ export function getDocumentThumbnail(mediaFile: MediaFile) {
   return path + thumbnail;
 }
 
-export function getFileSize(mediaFile: MediaFile): string {
-  let filesize = 0;
-  if (mediaFile.status === 'ready') filesize = mediaFile.size!;
-  else filesize = mediaFile.file ? mediaFile.file.size : 0;
-
-  // Megabytes
-  if (filesize > 1000000) {
-    return (filesize / 1000000).toFixed(2).toString() + 'MB';
-  }
-  // Kilobytes
-  else if (filesize > 1000) {
-    return (filesize / 1000).toFixed(2).toString() + 'kB';
-  }
-  // Bytes
-  else {
-    return filesize + 'bytes';
-  }
-}
-
 // Our media api returns a relative url with a filename that has an id prepended, instead of the original filename.
 // This function attempts to take that url, and return the original filename.
 export function getFileNameFromUrl(url: string | SafeUrl): string {

--- a/apps/web-mzima-client/src/app/core/helpers/media-helper.ts
+++ b/apps/web-mzima-client/src/app/core/helpers/media-helper.ts
@@ -1,6 +1,6 @@
 import { SafeUrl } from '@angular/platform-browser';
 import { ɵunwrapSafeValue as unwrapSafeValue } from '@angular/core';
-import { MediaFile } from '../interfaces/media';
+import { MediaFile } from '@mzima-client/sdk';
 
 export function getDocumentThumbnail(mediaFile: MediaFile) {
   const path = '/assets/images/logos/';

--- a/apps/web-mzima-client/src/app/core/interfaces/media.ts
+++ b/apps/web-mzima-client/src/app/core/interfaces/media.ts
@@ -1,10 +1,28 @@
 import { SafeUrl } from '@angular/platform-browser';
 
-enum ErrorEnum {
+enum MediaUploaderError {
   NONE = 'none',
   MAX_SIZE = 'post.media.messages.max_size',
   REQUIRED = 'post.media.messages.required',
+  INVALID_TYPE = 'post.media.messages.invalid_type',
   MAX_FILES = 'post.media.messages.max_files',
+}
+
+enum MediaFileError {
+  NONE = 'none',
+  UNKNOWN = 'unknown',
+  TOO_BIG = 'post.media.messages.max_size',
+  INVALID_TYPE = 'post.media.messages.invalid_type',
+}
+
+enum MediaFileStatus {
+  NONE = 'none',
+  READY = 'ready',
+  UPLOAD = 'upload',
+  UPLOADING = 'uploading',
+  UPLOADED = 'uploaded',
+  ERROR = 'error',
+  DELETE = 'delete',
 }
 
 type MediaType = {
@@ -12,15 +30,6 @@ type MediaType = {
   buttonText: string;
   fileTypes: string;
 };
-
-type MediaFileStatus =
-  | 'ready'
-  | 'upload'
-  | 'uploading'
-  | 'uploaded'
-  | 'error'
-  | 'too_big'
-  | 'delete';
 
 const mediaTypes = new Map<string, MediaType>([
   [
@@ -50,18 +59,58 @@ const mediaTypes = new Map<string, MediaType>([
   ],
 ]);
 
-type MediaFile = {
-  id?: number;
+class MediaFile {
+  id: number;
   generatedId: number;
-  file?: File;
+  file: File;
   filename: string;
-  fileExtension?: string;
   url: string | SafeUrl | null;
-  caption?: string;
+  caption: string;
   status: MediaFileStatus;
-  size?: number;
-  mimeType?: string;
-  value?: number;
-};
+  size: number;
+  mimeType: string;
+  value: number;
+  error: MediaFileError = MediaFileError.NONE;
 
-export { MediaFile, MediaFileStatus, MediaType, ErrorEnum, mediaTypes };
+  constructor(file: File, url: string | SafeUrl) {
+    this.id = 0;
+    this.value = 0;
+    this.filename = file.name;
+    this.caption = '';
+    this.size = file.size;
+    this.file = file;
+    this.status = MediaFileStatus.NONE;
+    this.error = MediaFileError.NONE;
+    this.mimeType = file.type;
+    this.url = url;
+    this.generatedId = this.generateId();
+  }
+
+  private generateId(): number {
+    return (
+      Math.floor(Math.random() * (Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER + 1)) +
+      Number.MIN_SAFE_INTEGER
+    );
+  }
+
+  getFileSize(): string {
+    let filesize = 0;
+    if (this.status === MediaFileStatus.READY) filesize = this.size;
+    else filesize = this.file ? this.file.size : 0;
+
+    // Megabytes
+    if (filesize > 1000000) {
+      return (filesize / 1000000).toFixed(2).toString() + 'MB';
+    }
+    // Kilobytes
+    else if (filesize > 1000) {
+      return (filesize / 1000).toFixed(2).toString() + 'kB';
+    }
+    // Bytes
+    else {
+      return filesize + 'bytes';
+    }
+  }
+}
+
+export { MediaFile, MediaFileStatus, MediaType, MediaUploaderError, MediaFileError, mediaTypes };

--- a/apps/web-mzima-client/src/app/core/interfaces/media.ts
+++ b/apps/web-mzima-client/src/app/core/interfaces/media.ts
@@ -1,28 +1,9 @@
-import { SafeUrl } from '@angular/platform-browser';
-
 enum MediaUploaderError {
   NONE = 'none',
   MAX_SIZE = 'post.media.messages.max_size',
   REQUIRED = 'post.media.messages.required',
   INVALID_TYPE = 'post.media.messages.invalid_type',
   MAX_FILES = 'post.media.messages.max_files',
-}
-
-enum MediaFileError {
-  NONE = 'none',
-  UNKNOWN = 'unknown',
-  TOO_BIG = 'post.media.messages.max_size',
-  INVALID_TYPE = 'post.media.messages.invalid_type',
-}
-
-enum MediaFileStatus {
-  NONE = 'none',
-  READY = 'ready',
-  UPLOAD = 'upload',
-  UPLOADING = 'uploading',
-  UPLOADED = 'uploaded',
-  ERROR = 'error',
-  DELETE = 'delete',
 }
 
 type MediaType = {
@@ -45,7 +26,7 @@ const mediaTypes = new Map<string, MediaType>([
     {
       icon: 'speaker',
       buttonText: 'post.media.add_audio',
-      fileTypes: 'audio/mp3, audio/ogg, audio/aac',
+      fileTypes: 'audio/mp3, audio/mpeg, audio/ogg, audio/aac',
     },
   ],
   [
@@ -59,58 +40,4 @@ const mediaTypes = new Map<string, MediaType>([
   ],
 ]);
 
-class MediaFile {
-  id: number;
-  generatedId: number;
-  file: File;
-  filename: string;
-  url: string | SafeUrl | null;
-  caption: string;
-  status: MediaFileStatus;
-  size: number;
-  mimeType: string;
-  value: number;
-  error: MediaFileError = MediaFileError.NONE;
-
-  constructor(file: File, url: string | SafeUrl) {
-    this.id = 0;
-    this.value = 0;
-    this.filename = file.name;
-    this.caption = '';
-    this.size = file.size;
-    this.file = file;
-    this.status = MediaFileStatus.NONE;
-    this.error = MediaFileError.NONE;
-    this.mimeType = file.type;
-    this.url = url;
-    this.generatedId = this.generateId();
-  }
-
-  private generateId(): number {
-    return (
-      Math.floor(Math.random() * (Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER + 1)) +
-      Number.MIN_SAFE_INTEGER
-    );
-  }
-
-  getFileSize(): string {
-    let filesize = 0;
-    if (this.status === MediaFileStatus.READY) filesize = this.size;
-    else filesize = this.file ? this.file.size : 0;
-
-    // Megabytes
-    if (filesize > 1000000) {
-      return (filesize / 1000000).toFixed(2).toString() + 'MB';
-    }
-    // Kilobytes
-    else if (filesize > 1000) {
-      return (filesize / 1000).toFixed(2).toString() + 'kB';
-    }
-    // Bytes
-    else {
-      return filesize + 'bytes';
-    }
-  }
-}
-
-export { MediaFile, MediaFileStatus, MediaType, MediaUploaderError, MediaFileError, mediaTypes };
+export { MediaType, MediaUploaderError, mediaTypes };

--- a/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.html
+++ b/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.html
@@ -34,7 +34,7 @@
             ></audio>
             <div class="media-details">
               <div class="filename">{{ mediaFile.filename }}</div>
-              <div class="filesize">{{ mediaFile.getFileSize() }}</div>
+              <div class="filesize">{{ mediaFile.fileSize }}</div>
             </div>
           </ng-template>
 

--- a/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.html
+++ b/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.html
@@ -22,8 +22,16 @@
               class="thumbnail"
               [src]="getDocumentThumbnail(mediaFile)"
             />
-            <img *ngIf="media === 'image'" class="thumbnail" [src]="mediaFile.url" />
-            <audio *ngIf="media === 'audio'" controls [src]="mediaFile.url"></audio>
+            <img
+              *ngIf="media === 'image'"
+              class="thumbnail"
+              [src]="this.sanitizer.bypassSecurityTrustUrl(mediaFile.url!)"
+            />
+            <audio
+              *ngIf="media === 'audio'"
+              controls
+              [src]="this.sanitizer.bypassSecurityTrustUrl(mediaFile.url!)"
+            ></audio>
             <div class="media-details">
               <div class="filename">{{ mediaFile.filename }}</div>
               <div class="filesize">{{ mediaFile.getFileSize() }}</div>

--- a/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.html
+++ b/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.html
@@ -8,7 +8,8 @@
         >
           <ng-container
             *ngIf="
-              mediaFile.status === 'ready' || mediaFile.status === 'uploaded';
+              mediaFile.status === MediaFileStatus.READY ||
+                mediaFile.status === MediaFileStatus.UPLOADED;
               then itemReady;
               else inProgress
             "
@@ -25,26 +26,28 @@
             <audio *ngIf="media === 'audio'" controls [src]="mediaFile.url"></audio>
             <div class="media-details">
               <div class="filename">{{ mediaFile.filename }}</div>
-              <div class="filesize">{{ getFileSize(mediaFile) }}</div>
+              <div class="filesize">{{ mediaFile.getFileSize() }}</div>
             </div>
           </ng-template>
 
           <ng-template #inProgress>
             <div class="media-blank">
               <mat-icon
-                *ngIf="mediaFile.status === 'error' || mediaFile.status === 'too_big'"
+                *ngIf="mediaFile.status === MediaFileStatus.ERROR"
                 class="xicon"
                 icon
                 svgIcon="warning"
               ></mat-icon>
-              <div class="media-error" *ngIf="mediaFile.status === 'too_big'">
-                {{ ErrorEnum.MAX_SIZE | translate }}
+              <div class="media-error" *ngIf="mediaFile.status === MediaFileStatus.ERROR">
+                {{ mediaFile.error! | translate }}
               </div>
               <app-spinner
                 class="loading-spinner"
-                *ngIf="mediaFile.status === 'uploading'"
+                *ngIf="mediaFile.status === MediaFileStatus.UPLOADING"
               ></app-spinner>
-              <div class="media-status" *ngIf="mediaFile.status === 'uploading'">Uploading...</div>
+              <div class="media-status" *ngIf="mediaFile.status === MediaFileStatus.UPLOADING">
+                Uploading...
+              </div>
             </div>
           </ng-template>
 
@@ -52,7 +55,9 @@
             class="status-button"
             (click)="clickDeleteButton(mediaFile.value, mediaFile.generatedId)"
           >
-            <ng-container *ngIf="mediaFile.status === 'uploaded'; then check; else cross">
+            <ng-container
+              *ngIf="mediaFile.status === MediaFileStatus.UPLOADED; then check; else cross"
+            >
             </ng-container>
             <ng-template #check>
               <mat-icon class="xicon" fontIcon="check"></mat-icon>

--- a/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.scss
+++ b/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.scss
@@ -113,7 +113,7 @@
       column-gap: 4px;
       row-gap: 4px;
       .media-preview {
-        height: 64px;
+        height: 100px;
       }
     }
 

--- a/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.ts
+++ b/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.ts
@@ -13,12 +13,15 @@ import { MediaService } from '@mzima-client/sdk';
 import { TranslateService } from '@ngx-translate/core';
 import { catchError, forkJoin, last, Observable, tap, throwError } from 'rxjs';
 import { ConfirmModalService } from '../../core/services/confirm-modal.service';
-import { ErrorEnum, MediaFile, MediaType, mediaTypes } from '../../core/interfaces/media';
 import {
-  getDocumentThumbnail,
-  getFileNameFromUrl,
-  getFileSize,
-} from '../../core/helpers/media-helper';
+  MediaUploaderError,
+  MediaFileError,
+  MediaFile,
+  MediaType,
+  mediaTypes,
+  MediaFileStatus,
+} from '../../core/interfaces/media';
+import { getDocumentThumbnail, getFileNameFromUrl } from '../../core/helpers/media-helper';
 
 @Component({
   selector: 'app-media-uploader',
@@ -48,7 +51,7 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
   id?: number;
   captionControl = new FormControl('');
   isDisabled = false;
-  error: ErrorEnum = ErrorEnum.NONE;
+  error: MediaUploaderError = MediaUploaderError.NONE;
   mediaType: MediaType;
   onChange: any = () => {};
   onTouched: any = () => {};
@@ -67,10 +70,11 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
     this.mediaType = mediaTypes.get(this.media)!;
   }
 
-  // helper imports for the template
+  // helper method and enum imports for the template
   getDocumentThumbnail = getDocumentThumbnail;
-  getFileSize = getFileSize;
-  ErrorEnum = ErrorEnum;
+  MediaUploaderError = MediaUploaderError;
+  MediaFileError = MediaFileError;
+  MediaFileStatus = MediaFileStatus;
 
   writeValue(obj: MediaFile[]): void {
     if (Array.isArray(obj)) {
@@ -92,11 +96,13 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
 
   validate(): ValidationErrors | null {
     for (const upload of this.mediaFiles) {
-      if (upload.status === 'error') return { uploadError: true };
+      if (upload.status === MediaFileStatus.ERROR) {
+        if (upload.error === MediaFileError.UNKNOWN) return { uploadError: true };
 
-      if (upload.status === 'too_big') return { uploadsInvalid: true };
+        if (upload.error === MediaFileError.TOO_BIG) return { uploadsInvalid: true };
 
-      if (upload.status === 'uploading') return { uploadInProgress: true };
+        if (upload.error === MediaFileError.INVALID_TYPE) return { uploadsInvalid: true };
+      } else if (upload.status === MediaFileStatus.UPLOADING) return { uploadInProgress: true };
     }
     return null;
   }
@@ -109,31 +115,32 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
         this.maxFiles !== -1 &&
         this.mediaFiles.length + inputElement.files.length > this.maxFiles
       ) {
-        this.error = ErrorEnum.MAX_FILES;
+        this.error = MediaUploaderError.MAX_FILES;
         event.preventDefault();
       } else if (inputElement.files.length) {
         for (let i = 0; i < inputElement.files.length; i++) {
           const aFile = inputElement.files.item(i);
           if (aFile) {
             const photoUrl = formHelper.prepareImageFileToUpload(aFile);
-            const mediaFile: MediaFile = {
-              generatedId: this.generateId(),
-              filename: aFile.name,
-              size: aFile.size,
-              file: photoUrl,
-              status: 'uploading',
-              mimeType: aFile.type,
-              url: this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(photoUrl)),
-            };
+            const mediaFile = new MediaFile(
+              aFile,
+              this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(photoUrl)),
+            );
+
             if (mediaFile.size! > this.maxUploadSize * 1000000) {
-              mediaFile.status = 'too_big';
-            }
+              mediaFile.status = MediaFileStatus.ERROR;
+              mediaFile.error = MediaFileError.TOO_BIG;
+            } else if (!this.mediaType.fileTypes.includes(mediaFile.mimeType)) {
+              mediaFile.status = MediaFileStatus.ERROR;
+              mediaFile.error = MediaFileError.INVALID_TYPE;
+            } else mediaFile.status = MediaFileStatus.UPLOADING;
+
             this.mediaFiles.push(mediaFile);
           }
         }
         this.uploads = new Map();
         this.mediaFiles
-          .filter((mediaFile) => mediaFile.status === 'uploading')
+          .filter((mediaFile) => mediaFile.status === MediaFileStatus.UPLOADING)
           .forEach((aMediaFile) => {
             const uploadObservable: Observable<any> = this.mediaService
               .uploadFileProgress(aMediaFile.file!, '')
@@ -154,7 +161,7 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
                       aMediaFile.generatedId,
                       uploadEvent.body,
                       (mediaFile, resultBody) => {
-                        mediaFile.status = 'uploaded';
+                        mediaFile.status = MediaFileStatus.UPLOADED;
                         mediaFile.value = resultBody.result.id;
                         return mediaFile;
                       },
@@ -167,7 +174,7 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
                           mediaFile.generatedId,
                           uploadEvent.body,
                           (theMediaFile) => {
-                            theMediaFile.status = 'ready';
+                            theMediaFile.status = MediaFileStatus.READY;
                             return theMediaFile;
                           },
                         );
@@ -180,7 +187,7 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
                 last(),
                 catchError((error: HttpErrorResponse) => {
                   this.updateMediaFileById(aMediaFile.generatedId, null, (mediaFile) => {
-                    mediaFile.status = 'error';
+                    mediaFile.status = MediaFileStatus.ERROR;
                     return mediaFile;
                   });
                   return throwError(() => new Error(error.statusText));
@@ -202,7 +209,6 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
           }
           this.onChange(this.mediaFiles);
           inputElement.value = '';
-          console.log(results);
         });
       }
       this.onChange(this.mediaFiles);
@@ -224,29 +230,32 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
     }
 
     if (mediaFile) {
-      if (mediaFile.status === 'upload' || mediaFile.status === 'ready') {
+      if (
+        mediaFile.status === MediaFileStatus.UPLOAD ||
+        mediaFile.status === MediaFileStatus.READY
+      ) {
         const confirmed = await this.confirm.open({
           title: this.translate.instant('notify.default.are_you_sure_you_want_to_delete_this'),
           description: this.translate.instant('notify.default.proceed_warning'),
         });
         if (!confirmed) return;
-      } else if (mediaFile.status === 'uploading') {
+      } else if (mediaFile.status === MediaFileStatus.UPLOADING) {
         const uploadObservable = this.uploads.get(generatedId);
         if (uploadObservable) {
           const uploadSubscription = uploadObservable.subscribe(() =>
             uploadSubscription.unsubscribe(),
           );
         }
-      } else {
+      } else if (mediaFile.status !== MediaFileStatus.ERROR) {
         return;
       }
 
-      // this.mediaFiles[index].status = 'delete';
+      // this.mediaFiles[index].status = MediaFileStatus.DELETE;
       this.mediaFiles.splice(index, 1);
-      const filteredItems = this.mediaFiles.filter(
-        (item) => item.status === 'error' || item.status === 'too_big',
-      );
-      if (filteredItems.length === 0) this.error = ErrorEnum.NONE;
+
+      // Check for errors
+      const filteredItems = this.mediaFiles.filter((item) => item.status === MediaFileStatus.ERROR);
+      if (filteredItems.length === 0) this.error = MediaUploaderError.NONE;
     }
     this.onChange(this.mediaFiles);
   }
@@ -279,12 +288,5 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
         i = this.mediaFiles.length;
       }
     }
-  }
-
-  generateId(): number {
-    return (
-      Math.floor(Math.random() * (Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER + 1)) +
-      Number.MIN_SAFE_INTEGER
-    );
   }
 }

--- a/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.ts
+++ b/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.ts
@@ -9,18 +9,11 @@ import {
 } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
 import { formHelper } from '@helpers';
-import { MediaService } from '@mzima-client/sdk';
+import { MediaFile, MediaFileError, MediaFileStatus, MediaService } from '@mzima-client/sdk';
 import { TranslateService } from '@ngx-translate/core';
 import { catchError, forkJoin, last, Observable, tap, throwError } from 'rxjs';
 import { ConfirmModalService } from '../../core/services/confirm-modal.service';
-import {
-  MediaUploaderError,
-  MediaFileError,
-  MediaFile,
-  MediaType,
-  mediaTypes,
-  MediaFileStatus,
-} from '../../core/interfaces/media';
+import { MediaUploaderError, MediaType, mediaTypes } from '../../core/interfaces/media';
 import { getDocumentThumbnail, getFileNameFromUrl } from '../../core/helpers/media-helper';
 
 @Component({

--- a/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.ts
+++ b/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.ts
@@ -14,7 +14,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { catchError, forkJoin, last, Observable, tap, throwError } from 'rxjs';
 import { ConfirmModalService } from '../../core/services/confirm-modal.service';
 import { MediaUploaderError, MediaType, mediaTypes } from '../../core/interfaces/media';
-import { getDocumentThumbnail, getFileNameFromUrl } from '../../core/helpers/media-helper';
+import { getDocumentThumbnail } from '../../core/helpers/media-helper';
 
 @Component({
   selector: 'app-media-uploader',
@@ -53,7 +53,7 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
   uploads: Map<number, Observable<any>> = new Map();
 
   constructor(
-    private sanitizer: DomSanitizer,
+    protected sanitizer: DomSanitizer,
     private confirm: ConfirmModalService,
     private translate: TranslateService,
     private mediaService: MediaService,
@@ -115,10 +115,7 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
           const aFile = inputElement.files.item(i);
           if (aFile) {
             const photoUrl = formHelper.prepareImageFileToUpload(aFile);
-            const mediaFile = new MediaFile(
-              aFile,
-              this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(photoUrl)),
-            );
+            const mediaFile = new MediaFile(aFile, URL.createObjectURL(photoUrl));
 
             if (mediaFile.size! > this.maxUploadSize * 1000000) {
               mediaFile.status = MediaFileStatus.ERROR;
@@ -190,7 +187,7 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
           });
         forkJoin(Array.from(this.uploads.values())).subscribe((results) => {
           for (const result of results) {
-            const filename = getFileNameFromUrl(result.body.result.original_file_url);
+            const filename = MediaFile.getFileNameFromUrl(result.body.result.original_file_url);
             this.updateMediaFileByNameAndSize(
               filename,
               result.body.result.original_file_size,

--- a/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.ts
+++ b/apps/web-mzima-client/src/app/post/media-uploader/media-uploader.component.ts
@@ -117,7 +117,7 @@ export class MediaUploaderComponent implements ControlValueAccessor, OnInit {
             const photoUrl = formHelper.prepareImageFileToUpload(aFile);
             const mediaFile = new MediaFile(aFile, URL.createObjectURL(photoUrl));
 
-            if (mediaFile.size! > this.maxUploadSize * 1000000) {
+            if (mediaFile.size > this.maxUploadSize * 1000000) {
               mediaFile.status = MediaFileStatus.ERROR;
               mediaFile.error = MediaFileError.TOO_BIG;
             } else if (!this.mediaType.fileTypes.includes(mediaFile.mimeType)) {

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
@@ -173,25 +173,25 @@
                 </div>
               </ng-container>
 
-              <div class="post__images">
-                <ng-container *ngIf="field.input === 'image' && field.value.length > 0">
-                  <div class="post__images__item" *ngFor="let mediaFile of field.value">
-                    <img *ngIf="mediaFile.value" [src]="mediaFile.url" [alt]="post.title" />
-                    <span *ngIf="mediaFile.caption?.length" class="post__images__item__caption">{{
-                      mediaFile.caption
-                    }}</span>
-                  </div>
-                </ng-container>
+              <div class="post__images" *ngIf="field.input === 'image' && field.value.length > 0">
+                <div class="post__images__item" *ngFor="let mediaFile of field.value">
+                  <img
+                    *ngIf="mediaFile.value"
+                    [src]="this.sanitizer.bypassSecurityTrustUrl(mediaFile.url)"
+                    [alt]="post.title"
+                  />
+                  <span *ngIf="mediaFile.caption?.length" class="post__images__item__caption">{{
+                    mediaFile.caption
+                  }}</span>
+                </div>
               </div>
 
-              <div class="post__documents">
-                <ng-container *ngIf="field.input === 'document' && field.value.length > 0">
-                  <a
-                    class="post__documents__item"
-                    [href]="mediaFile.url"
-                    target="_blank"
-                    *ngFor="let mediaFile of field.value"
-                  >
+              <div
+                class="post__documents"
+                *ngIf="field.input === 'document' && field.value.length > 0"
+              >
+                <div class="post__documents__item" *ngFor="let mediaFile of field.value">
+                  <a [href]="this.sanitizer.bypassSecurityTrustUrl(mediaFile.url)" target="_blank">
                     <img
                       class="post__documents__item__thumbnail"
                       [src]="getDocumentThumbnail(mediaFile)"
@@ -201,16 +201,17 @@
                       <div class="filesize">{{ mediaFile.getFileSize() }}</div>
                     </div>
                   </a>
-                </ng-container>
+                </div>
               </div>
 
-              <div class="post__audio">
-                <ng-container *ngIf="field.input === 'audio' && field.value.length > 0">
-                  <div class="post__audio__item" *ngFor="let mediaFile of field.value">
-                    <span class="post__audio__item__filename">{{ mediaFile.filename }}</span>
-                    <audio controls [src]="mediaFile.url"></audio>
-                  </div>
-                </ng-container>
+              <div class="post__audio" *ngIf="field.input === 'audio' && field.value.length > 0">
+                <div class="post__audio__item" *ngFor="let mediaFile of field.value">
+                  <span class="post__audio__item__filename">{{ mediaFile.filename }}</span>
+                  <audio
+                    controls
+                    [src]="this.sanitizer.bypassSecurityTrustUrl(mediaFile.url)"
+                  ></audio>
+                </div>
               </div>
 
               <ng-container *ngIf="field.input === 'relation'">

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
@@ -198,7 +198,7 @@
                     />
                     <div class="post__documents__item__details">
                       <div class="filename">{{ mediaFile.filename }}</div>
-                      <div class="filesize">{{ getFileSize(mediaFile) }}</div>
+                      <div class="filesize">{{ mediaFile.getFileSize() }}</div>
                     </div>
                   </a>
                 </ng-container>

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
@@ -190,18 +190,21 @@
                 class="post__documents"
                 *ngIf="field.input === 'document' && field.value.length > 0"
               >
-                <div class="post__documents__item" *ngFor="let mediaFile of field.value">
-                  <a [href]="this.sanitizer.bypassSecurityTrustUrl(mediaFile.url)" target="_blank">
-                    <img
-                      class="post__documents__item__thumbnail"
-                      [src]="getDocumentThumbnail(mediaFile)"
-                    />
-                    <div class="post__documents__item__details">
-                      <div class="filename">{{ mediaFile.filename }}</div>
-                      <div class="filesize">{{ mediaFile.getFileSize() }}</div>
-                    </div>
-                  </a>
-                </div>
+                <a
+                  class="post__documents__item"
+                  *ngFor="let mediaFile of field.value"
+                  [href]="this.sanitizer.bypassSecurityTrustUrl(mediaFile.url)"
+                  target="_blank"
+                >
+                  <img
+                    class="post__documents__item__thumbnail"
+                    [src]="getDocumentThumbnail(mediaFile)"
+                  />
+                  <div class="post__documents__item__details">
+                    <div class="filename">{{ mediaFile.filename }}</div>
+                    <div class="filesize">{{ mediaFile.fileSize }}</div>
+                  </div>
+                </a>
               </div>
 
               <div class="post__audio" *ngIf="field.input === 'audio' && field.value.length > 0">

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.scss
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.scss
@@ -194,7 +194,7 @@
 
   &__documents {
     display: grid;
-    grid-template-columns: auto auto;
+    grid-template-columns: 1fr 1fr;
     @include breakpoint-max($tablet) {
       grid-template-columns: 1fr;
     }

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -126,20 +126,20 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
         this.post!.form = form.result;
         this.getData(this.post);
       });
-      this.isPostLoading = false;
       this.preparePostForView();
       //----------------------
-      this.postChanged = false;
       //----------------------
     }
   }
 
-  private getData(post: PostResult): void {
+  private async getData(post: PostResult): Promise<void> {
     for (const content of post.post_content as PostContent[]) {
-      this.preparingMediaField(content.fields);
       this.preparingSafeVideoUrls(content.fields);
       this.preparingRelatedPosts(content.fields);
       this.preparingCategories(content.fields);
+      this.preparingMediaField(content.fields).then(() => {
+        this.postChanged = false;
+      });
     }
   }
 
@@ -166,7 +166,7 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
         return categories;
       });
     //----------------------
-    this.postChanged = false;
+    // this.postChanged = false;
     //----------------------
   }
 
@@ -190,15 +190,9 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
     fields
       .filter((field: any) => field.type === 'media')
       .map(async (mediaField) => {
-        if (mediaField.value?.value) {
-          const media = await this.getPostMedia(mediaField.value.value);
-          mediaField.value.preview = media.result.original_file_url;
-          mediaField.value.caption = media.result.caption;
-          mediaField.value.mimeType = media.result.mime;
-          mediaField.value.size = media.result.original_file_size;
-        } else if (Array.isArray(mediaField.value)) {
+        if (Array.isArray(mediaField.value)) {
           const mediaFiles: MediaFile[] = [];
-          for (const mediaValue of mediaField.value) {
+          for await (const mediaValue of mediaField.value) {
             const media = await lastValueFrom(this.mediaService.getById(mediaValue.value!));
             const mediaFile: MediaFile = new MediaFile(
               media.result,
@@ -211,6 +205,12 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
             mediaFiles.push(mediaFile);
           }
           mediaField.value = mediaFiles;
+        } else if (mediaField.value?.value) {
+          const media = await this.getPostMedia(mediaField.value.value);
+          mediaField.value.preview = media.result.original_file_url;
+          mediaField.value.caption = media.result.caption;
+          mediaField.value.mimeType = media.result.mime;
+          mediaField.value.size = media.result.original_file_size;
         }
       });
   }

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -4,6 +4,7 @@ import {
   Input,
   OnChanges,
   OnDestroy,
+  OnInit,
   Output,
   SimpleChanges,
 } from '@angular/core';
@@ -13,6 +14,8 @@ import { ActivatedRoute } from '@angular/router';
 import { Permissions } from '@enums';
 import {
   CategoryInterface,
+  MediaFile,
+  MediaFileStatus,
   MediaService,
   PostContent,
   PostContentField,
@@ -27,14 +30,14 @@ import { BaseComponent } from '../../base.component';
 import { preparingVideoUrl } from '../../core/helpers/validators';
 import { dateHelper } from '@helpers';
 import { BreakpointService, EventBusService, EventType, SessionService } from '@services';
-import { getDocumentThumbnail, getFileNameFromUrl } from '../../core/helpers/media-helper';
+import { getDocumentThumbnail } from '../../core/helpers/media-helper';
 
 @Component({
   selector: 'app-post-details',
   templateUrl: './post-details.component.html',
   styleUrls: ['./post-details.component.scss'],
 })
-export class PostDetailsComponent extends BaseComponent implements OnChanges, OnDestroy {
+export class PostDetailsComponent extends BaseComponent implements OnChanges, OnDestroy, OnInit {
   @Input() post: PostResult;
   @Input() feedView: boolean = true;
   @Input() userId?: number | string;
@@ -60,14 +63,16 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
     private route: ActivatedRoute,
     private postsService: PostsService,
     private surveyService: SurveysService,
-    private sanitizer: DomSanitizer,
+    protected sanitizer: DomSanitizer,
     private eventBusService: EventBusService,
   ) {
     super(sessionService, breakpointService);
     this.getUserData();
     this.checkPermission();
     this.userId = Number(this.user.userId);
+  }
 
+  ngOnInit(): void {
     this.route.params.subscribe((params) => {
       if (params['id']) {
         //----------------------
@@ -119,9 +124,9 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
     if (this.post) {
       this.surveyService.getById(this.post.form_id!).subscribe((form) => {
         this.post!.form = form.result;
+        this.getData(this.post);
       });
       this.isPostLoading = false;
-      this.getData(this.post);
       this.preparePostForView();
       //----------------------
       this.postChanged = false;
@@ -192,15 +197,20 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
           mediaField.value.mimeType = media.result.mime;
           mediaField.value.size = media.result.original_file_size;
         } else if (Array.isArray(mediaField.value)) {
+          const mediaFiles: MediaFile[] = [];
           for (const mediaValue of mediaField.value) {
-            const media = await this.getPostMedia(mediaValue.value);
-            mediaValue.url = media.result.original_file_url;
-            mediaValue.caption = media.result.caption;
-            mediaValue.mimeType = media.result.mime;
-            mediaValue.size = media.result.original_file_size;
-            mediaValue.filename = getFileNameFromUrl(mediaValue.url);
-            mediaValue.status = 'ready';
+            const media = await lastValueFrom(this.mediaService.getById(mediaValue.value!));
+            const mediaFile: MediaFile = new MediaFile(
+              media.result,
+              media.result.original_file_url,
+            );
+            mediaFile.id = mediaValue.id;
+            mediaFile.value = media.result.id;
+            mediaFile.caption = media.result.caption;
+            mediaFile.status = MediaFileStatus.READY;
+            mediaFiles.push(mediaFile);
           }
+          mediaField.value = mediaFiles;
         }
       });
   }

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -27,11 +27,7 @@ import { BaseComponent } from '../../base.component';
 import { preparingVideoUrl } from '../../core/helpers/validators';
 import { dateHelper } from '@helpers';
 import { BreakpointService, EventBusService, EventType, SessionService } from '@services';
-import {
-  getDocumentThumbnail,
-  getFileNameFromUrl,
-  getFileSize,
-} from '../../core/helpers/media-helper';
+import { getDocumentThumbnail, getFileNameFromUrl } from '../../core/helpers/media-helper';
 
 @Component({
   selector: 'app-post-details',
@@ -88,7 +84,6 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
 
   // Import Helper Methods for the template
   getDocumentThumbnail = getDocumentThumbnail;
-  getFileSize = getFileSize;
 
   loadData(): void {}
 

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -49,7 +49,7 @@ import { Observable, lastValueFrom, of } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { LanguageInterface } from '@mzima-client/sdk';
 import { MatSelectChange } from '@angular/material/select';
-import { MediaFile } from '../../core/interfaces/media';
+import { MediaFile, MediaFileStatus } from '../../core/interfaces/media';
 import { getFileNameFromUrl } from '../../core/helpers/media-helper';
 
 dayjs.extend(timezone);
@@ -384,7 +384,7 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
         mediaValue.caption = media.result.caption;
         mediaValue.mimeType = media.result.mime;
         mediaValue.size = media.result.original_file_size;
-        mediaValue.status = 'ready';
+        mediaValue.status = MediaFileStatus.READY;
         mediaValue.filename = getFileNameFromUrl(mediaValue.url!);
       }
 

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -40,6 +40,8 @@ import {
   MediaService,
   postHelpers,
   SurveyItem,
+  MediaFile,
+  MediaFileStatus,
 } from '@mzima-client/sdk';
 import { BaseComponent } from '../../base.component';
 import { preparingVideoUrl } from '../../core/helpers/validators';
@@ -49,7 +51,6 @@ import { Observable, lastValueFrom, of } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { LanguageInterface } from '@mzima-client/sdk';
 import { MatSelectChange } from '@angular/material/select';
-import { MediaFile, MediaFileStatus } from '../../core/interfaces/media';
 import { getFileNameFromUrl } from '../../core/helpers/media-helper';
 
 dayjs.extend(timezone);

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -51,7 +51,6 @@ import { Observable, lastValueFrom, of } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { LanguageInterface } from '@mzima-client/sdk';
 import { MatSelectChange } from '@angular/material/select';
-import { getFileNameFromUrl } from '../../core/helpers/media-helper';
 
 dayjs.extend(timezone);
 
@@ -376,21 +375,22 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
     }
   }
 
-  private async handleMedia(key: string, value: MediaFile[]) {
+  private async handleMedia(key: string, value: any[]) {
     if (value?.length === 0) return;
     try {
+      const mediaFiles: MediaFile[] = [];
       for (const mediaValue of value) {
         const media = await lastValueFrom(this.mediaService.getById(mediaValue.value!));
-        mediaValue.url = media.result.original_file_url;
-        mediaValue.caption = media.result.caption;
-        mediaValue.mimeType = media.result.mime;
-        mediaValue.size = media.result.original_file_size;
-        mediaValue.status = MediaFileStatus.READY;
-        mediaValue.filename = getFileNameFromUrl(mediaValue.url!);
+        const mediaFile: MediaFile = new MediaFile(media.result, media.result.original_file_url);
+        mediaFile.id = mediaValue.id;
+        mediaFile.value = media.result.id;
+        mediaFile.caption = media.result.caption;
+        mediaFile.status = MediaFileStatus.READY;
+        mediaFiles.push(mediaFile);
       }
 
       this.form.patchValue({
-        [key]: value,
+        [key]: mediaFiles,
       });
     } catch (error: any) {
       this.form.patchValue({ [key]: null });

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -995,7 +995,8 @@
       "messages": {
         "max_size" : "Your file is too large.",
         "max_files" : "You have exceeded the maximum number of files.",
-        "required" : "Media is required."
+        "required" : "Media is required.",
+        "invalid_type" : "Unsupported file type."
       },
       "status" : {
         "uploading" : "Uploading...",

--- a/libs/sdk/src/lib/models/media.interface.ts
+++ b/libs/sdk/src/lib/models/media.interface.ts
@@ -18,14 +18,14 @@ export interface MediaResult {
   allowed_privileges: string[];
 }
 
-enum MediaFileError {
+export enum MediaFileError {
   NONE = 'none',
   UNKNOWN = 'unknown',
   TOO_BIG = 'post.media.messages.max_size',
   INVALID_TYPE = 'post.media.messages.invalid_type',
 }
 
-enum MediaFileStatus {
+export enum MediaFileStatus {
   NONE = 'none',
   READY = 'ready',
   UPLOAD = 'upload',
@@ -35,11 +35,12 @@ enum MediaFileStatus {
   DELETE = 'delete',
 }
 
-class MediaFile {
+export class MediaFile {
   id: number;
   generatedId: number;
   file?: File;
   filename: string;
+  fileSize: string;
   url?: string;
   caption: string;
   status: MediaFileStatus;
@@ -66,7 +67,7 @@ class MediaFile {
       this.filename = MediaFile.getFileNameFromUrl(file.original_file_url);
       this.mimeType = file.mime ? file.mime : '';
     }
-    console.log(this.mimeType);
+    this.fileSize = this.getFileSize();
   }
 
   private generateId(): number {
@@ -76,10 +77,8 @@ class MediaFile {
     );
   }
 
-  getFileSize(): string {
-    let filesize = 0;
-    if (this.status === MediaFileStatus.READY) filesize = this.size;
-    else filesize = this.file ? this.file.size : 0;
+  public getFileSize(): string {
+    const filesize = this.file ? this.file.size : this.size;
 
     // Megabytes
     if (filesize > 1000000) {
@@ -110,5 +109,3 @@ class MediaFile {
     return newFilename.substring(firstHyphenIndex);
   }
 }
-
-export { MediaFile, MediaFileError, MediaFileStatus };

--- a/libs/sdk/src/lib/models/media.interface.ts
+++ b/libs/sdk/src/lib/models/media.interface.ts
@@ -1,4 +1,3 @@
-import { SafeUrl } from '@angular/platform-browser';
 import { ApiResponse } from './api-response.interface';
 
 export interface MediaResponse extends ApiResponse {
@@ -39,9 +38,9 @@ enum MediaFileStatus {
 class MediaFile {
   id: number;
   generatedId: number;
-  file: File;
+  file?: File;
   filename: string;
-  url: string | SafeUrl | null;
+  url?: string;
   caption: string;
   status: MediaFileStatus;
   size: number;
@@ -49,18 +48,25 @@ class MediaFile {
   value: number;
   error: MediaFileError = MediaFileError.NONE;
 
-  constructor(file: File, url: string | SafeUrl) {
+  constructor(file: File | MediaResult, url: string) {
     this.id = 0;
     this.value = 0;
-    this.filename = file.name;
     this.caption = '';
-    this.size = file.size;
-    this.file = file;
     this.status = MediaFileStatus.NONE;
     this.error = MediaFileError.NONE;
-    this.mimeType = file.type;
     this.url = url;
     this.generatedId = this.generateId();
+    if (file instanceof File) {
+      this.size = file.size;
+      this.file = file;
+      this.filename = file.name;
+      this.mimeType = file.type;
+    } else {
+      this.size = file.original_file_size;
+      this.filename = MediaFile.getFileNameFromUrl(file.original_file_url);
+      this.mimeType = file.mime ? file.mime : '';
+    }
+    console.log(this.mimeType);
   }
 
   private generateId(): number {
@@ -87,6 +93,21 @@ class MediaFile {
     else {
       return filesize + 'bytes';
     }
+  }
+
+  // Our media api returns a relative url with a filename that has an id prepended, instead of the original filename.
+  // This function attempts to take that url, and return the original filename.
+  static getFileNameFromUrl(url: string): string {
+    // Try to use a regex to strip out what we add to the filename and the path
+    const regex = /.*\/[0-9a-fA-F]{13}-(.*)/;
+    const match = url.match(regex);
+    if (match && match[1]) return match[1];
+
+    // The url doesnt have the expected filename, so return everything after the final slash
+    const lastSlashIndex = url.lastIndexOf('/');
+    const newFilename = lastSlashIndex !== -1 ? url.substring(lastSlashIndex + 1) : url;
+    const firstHyphenIndex = newFilename.indexOf('-') + 1;
+    return newFilename.substring(firstHyphenIndex);
   }
 }
 

--- a/libs/sdk/src/lib/models/media.interface.ts
+++ b/libs/sdk/src/lib/models/media.interface.ts
@@ -1,3 +1,4 @@
+import { SafeUrl } from '@angular/platform-browser';
 import { ApiResponse } from './api-response.interface';
 
 export interface MediaResponse extends ApiResponse {
@@ -17,3 +18,76 @@ export interface MediaResult {
   updated?: Date | null;
   allowed_privileges: string[];
 }
+
+enum MediaFileError {
+  NONE = 'none',
+  UNKNOWN = 'unknown',
+  TOO_BIG = 'post.media.messages.max_size',
+  INVALID_TYPE = 'post.media.messages.invalid_type',
+}
+
+enum MediaFileStatus {
+  NONE = 'none',
+  READY = 'ready',
+  UPLOAD = 'upload',
+  UPLOADING = 'uploading',
+  UPLOADED = 'uploaded',
+  ERROR = 'error',
+  DELETE = 'delete',
+}
+
+class MediaFile {
+  id: number;
+  generatedId: number;
+  file: File;
+  filename: string;
+  url: string | SafeUrl | null;
+  caption: string;
+  status: MediaFileStatus;
+  size: number;
+  mimeType: string;
+  value: number;
+  error: MediaFileError = MediaFileError.NONE;
+
+  constructor(file: File, url: string | SafeUrl) {
+    this.id = 0;
+    this.value = 0;
+    this.filename = file.name;
+    this.caption = '';
+    this.size = file.size;
+    this.file = file;
+    this.status = MediaFileStatus.NONE;
+    this.error = MediaFileError.NONE;
+    this.mimeType = file.type;
+    this.url = url;
+    this.generatedId = this.generateId();
+  }
+
+  private generateId(): number {
+    return (
+      Math.floor(Math.random() * (Number.MAX_SAFE_INTEGER - Number.MIN_SAFE_INTEGER + 1)) +
+      Number.MIN_SAFE_INTEGER
+    );
+  }
+
+  getFileSize(): string {
+    let filesize = 0;
+    if (this.status === MediaFileStatus.READY) filesize = this.size;
+    else filesize = this.file ? this.file.size : 0;
+
+    // Megabytes
+    if (filesize > 1000000) {
+      return (filesize / 1000000).toFixed(2).toString() + 'MB';
+    }
+    // Kilobytes
+    else if (filesize > 1000) {
+      return (filesize / 1000).toFixed(2).toString() + 'kB';
+    }
+    // Bytes
+    else {
+      return filesize + 'bytes';
+    }
+  }
+}
+
+export { MediaFile, MediaFileError, MediaFileStatus };

--- a/libs/sdk/src/lib/services/media.service.ts
+++ b/libs/sdk/src/lib/services/media.service.ts
@@ -1,6 +1,5 @@
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { apiHelpers } from '../helpers';
 import { EnvLoader } from '../loader';
 import { ResourceService } from './resource.service';
@@ -21,7 +20,6 @@ export class MediaService extends ResourceService<any> {
   constructor(
     protected override httpClient: HttpClient,
     protected override currentLoader: EnvLoader,
-    private sanitizer: DomSanitizer,
   ) {
     super(httpClient, currentLoader);
     this.domainPrefix = this.backendUrl.substring(0, this.backendUrl.length - 1);
@@ -87,12 +85,11 @@ export class MediaService extends ResourceService<any> {
     return super.patch(id, { caption });
   }
 
-  private cleanUrl(url: string): SafeUrl {
+  private cleanUrl(url: string): string {
     // If we get back only a relative url for a media request, add the backend domain to it
     if (url[0] === '/') {
       url = this.domainPrefix + url;
     }
-    // also sanitize it to prevent angular thinking we're xssing
-    return this.sanitizer.bypassSecurityTrustUrl(url);
+    return url;
   }
 }


### PR DESCRIPTION
**Issues:**

The functionality (described in USH-1415) initially committed had 2 bugs:

- Mime types were not strictly enforced in the frontend.
- An upload that failed due to size, could not be removed.

**Solution:**

This PR contains:
- fixes for both of the above issues.
- much stronger type safety with a class replacing the previous type
- More enums!
- Moves the MediaFile class and its associated Enums into the shared library to be used in mobile.

**Testing:**

USH-1415 functionality but with mime types being enforced and the ability to remove failed uploads.