### PR TITLE
[USH-1698] The discard-button when deleting a post has disappeared

### DIFF
--- a/apps/web-mzima-client/src/app/core/services/confirm-modal.service.ts
+++ b/apps/web-mzima-client/src/app/core/services/confirm-modal.service.ts
@@ -8,8 +8,8 @@ interface ConfirmModalProps {
   buttonSuccess?: string;
   confirmButtonText?: string;
   cancelButtonText?: string;
-  actionButtonText?: string;
   isCancelDestructive?: boolean;
+  isConfirmNotDestructive?: boolean;
 }
 
 @Injectable({
@@ -25,8 +25,8 @@ export class ConfirmModalService {
       buttonSuccess: params.buttonSuccess,
       confirmButtonText: params.confirmButtonText,
       cancelButtonText: params.cancelButtonText,
-      actionButtonText: params.actionButtonText,
       isCancelDestructive: params.isCancelDestructive,
+      isConfirmNotDestructive: params.isConfirmNotDestructive,
     };
     return new Promise<boolean>((resolve, reject) => {
       const dialogRef = this.dialog.open(ConfirmModalComponent, {

--- a/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.ts
@@ -352,8 +352,9 @@ export class SurveyItemComponent extends BaseComponent implements OnInit {
         title: this.translate.instant('notify.default.discard_changes'),
         description: this.translate.instant('notify.default.survey_has_not_been_saved'),
         cancelButtonText: 'Discard Changes',
-        actionButtonText: 'Save Changes',
+        confirmButtonText: 'Save Changes',
         isCancelDestructive: true,
+        isConfirmNotDestructive: true,
       });
 
       if (confirmed) {

--- a/apps/web-mzima-client/src/app/shared/components/confirm-modal/confirm-modal.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/confirm-modal/confirm-modal.component.html
@@ -46,20 +46,11 @@
         {{ data.cancelButtonText || ('app.cancel' | translate) }}
       </mzima-client-button>
       <mzima-client-button
-        *ngIf="data.confirmButtonText"
-        color="danger"
+        [color]="data.isConfirmNotDestructive ? 'primary' : 'danger'"
         [mat-dialog-close]="true"
         [data-qa]="'btn-confirm-delete'"
       >
         {{ data.confirmButtonText || ('app.delete' | translate) }}
-      </mzima-client-button>
-      <mzima-client-button
-        *ngIf="data.actionButtonText"
-        color="primary"
-        [mat-dialog-close]="true"
-        [data-qa]="'btn-confirm-action'"
-      >
-        {{ data.actionButtonText || ('app.confirm' | translate) }}
       </mzima-client-button>
     </ng-container>
   </mat-dialog-actions>

--- a/apps/web-mzima-client/src/app/shared/components/confirm-modal/confirm-modal.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/confirm-modal/confirm-modal.component.ts
@@ -7,8 +7,8 @@ export interface ConfirmDialogData {
   buttonSuccess?: string;
   confirmButtonText?: string;
   cancelButtonText?: string;
-  actionButtonText?: string;
   isCancelDestructive?: boolean;
+  isConfirmNotDestructive?: boolean;
 }
 
 @Component({


### PR DESCRIPTION
Removed the unnecessary action button and defined two conditions to the ones that existed before

- By default the 'confirm' button is set to `danger,` but if the button isn't destructive, it will display in `primary`
- By default the 'cancel' button is set to `outline`, but if the button is destructive, it will display in `danger`

Developers will now have to define if the buttons are destructive or not in the code so as to conditionally change their appearance eg:
   
```
isCancelDestructive?: true;
isConfirmNotDestructive?: true;
```
How QA can test this

- [ ] Open any confirmation modal in the system to check this
- [ ] Try creating a new survey > insert text on any field > press cancel instead of save changes ...and observe that the confirmation modal is one of the examples that fulfills what was stated above