### PR TITLE
[USH-1691] All the posts on web show a timeline of 'a long time ago'

### DIFF
--- a/libs/sdk/src/lib/helpers/api.ts
+++ b/libs/sdk/src/lib/helpers/api.ts
@@ -15,7 +15,7 @@ export const ONLY = {
   NAME_COLOR_PERMISSIONS: 'name,color,everyone_can_create,can_create',
   NAME_ID_DESCRIPTION: 'name,id,description',
   NEEDED_POSTS_LIST_PROPERTIES:
-    'id,title,status,color,contact,locks,post_media,data_source_message_id',
+    'id,title,status,color,contact,locks,post_media,data_source_message_id,post_date',
 };
 
 export const API_V_3 = `api/v3/`;


### PR DESCRIPTION
**Issue Solved:**
Previously all posts were showing 'a long time ago', including the recent posts, without showing the actual posting dates. This also affected the recent posts

**Approach:**
Added `post-date` to the list of only parameters being called

**Testing:**

- [ ] Open https://mzima-dev.staging.ush.zone/feed
- [ ] Observe that the posts timelines are now correct