### PR TITLE
USH-1683 - Posts not submitting for surveys with the old image field

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -678,7 +678,7 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
                     throw new Error(`Error updating caption: ${error.message}`);
                   }
                 } else {
-                  value.value = this.form.value[field.key]?.id || null;
+                  value.value = this.form.value[field.key]?.id || [];
                 }
                 break;
               case 'image':


### PR DESCRIPTION
**Issue:**

For surveys with the previous image field, posts fail to submit if an image is not uploaded.

**Solution:**

A tiny little fix that presents an empty array, rather than a null value in the field values.

**Ticket:** 

https://linear.app/ushahidi/issue/USH-1683/posts-not-submitting-for-surveys-that-already-had-image-field#comment-03592f34

**Testing:**

1. Create a survey with an old image field.
2. Create a new post of the above survey, but without uploading an image.
3. Submit the post successfully.