### PR TITLE
[USH-1546] Loading surveys on mobile still shows "Getting data" instead of "Fetching Surveys"

### DIFF
--- a/apps/mobile-mzima-client/src/assets/locales/en.json
+++ b/apps/mobile-mzima-client/src/assets/locales/en.json
@@ -74,7 +74,7 @@
       "edit": "Edit",
       "toc_text":"<p>These Terms of Service (the “Terms”) and our Privacy Policy apply to and govern your use of any websites owned or operated by Ushahidi Inc. (“Ushahidi”) that post a link to these Terms (such websites, the “Sites”), the Ushahidi services accessible via the Sites (including any cloud-based servers or platforms) and the Ushahidi mobile device applications (the “Apps”).</p><p>To make these Terms easier to read, the Sites, our services, platforms, and Apps are collectively called the “Services.” Please note that these Terms do not cover any of our products you download under an open source license. Additionally, these Terms may not apply if you have entered into a separate agreement with Ushahidi that governs your relationship with us, such as a separately-negotiated enterprise agreement.</p><h2>Agreement To Terms</h2><p>these Terms, do not use the Services. If you are accessing and using the Services on behalf of a company (such as your employer) or other legal entity, you represent and warrant that you have the authority to bind that company or other legal entity to these Terms.</p><p>In that case, “you” and “your” will refer to that company or other legal entity.</p>",
       "skip": "Skip",
-      "loading":"Getting data...",
+      "loading":"Fetching Surveys...",
       "emtpy_field_error": "This field cannot be empty",
       "info" : {
         "auth_not_online" : "Sorry. You're offline…please check your internet connection",

--- a/apps/mobile-mzima-client/src/assets/locales/es.json
+++ b/apps/mobile-mzima-client/src/assets/locales/es.json
@@ -69,6 +69,6 @@
     "edit": "Editar",
     "toc_text":"<p>These Terms of Service (the “Terms”) and our Privacy Policy apply to and govern your use of any websites owned or operated by Ushahidi Inc. (“Ushahidi”) that post a link to these Terms (such websites, the “Sites”), the Ushahidi services accessible via the Sites (including any cloud-based servers or platforms) and the Ushahidi mobile device applications (the “Apps”).</p><p>To make these Terms easier to read, the Sites, our services, platforms, and Apps are collectively called the “Services.” Please note that these Terms do not cover any of our products you download under an open source license. Additionally, these Terms may not apply if you have entered into a separate agreement with Ushahidi that governs your relationship with us, such as a separately-negotiated enterprise agreement.</p><h2>Agreement To Terms</h2><p>these Terms, do not use the Services. If you are accessing and using the Services on behalf of a company (such as your employer) or other legal entity, you represent and warrant that you have the authority to bind that company or other legal entity to these Terms.</p><p>In that case, “you” and “your” will refer to that company or other legal entity.</p>",
     "skip": "Skip",
-    "loading":"Getting data..."
+    "loading":"Fetching Surveys..."
   }
 }


### PR DESCRIPTION
Show 'fetching surveys' instead of 'getting data' for loading surveys

**To test;**

- [x] Open the mobile app 
- [x] Click on the + icon to add a new post 
- [x] Observe the text that appears while fetching the list of surveys