### PR TITLE
Adding extra check for form_id and displaying messages in detailed view

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -128,7 +128,7 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
   }
 
   private async getData(post: PostResult): Promise<void> {
-    if (!post || post.post_content?.length === 0) {
+    if (!post.form_id) {
       this.postChanged = false;
       return;
     }

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -117,21 +117,17 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
   private async getPost(id: number): Promise<void> {
     if (!this.postId) return;
     this.post = await this.getPostInformation(id);
-    if (this.post?.form_id) {
+    if (this.post && this.post.form_id) {
       const form = await lastValueFrom(this.surveyService.getById(this.post.form_id!));
       this.post.form = form.result;
+      this.getData(this.post);
+      this.preparePostForView();
+    } else {
+      this.postChanged = false;
     }
-    this.getData(this.post);
-    this.preparePostForView();
-    //----------------------
-    //----------------------
   }
 
   private async getData(post: PostResult): Promise<void> {
-    if (!post.form_id) {
-      this.postChanged = false;
-      return;
-    }
     for (const content of post.post_content as PostContent[]) {
       this.preparingSafeVideoUrls(content.fields);
       this.preparingRelatedPosts(content.fields);

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -117,18 +117,21 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
   private async getPost(id: number): Promise<void> {
     if (!this.postId) return;
     this.post = await this.getPostInformation(id);
-    if (this.post) {
-      this.surveyService.getById(this.post.form_id!).subscribe((form) => {
-        this.post!.form = form.result;
-        this.getData(this.post);
-      });
-      this.preparePostForView();
-      //----------------------
-      //----------------------
+    if (this.post?.form_id) {
+      const form = await lastValueFrom(this.surveyService.getById(this.post.form_id!));
+      this.post.form = form.result;
     }
+    this.getData(this.post);
+    this.preparePostForView();
+    //----------------------
+    //----------------------
   }
 
   private async getData(post: PostResult): Promise<void> {
+    if (!post || post.post_content?.length === 0) {
+      this.postChanged = false;
+      return;
+    }
     for (const content of post.post_content as PostContent[]) {
       this.preparingSafeVideoUrls(content.fields);
       this.preparingRelatedPosts(content.fields);


### PR DESCRIPTION
Adding an extra check for form_id to not having to be dependent on post-fields to display the post.

To test:
Go to feed-view
Click on an unstructured post
- [ ] The content should be visible in the post-detailed view
Click on a structured post
- [ ] The content should be visible in the post-detailed view