### PR TITLE
Ush 1637 - Allow backend_url be specified in mobile app when not in production

### DIFF
--- a/apps/mobile-mzima-client/src/app/core/services/deployment.service.ts
+++ b/apps/mobile-mzima-client/src/app/core/services/deployment.service.ts
@@ -206,7 +206,7 @@ export class DeploymentService {
     this.databaseService.clear();
   }
 
-  private generateRandomId(length: number = 10): string {
+  public generateRandomId(length: number = 10): string {
     let result = '';
     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     const charactersLength = characters.length;

--- a/apps/mobile-mzima-client/src/app/core/services/env.service.ts
+++ b/apps/mobile-mzima-client/src/app/core/services/env.service.ts
@@ -21,10 +21,15 @@ export class EnvService {
 
   async initEnv(): Promise<EnvConfigInterface> {
     const envy: EnvConfigInterface = await fetch('./env.json').then((res) => res.json());
-    envy['backend_url'] = null;
-    if (this.deploymentUrl) {
-      envy.backend_url = this.deploymentUrl;
+    if (envy['production']) {
+      envy['backend_url'] = null;
+      if (this.deploymentUrl) {
+        envy.backend_url = this.deploymentUrl;
+      }
+    } else {
+      if (envy.backend_url) this.setDynamicBackendUrl();
     }
+
     EnvService.ENV = envy;
     this.env = envy;
     return envy;
@@ -44,7 +49,7 @@ export class EnvService {
   setDynamicBackendUrl() {
     const deployment: any = this.deploymentService.getDeployment();
     const envy: EnvConfigInterface = this.env;
-    envy.backend_url = this.deploymentUrl;
+    if (envy.production) envy.backend_url = this.deploymentUrl;
     EnvService.ENV = envy;
     this.env = envy;
     this.deployment.next(deployment);

--- a/apps/mobile-mzima-client/src/app/core/services/env.service.ts
+++ b/apps/mobile-mzima-client/src/app/core/services/env.service.ts
@@ -29,7 +29,6 @@ export class EnvService {
       }
     } else {
       if (envy.backend_url) {
-        // this.env = envy;
         const deployment: Deployment = {
           id: this.deploymentService.generateRandomId(),
           domain: envy.backend_url,

--- a/apps/mobile-mzima-client/src/app/core/services/env.service.ts
+++ b/apps/mobile-mzima-client/src/app/core/services/env.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { checkBackendURL } from '@helpers';
 import { EnvConfigInterface } from '@models';
+import { Deployment } from '@mzima-client/sdk';
 
 import { DeploymentService } from '@services';
 import { BehaviorSubject } from 'rxjs';
@@ -27,7 +28,21 @@ export class EnvService {
         envy.backend_url = this.deploymentUrl;
       }
     } else {
-      if (envy.backend_url) this.setDynamicBackendUrl();
+      if (envy.backend_url) {
+        // this.env = envy;
+        const deployment: Deployment = {
+          id: this.deploymentService.generateRandomId(),
+          domain: envy.backend_url,
+          deployment_name: 'Development Deployment',
+          selected: true,
+          fqdn: envy.backend_url,
+          description: 'Configured in env.json',
+          tier: 'N/A',
+        };
+        this.deploymentService.setDeployments([deployment]);
+        this.deploymentService.setDeployment(deployment);
+        this.deployment.next(deployment);
+      }
     }
 
     EnvService.ENV = envy;
@@ -49,7 +64,7 @@ export class EnvService {
   setDynamicBackendUrl() {
     const deployment: any = this.deploymentService.getDeployment();
     const envy: EnvConfigInterface = this.env;
-    if (envy.production) envy.backend_url = this.deploymentUrl;
+    envy.backend_url = this.deploymentUrl;
     EnvService.ENV = envy;
     this.env = envy;
     this.deployment.next(deployment);

--- a/apps/mobile-mzima-client/src/env.json
+++ b/apps/mobile-mzima-client/src/env.json
@@ -1,6 +1,6 @@
 {
-  "production": false,
-  "backend_url": "https://mzima-dev-api.staging.ush.zone/",
+  "production": true,
+  "backend_url": "http://localhost:8080/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",

--- a/apps/mobile-mzima-client/src/env.json
+++ b/apps/mobile-mzima-client/src/env.json
@@ -1,5 +1,6 @@
 {
-  "production": true,
+  "production": false,
+  "backend_url": "https://mzima-dev-api.staging.ush.zone/",
   "api_v3": "api/v3/",
   "api_v5": "api/v5/",
   "mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",


### PR DESCRIPTION
**Issue:**

The mobile app is designed to have the deployment configured solely through its frontend and doesnt allow the developer to specify a backend in the env.json file.

**Solution:**

This PR allows the developer to specify the backend_url in the env.json which will be used if the app is NOT in production mode. It will then replace all the saved deployments with this one specified deployment and startup with this deployment selected.

**Testing:**

1. Modify the env.json file with production: false and a fully qualified domain in the backend_url, eg. http://localhost:8080/.
2. Start the app.
3. Note the deployment is now the only one specified in the list and is selected.
