### PR TITLE
[USH-1632] Use only parameters for category in web client

### DIFF
--- a/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
+++ b/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
@@ -27,11 +27,13 @@ export class CategoriesComponent {
   }
 
   public getCategories(): void {
-    this.categoriesService.get().subscribe({
-      next: (data) => {
-        this.categories = data.results;
-      },
-    });
+    this.categoriesService
+      .getCategories({ only: 'id,parent_id,tag,slug,children,parent' })
+      .subscribe({
+        next: (data) => {
+          this.categories = data.results;
+        },
+      });
   }
 
   public displayChildren(id: number) {

--- a/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
+++ b/apps/web-mzima-client/src/app/settings/categories/categories.component.ts
@@ -1,6 +1,6 @@
 import { Component, QueryList, ViewChildren } from '@angular/core';
 import { CategoryItemComponent } from './category-item/category-item.component';
-import { CategoriesService, CategoryInterface } from '@mzima-client/sdk';
+import { apiHelpers, CategoriesService, CategoryInterface } from '@mzima-client/sdk';
 import { forkJoin } from 'rxjs';
 import { ConfirmModalService, NotificationService } from '@services';
 import { TranslateService } from '@ngx-translate/core';
@@ -28,7 +28,7 @@ export class CategoriesComponent {
 
   public getCategories(): void {
     this.categoriesService
-      .getCategories({ only: 'id,parent_id,tag,slug,children,parent' })
+      .getCategories({ only: apiHelpers.ONLY.TAG_ID_PARENTID_PARENT_SLUG_CHILDREN })
       .subscribe({
         next: (data) => {
           this.categories = data.results;

--- a/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.ts
+++ b/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.ts
@@ -165,7 +165,7 @@ export class CreateCategoryFormComponent extends BaseComponent implements OnInit
   }
 
   private getCategories() {
-    this.categoriesService.get().subscribe({
+    this.categoriesService.getCategories({ only: 'id,parent,parent_id,slug,tag' }).subscribe({
       next: (data) => {
         this.categories = data.results
           .filter((cat: CategoryInterface) => !cat.parent_id)

--- a/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.ts
+++ b/apps/web-mzima-client/src/app/settings/categories/create-category-form/create-category-form.component.ts
@@ -3,7 +3,7 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angu
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-import { TranslationInterface, LanguageInterface } from '@mzima-client/sdk';
+import { TranslationInterface, LanguageInterface, apiHelpers } from '@mzima-client/sdk';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { formHelper } from '@helpers';
@@ -165,13 +165,15 @@ export class CreateCategoryFormComponent extends BaseComponent implements OnInit
   }
 
   private getCategories() {
-    this.categoriesService.getCategories({ only: 'id,parent,parent_id,slug,tag' }).subscribe({
-      next: (data) => {
-        this.categories = data.results
-          .filter((cat: CategoryInterface) => !cat.parent_id)
-          .filter((cat: CategoryInterface) => cat.id !== this.category?.id);
-      },
-    });
+    this.categoriesService
+      .getCategories({ only: apiHelpers.ONLY.TAG_ID_PARENTID_PARENT_SLUG })
+      .subscribe({
+        next: (data) => {
+          this.categories = data.results
+            .filter((cat: CategoryInterface) => !cat.parent_id)
+            .filter((cat: CategoryInterface) => cat.id !== this.category?.id);
+        },
+      });
   }
 
   private getRoles() {

--- a/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.ts
@@ -118,7 +118,7 @@ export class CreateFieldModalComponent implements OnInit {
   private getCategories() {
     const array: MultilevelSelectOption[] = [];
     this.categoriesService
-      .get()
+      .getCategories({ only: 'id,parent_id,tag,children' })
       .pipe(
         map((res) => {
           for (const category of res?.results) {

--- a/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/create-field-modal/create-field-modal.component.ts
@@ -10,6 +10,7 @@ import {
   CategoryInterface,
   FormAttributeInterface,
   SurveyItem,
+  apiHelpers,
 } from '@mzima-client/sdk';
 import { NotificationService } from '@services';
 import _ from 'lodash';
@@ -118,7 +119,7 @@ export class CreateFieldModalComponent implements OnInit {
   private getCategories() {
     const array: MultilevelSelectOption[] = [];
     this.categoriesService
-      .getCategories({ only: 'id,parent_id,tag,children' })
+      .getCategories({ only: apiHelpers.ONLY.TAG_ID_PARENTID_CHILDREN })
       .pipe(
         map((res) => {
           for (const category of res?.results) {

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -330,33 +330,35 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
   }
 
   private getCategories() {
-    this.categoriesService.getCategories({ only: 'id,parent_id,tag,children' }).subscribe({
-      next: (response) => {
-        const mainResults = response?.results.filter((c: CategoryInterface) => !c.parent_id);
-        this.categoriesData = mainResults?.map((category: CategoryInterface) => {
-          return {
-            id: category.id,
-            name: category.tag,
-            children: category?.children?.map((cat: CategoryInterface) => {
-              return {
-                id: cat.id,
-                name: cat.tag,
-              };
-            }),
-          };
-        });
-        if (!this.categoriesData.length) {
-          document.body.classList.add('filters-panel-no-categories');
-        } else {
-          document.body.classList.remove('filters-panel-no-categories');
-        }
-      },
-      error: (err) => {
-        if (err.message.match(/Http failure response for/)) {
-          setTimeout(() => this.getCategories(), 2000);
-        }
-      },
-    });
+    this.categoriesService
+      .getCategories({ only: apiHelpers.ONLY.TAG_ID_PARENTID_CHILDREN })
+      .subscribe({
+        next: (response) => {
+          const mainResults = response?.results.filter((c: CategoryInterface) => !c.parent_id);
+          this.categoriesData = mainResults?.map((category: CategoryInterface) => {
+            return {
+              id: category.id,
+              name: category.tag,
+              children: category?.children?.map((cat: CategoryInterface) => {
+                return {
+                  id: cat.id,
+                  name: cat.tag,
+                };
+              }),
+            };
+          });
+          if (!this.categoriesData.length) {
+            document.body.classList.add('filters-panel-no-categories');
+          } else {
+            document.body.classList.remove('filters-panel-no-categories');
+          }
+        },
+        error: (err) => {
+          if (err.message.match(/Http failure response for/)) {
+            setTimeout(() => this.getCategories(), 2000);
+          }
+        },
+      });
   }
 
   private getActiveFilters(values: any): void {

--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -330,7 +330,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
   }
 
   private getCategories() {
-    this.categoriesService.get().subscribe({
+    this.categoriesService.getCategories({ only: 'id,parent_id,tag,children' }).subscribe({
       next: (response) => {
         const mainResults = response?.results.filter((c: CategoryInterface) => !c.parent_id);
         this.categoriesData = mainResults?.map((category: CategoryInterface) => {

--- a/libs/sdk/src/lib/helpers/api.ts
+++ b/libs/sdk/src/lib/helpers/api.ts
@@ -16,6 +16,9 @@ export const ONLY = {
   NAME_ID_DESCRIPTION: 'name,id,description',
   NEEDED_POSTS_LIST_PROPERTIES:
     'id,title,status,color,contact,locks,post_media,data_source_message_id,post_date',
+  TAG_ID_PARENTID_PARENT_SLUG: 'tag,id,parent_id,parent,slug',
+  TAG_ID_PARENTID_PARENT_SLUG_CHILDREN: 'tag,id,parent_id,parent,slug,children',
+  TAG_ID_PARENTID_CHILDREN: 'tag,id,parent_id,children',
 };
 
 export const API_V_3 = `api/v3/`;

--- a/libs/sdk/src/lib/services/categories.service.ts
+++ b/libs/sdk/src/lib/services/categories.service.ts
@@ -26,4 +26,8 @@ export class CategoriesService extends ResourceService<any> {
   getResourceUrl(): string {
     return 'categories';
   }
+
+  public getCategories(params: any) {
+    return super.get('', params);
+  }
 }


### PR DESCRIPTION
Add only parameters for categories:
- Settings:
  - Categories (List, creating or editing)
  - Survey "add field modal" (when adding or editing a new survey)
- Map view's categories endpoint usage