### PR TITLE
[USH-1690] Localize heading texts in post-routing.module to support translation

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-routing.module.ts
+++ b/apps/web-mzima-client/src/app/post/post-routing.module.ts
@@ -12,13 +12,13 @@ const routes: Routes = [
   {
     path: 'create/:type',
     component: PostEditComponent,
-    data: { breadcrumb: 'Add New Post' },
+    data: { breadcrumb: 'nav.add_new_post' },
   },
   {
     path: ':id/edit',
     canActivate: [RedirectGuard],
     component: PostEditComponent,
-    data: { breadcrumb: 'Edit Post', edit: true },
+    data: { breadcrumb: 'nav.edit_post', edit: true },
   },
 ];
 

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -749,7 +749,9 @@
     "yesterday": "Yesterday",
     "map": "Map",
     "data": "Data",
-    "feed": "Data view"
+    "feed": "Data view",
+    "add_new_post":"Add New Post",
+    "edit_post": "Edit Post"
   },
   "views": {
     "map": "Map view",


### PR DESCRIPTION
**Describe the bug**
The text in the post-routing.module.ts are not localized. 
This applies to 'Create Post' (now called 'Add New Post') and 'Edit Post'

**To Reproduce**
Navigate to the `web-mzima-client/src/app/post/post-routing.module.ts`
Observe lines 15 and 21

**To Test**

- [ ] Go to mzima-dev web platform and create a post. Select your desired survey and proceed
- [ ] Notice the header text and confirm if it appears as it should in English
