### PR TITLE
[USH-1680-M] Change wording in "Success" window after creating a post

### DIFF
--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
@@ -861,7 +861,7 @@ export class PostEditPage {
       const result = await this.alertService.presentAlert({
         header: 'Success!',
         message:
-          'Thank you for submitting your report. The post is being reviewed by our team and soon will appear on the platform.',
+          'Thank you for submitting your post. It is being reviewed, and will soon will appear on the platform.',
       });
       if (result.role !== 'confirm') return;
     }

--- a/apps/mobile-mzima-client/src/assets/locales/en.json
+++ b/apps/mobile-mzima-client/src/assets/locales/en.json
@@ -78,8 +78,8 @@
       "emtpy_field_error": "This field cannot be empty",
       "info" : {
         "auth_not_online" : "Sorry. You're offline…please check your internet connection",
-        "post_submitted_online" : "Thank you for submitting your report. The post is being reviewed by our team and soon will appear on the platform.",
-        "post_submitted_offline" : "Thank you for your report. A message will be sent when the connection is restored.",
+        "post_submitted_online" : "Thank you for submitting your post. It is being reviewed, and will soon appear on the platform.",
+        "post_submitted_offline" : "Thank you for your post. A message will be sent when the connection is restored.",
         "posts_not_uploaded" : "<b>{{num_posts}} Posts not Uploaded!</b><br/>The posts were not uploaded due to bad internet connection or you were offline. They will be automatically uploaded as soon as you connect to the internet",
         "posts_uploading" : "<b>Uploading {{num_posts}} Posts</b><br/>We are currently uploading your posts",
         "posts_uploaded" : "<b>{{num_posts}} Posts Uploaded Successfully!</b><br/>Your posts were successfully uploaded. You can see them under \"My Posts\""


### PR DESCRIPTION
Changing wording in success message after creating post

Previous Message:
_Thank you for submitting your report. The post is being reviewed by our team and soon will appear on the platform._

Current Message:
_Thank you for submitting your post. It is being reviewed, and will soon appear on the platform._