### PR TITLE
USH-1684 - Edit posts with old image fields

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -678,7 +678,7 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
                     throw new Error(`Error updating caption: ${error.message}`);
                   }
                 } else {
-                  value.value = this.form.value[field.key]?.id || null;
+                  value.value = this.form.value[field.key]?.id || [];
                 }
                 break;
               case 'image':

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -668,7 +668,7 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
                   }
                 } else if (
                   originalValue?.value?.length > 0 &&
-                  originalValue.value[0].caption !== value.value[0].caption
+                  originalValue.value[0].caption !== value.value.caption
                 ) {
                   try {
                     const captionObservable = await this.mediaService.updateCaption(

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -359,7 +359,7 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
   }
 
   private async handleUpload(key: string, value: any) {
-    if (!value[0].value) return;
+    if (!value?.[0]?.value) return;
     try {
       const response: any = await lastValueFrom(this.mediaService.getById(value[0].value));
       this.form.patchValue({
@@ -666,7 +666,10 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
                   } catch (error: any) {
                     throw new Error(`Error deleting file: ${error.message}`);
                   }
-                } else if (originalValue?.value[0].caption !== value.value?.caption) {
+                } else if (
+                  originalValue?.value?.length > 0 &&
+                  originalValue.value[0].caption !== value.value?.caption
+                ) {
                   try {
                     const captionObservable = await this.mediaService.updateCaption(
                       originalValue.value[0].value,

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -681,7 +681,8 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
                     throw new Error(`Error updating caption: ${error.message}`);
                   }
                 } else {
-                  value.value = this.form.value[field.key]?.id || [];
+                  if (this.form.value[field.key]) value.value = [this.form.value[field.key]?.id];
+                  else value.value = [];
                 }
                 break;
               case 'image':

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -668,7 +668,7 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
                   }
                 } else if (
                   originalValue?.value?.length > 0 &&
-                  originalValue.value[0].caption !== value.value?.caption
+                  originalValue.value[0].caption !== value.value[0].caption
                 ) {
                   try {
                     const captionObservable = await this.mediaService.updateCaption(

--- a/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-edit/post-edit.component.ts
@@ -662,18 +662,18 @@ export class PostEditComponent extends BaseComponent implements OnInit, OnChange
                       this.form.value[field.key]?.id,
                     );
                     await lastValueFrom(deleteObservable);
-                    value.value = null;
+                    value.value = [];
                   } catch (error: any) {
                     throw new Error(`Error deleting file: ${error.message}`);
                   }
                 } else if (originalValue?.value[0].caption !== value.value?.caption) {
                   try {
                     const captionObservable = await this.mediaService.updateCaption(
-                      originalValue.value[0].id,
+                      originalValue.value[0].value,
                       value.value.caption,
                     );
                     await lastValueFrom(captionObservable);
-                    value.value = [originalValue.value[0].id];
+                    value.value = [originalValue.value[0].value];
                   } catch (error: any) {
                     throw new Error(`Error updating caption: ${error.message}`);
                   }

--- a/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-preview/post-preview.component.ts
@@ -44,7 +44,7 @@ export class PostPreviewComponent implements OnInit, OnChanges {
     if (changes['post']) {
       this.allowed_privileges = this.post?.allowed_privileges ?? '';
 
-      if (this.post.post_media) {
+      if (this.post.post_media && this.post.post_media.value.value) {
         this.mediaService.getById(this.post.post_media.value.value).subscribe({
           next: (media) => {
             this.media = media.result;


### PR DESCRIPTION
**Issue:**

When editing posts that have the old image field, but do not have an image uploaded, the user cannot save the edit due to an error around caption being missing.

**Solution:**

This PR adds better sanity checking in the old code, to prevent these errors from occurring. It also fixes some unreported issues around deleting and replacing images.

**Testing:**

1. Create a post with a survey that has the old image field, but do not upload any images.
2. Edit that post, without modifying the image field (no image or caption).
3. It will save changes successfully.
