### PR TITLE
[USH-1679] Rename the heading of the new post screen to 'Add New Post'

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-routing.module.ts
+++ b/apps/web-mzima-client/src/app/post/post-routing.module.ts
@@ -12,7 +12,7 @@ const routes: Routes = [
   {
     path: 'create/:type',
     component: PostEditComponent,
-    data: { breadcrumb: 'Create Post' },
+    data: { breadcrumb: 'Add New Post' },
   },
   {
     path: ':id/edit',


### PR DESCRIPTION
Renaming the heading of the new post breadcrumb to 'Add New Post'

**Testing**
- [ ] Open https://mzima-dev.staging.ush.zone/map
- [ ] Click on 'Add New Post'
- [ ] Observe the heading/breadcrumb text at the top

Previously it was 'Create Post' but now it's 'Add New Post'