### PR TITLE
[USH-1238] "There are no posts yet" - Separate the text for when there are no posts & when no filters match

### DIFF
--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -211,16 +211,29 @@
       }"
       [attr.data-qa]="'posts'"
     >
-      <!-- No posts 1: When there are no posts at all in the deployment or there no posts because none can be viewed by a user due to the permissions they have  -->
-      <ng-container *ngIf="!posts.length && isDefaultFilters">
-        <span class="posts-empty">{{ 'post.no_posts_yet' | translate }}</span>
-      </ng-container>
-      <!-- No posts 2: When there's no posts matching user's filter selection/combination -->
-      <ng-container *ngIf="!posts.length && !isDefaultFilters">
-        <span class="posts-empty">{{
-          'post.no_posts_match_your_current_filters' | translate
-        }}</span>
-      </ng-container>
+      <!-- No posts -->
+      <span *ngIf="!posts.length" class="posts-empty">
+        <ng-container *ngIf="isDefaultFilters">
+          <!-- No posts 1a: When there are no posts at all in the deployment or there no posts because none can be viewed by a user due to the permissions they have  -->
+          <ng-container *ngIf="!userIsSearchingPostsByKeyword">
+            {{ 'post.no_posts_yet' | translate }}
+          </ng-container>
+          <!-- No posts 1b: Keyword search (when default filters is on) -->
+          <ng-container *ngIf="userIsSearchingPostsByKeyword">
+            {{ 'post.no_posts_match_search' | translate }}
+          </ng-container>
+        </ng-container>
+        <ng-container *ngIf="!isDefaultFilters">
+          <!-- No posts 2a: When there's no posts matching user's filter selection/combination -->
+          <ng-container *ngIf="!userIsSearchingPostsByKeyword">
+            {{ 'post.no_posts_match_your_current_filters' | translate }}
+          </ng-container>
+          <!-- No posts 2b: Keyword search (when not in default filters) -->
+          <ng-container *ngIf="userIsSearchingPostsByKeyword">
+            {{ 'post.no_posts_match_search_plus_filter' | translate }}
+          </ng-container>
+        </ng-container>
+      </span>
       <!-- When there are posts -->
       <ng-container *ngIf="posts.length">
         <div

--- a/apps/web-mzima-client/src/app/feed/feed.component.html
+++ b/apps/web-mzima-client/src/app/feed/feed.component.html
@@ -211,9 +211,15 @@
       }"
       [attr.data-qa]="'posts'"
     >
-      <!-- No posts -->
-      <ng-container *ngIf="!posts.length">
+      <!-- No posts 1: When there are no posts at all in the deployment or there no posts because none can be viewed by a user due to the permissions they have  -->
+      <ng-container *ngIf="!posts.length && isDefaultFilters">
         <span class="posts-empty">{{ 'post.no_posts_yet' | translate }}</span>
+      </ng-container>
+      <!-- No posts 2: When there's no posts matching user's filter selection/combination -->
+      <ng-container *ngIf="!posts.length && !isDefaultFilters">
+        <span class="posts-empty">{{
+          'post.no_posts_match_your_current_filters' | translate
+        }}</span>
       </ng-container>
       <!-- When there are posts -->
       <ng-container *ngIf="posts.length">

--- a/apps/web-mzima-client/src/app/feed/feed.component.scss
+++ b/apps/web-mzima-client/src/app/feed/feed.component.scss
@@ -165,9 +165,13 @@
   display: block;
   max-width: 400px;
   margin: 20vh auto;
+  padding: 20px 10px;
   font-size: 16px;
   line-height: 1.5;
   text-align: center;
+  background: var(--color-light);
+  border-radius: 3px;
+  border: 1px solid var(--color-neutral-30);
 }
 
 .load-more {

--- a/apps/web-mzima-client/src/app/feed/feed.component.scss
+++ b/apps/web-mzima-client/src/app/feed/feed.component.scss
@@ -162,9 +162,9 @@
 }
 
 .posts-empty {
-  width: 100%;
   display: block;
-  margin: 20vh 0;
+  max-width: 400px;
+  margin: 20vh auto;
   font-size: 16px;
   line-height: 1.5;
   text-align: center;

--- a/apps/web-mzima-client/src/app/feed/feed.component.scss
+++ b/apps/web-mzima-client/src/app/feed/feed.component.scss
@@ -164,7 +164,7 @@
 .posts-empty {
   display: block;
   max-width: 400px;
-  margin: 20vh auto;
+  margin: 7vh auto;
   padding: 20px 10px;
   font-size: 16px;
   line-height: 1.5;

--- a/apps/web-mzima-client/src/app/feed/feed.component.ts
+++ b/apps/web-mzima-client/src/app/feed/feed.component.ts
@@ -65,6 +65,7 @@ export class FeedComponent extends MainViewComponent implements OnInit, OnDestro
   public postCurrentLength = 0;
   public isLoading: boolean;
   public isDefaultFilters: boolean;
+  public userIsSearchingPostsByKeyword: number;
   public atLeastOnePostExists: boolean;
   public noPostsYet: boolean = false;
   public loadingMorePosts: boolean;
@@ -284,6 +285,11 @@ export class FeedComponent extends MainViewComponent implements OnInit, OnDestro
           next: (currentUser) => {
             // Check if default filters is on or not to display "no posts" messages accordingly
             this.isDefaultFilters = this.getDefaultFilters(currentUser.role as string);
+            // ---------------
+            // Check if default filters is on or not to display "no posts" messages accordingly
+            const searchPostsByKeyword = localStorage.getItem('USH_searchPostByKeyword') as string;
+            this.userIsSearchingPostsByKeyword = searchPostsByKeyword?.length;
+            // ---------------
             // Get end of post load directly from the posts API, use it to set is loading state to false
             this.isLoading = isLoading;
           },

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -225,6 +225,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
   }
 
   private initFilters() {
+    this.clearPostsResults();
     if (this.filters) {
       const filters = JSON.parse(this.filters!);
       if (!this.router.url.includes('collection')) {
@@ -795,6 +796,10 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
 
   public searchPosts(): void {
     this.searchSubject.next(this.searchQuery);
+    //------------------------
+    // Save to localstorage: Needed for "search + filter" detection for posts ("no posts" message display particularly)
+    localStorage.setItem('USH_searchPostByKeyword', this.searchQuery);
+    //------------------------
   }
 
   public displayFn(city: SearchResponse): string {

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -793,6 +793,8 @@
     "all_posts": "All Posts",
     "no_search_results": "Your search didn't match any posts",
     "no_search_results_location": "Your search didn't match any posts with location information",
+    "no_posts_match_search": "No posts match your keyword search. Please change or clear keyword search to see matching posts.",
+    "no_posts_match_search_plus_filter": "No posts match your keyword search + filters. Please change or clear keyword search and/or filters to see matching posts.",
     "no_posts_match_your_current_filters": "No posts match the current filters. Please change or clear filters to see matching posts.",
     "no_posts_yet": "There are no posts yet!",
     "no_posts_yet_location": "There are no posts with location information yet!",

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -793,7 +793,7 @@
     "all_posts": "All Posts",
     "no_search_results": "Your search didn't match any posts",
     "no_search_results_location": "Your search didn't match any posts with location information",
-    "no_posts_match_your_current_filters": "No posts match the current filters. Please change or clear filters to see matching posts",
+    "no_posts_match_your_current_filters": "No posts match the current filters. Please change or clear filters to see matching posts.",
     "no_posts_yet": "There are no posts yet!",
     "no_posts_yet_location": "There are no posts with location information yet!",
     "add_first_post": "Add the first post",

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -793,6 +793,7 @@
     "all_posts": "All Posts",
     "no_search_results": "Your search didn't match any posts",
     "no_search_results_location": "Your search didn't match any posts with location information",
+    "no_posts_match_your_current_filters": "No posts match the current filters. Please change or clear filters to see matching posts",
     "no_posts_yet": "There are no posts yet!",
     "no_posts_yet_location": "There are no posts with location information yet!",
     "add_first_post": "Add the first post",


### PR DESCRIPTION
#### Solution implemented explained
- Show "There are no posts yet" text on feed view, when default filters is on (i.e. all 6 filter types are in default state) but there are no posts. There are 2 scenarios for this:
  - There are no posts at all in the deployment: You can test this by logging in as an admin for a deployment that has no posts at all.
  - There are posts in the deployment, but none can be viewed by a user due to the permissions they have.
- Show "No posts match the current filters. Please Change or Clear filters to see matching posts" text on feed view, when not default filters (i.e. at least one of the 6 filter types are in default state) and there's no matching post for user's filter selection/combination
- Search by keyword detection and no posts message:
  - Keyword search only (i.e. searching posts by keyword when Default filters is on): Use "No posts match your keyword search. Please change or clear keyword search to see matching posts".
  - Keyword search + filters applied (i.e. searching posts by keyword when not in default filters): Use "No posts match your keyword search + filters. Please change or clear keyword search and/or filters to see matching posts".