### PR TITLE
Removing re-fetch of categories if there is an error from the API

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/search-form/search-form.component.ts
@@ -352,9 +352,7 @@ export class SearchFormComponent extends BaseComponent implements OnInit {
         }
       },
       error: (err) => {
-        if (err.message.match(/Http failure response for/)) {
-          setTimeout(() => this.getCategories(), 2000);
-        }
+        console.log('getCategories:', err);
       },
     });
   }


### PR DESCRIPTION
Removing refetch of Categories in filters if the original request fails (this caused a never ending fetch of categories in the web-client when the API returned an error).
To test (check both as logged out and logged in):
- Go to the deployment
- Check the network tab
- [ ]  Only one request for categories should be made
- [ ] If the request has returned an error (happens right now in mzima-dev), no categories show up in the filters-bar (there are no Categories to show)
- [ ] If the request has returned an error, the client should not keep trying