### PR TITLE
USH-1686 - Cutoff posts for empty images

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
@@ -163,7 +163,9 @@
                 </div>
               </ng-container>
 
-              <ng-container *ngIf="field.input === 'upload' && field.value[0].url">
+              <ng-container
+                *ngIf="field.input === 'upload' && field.value.length === 1 && field.value[0].url"
+              >
                 <span *ngIf="!field.value[0].value">-</span>
                 <div class="post__media">
                   <img *ngIf="field.value[0].value" [src]="field.value[0].url" [alt]="post.title" />

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -188,16 +188,18 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
         if (Array.isArray(mediaField.value)) {
           const mediaFiles: MediaFile[] = [];
           for await (const mediaValue of mediaField.value) {
-            const media = await lastValueFrom(this.mediaService.getById(mediaValue.value!));
-            const mediaFile: MediaFile = new MediaFile(
-              media.result,
-              media.result.original_file_url,
-            );
-            mediaFile.id = mediaValue.id;
-            mediaFile.value = media.result.id;
-            mediaFile.caption = media.result.caption;
-            mediaFile.status = MediaFileStatus.READY;
-            mediaFiles.push(mediaFile);
+            if (mediaValue.value) {
+              const media = await lastValueFrom(this.mediaService.getById(mediaValue.value));
+              const mediaFile: MediaFile = new MediaFile(
+                media.result,
+                media.result.original_file_url,
+              );
+              mediaFile.id = mediaValue.id;
+              mediaFile.value = media.result.id;
+              mediaFile.caption = media.result.caption;
+              mediaFile.status = MediaFileStatus.READY;
+              mediaFiles.push(mediaFile);
+            }
           }
           mediaField.value = mediaFiles;
         } else if (mediaField.value?.value) {


### PR DESCRIPTION
**Issue:**

Posts that use the old image field, are cutoff when no image was uploaded.

**Solution:**

This PR adds some minor sanity checks to prevent this from happening.

**Testing:**

1. Create a post in a survey that uses the old image field, but importantly this field cannot be the last one in the post. Make sure there are fields filled in after the image field and that the image field itself is empty (no file uploaded).
2. Open the post in detail view.
3. See that all fields are included in the view and the post is not cutoff.