### PR TITLE
Using only-parameters for surveys + other performance issue

### DIFF
--- a/apps/mobile-mzima-client/src/app/map/components/filters-form/filters-form.component.ts
+++ b/apps/mobile-mzima-client/src/app/map/components/filters-form/filters-form.component.ts
@@ -8,6 +8,7 @@ import {
   SavedsearchesService,
   SurveyItem,
   SurveysService,
+  apiHelpers,
 } from '@mzima-client/sdk';
 import { Subject, debounceTime, lastValueFrom, takeUntil } from 'rxjs';
 import { AlertService, EnvService, SearchService, SessionService } from '@services';
@@ -311,7 +312,7 @@ export class FiltersFormComponent implements OnChanges, OnDestroy {
       this.activeFilters = null;
     }
     this.surveys = null;
-    this.surveysService.get().subscribe({
+    this.surveysService.getSurveys('', { only: apiHelpers.ONLY.NAME_ID_COLOR }).subscribe({
       next: (response) => {
         this.surveys = response.results;
         this.initSurveyFilters(isDeplaymentChanged);

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.html
@@ -1,12 +1,15 @@
 <app-header (back)="backNavigation()" title="{{!postId ? 'Create' : 'Edit'}} post"></app-header>
 
 <ion-content class="ion-padding-horizontal ion-padding-top page">
-  <ng-container *ngIf="!surveyList.length">
+  <ng-container *ngIf="!surveyList.length && !postId">
     <p>{{'app.loading' | translate}}</p>
+  </ng-container>
+  <ng-container *ngIf="postId && !selectedSurvey">
+    <p>{{'app.loading_post' | translate}}</p>
   </ng-container>
 
   <ng-container *ngIf="surveyList.length && !form">
-    <ion-title class="list-title">Select a survey</ion-title>
+    <ion-title class="list-title">{{'app.select_survey' | translate}} </ion-title>
     <ion-list class="list">
       <ion-item
         class="list-item"
@@ -27,9 +30,13 @@
     [disabled]="!!postId"
     [(ngModel)]="selectedSurveyId"
     (ngModelChange)="loadForm()"
-    *ngIf="form"
+    *ngIf="form && !postId"
   >
   </app-select>
+  <ion-title class="list-title survey-title" *ngIf="selectedSurvey&& postId">
+    {{selectedSurvey.name}}</ion-title
+  >
+
   <form
     class="form-post-create"
     novalidate

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.scss
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.scss
@@ -6,6 +6,13 @@
   margin-top: 24px;
 }
 
+.survey-title {
+  margin-top: 16px;
+  background-color: var(--ion-item-background);
+  min-height: 40px;
+  padding: 14px;
+}
+
 .other {
   display: flex;
   align-items: center;

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
@@ -11,6 +11,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { STORAGE_KEYS } from '@constants';
 import {
+  apiHelpers,
   GeoJsonFilter,
   MediaService,
   PostContent,
@@ -131,9 +132,9 @@ export class PostEditPage {
 
     this.filters = this.getFilters();
     this.post = await this.checkPost();
-    this.surveyList = await this.getSurveys();
-
-    if (this.post) {
+    if (!this.post) {
+      this.surveyList = await this.getSurveys();
+    } else {
       this.selectedSurveyId = this.post.form_id!;
       this.loadForm(this.selectedSurveyId, this.post.post_content);
     }
@@ -203,16 +204,32 @@ export class PostEditPage {
       : 'The connection was lost, the information will be saved to the database';
   }
 
+  async getSurvey(): Promise<any> {
+    if (this.isConnection) {
+      try {
+        const response: any = await lastValueFrom(
+          this.surveysService.getSurveyById(this.selectedSurveyId!),
+        );
+        return response.result;
+      } catch (err) {
+        return this.loadSurveyFormLocalDB();
+      }
+    } else {
+      return this.loadSurveyFormLocalDB();
+    }
+  }
+
   async getSurveys(): Promise<any[]> {
     if (this.isConnection) {
       try {
-        const response: any = await this.surveysService
-          .getSurveys('', {
+        const response: any = await lastValueFrom(
+          this.surveysService.getSurveys('', {
             page: 1,
             order: 'asc',
             limit: 0,
-          })
-          .toPromise();
+            only: apiHelpers.ONLY.NAME_COLOR_PERMISSIONS,
+          }),
+        );
 
         const filteredSurveys = response.results.filter((survey: any) => {
           return (
@@ -227,10 +244,10 @@ export class PostEditPage {
         return filteredSurveys;
       } catch (err) {
         console.log(err);
-        return this.loadSurveyFormLocalDB();
+        return this.loadSurveysFormLocalDB();
       }
     } else {
-      return this.loadSurveyFormLocalDB();
+      return this.loadSurveysFormLocalDB();
     }
   }
 
@@ -275,16 +292,15 @@ export class PostEditPage {
       : new PostEditForm(this.formBuilder).addFormControl(value, field);
   }
 
-  loadForm(surveyId?: any, updateContent?: PostContent[]) {
+  async loadForm(surveyId?: any, updateContent?: PostContent[]) {
     if (surveyId) this.selectedSurveyId = surveyId;
     if (!this.selectedSurveyId) return;
     this.clearData();
-
-    this.selectedSurvey = this.surveyList.find((item: any) => item.id === this.selectedSurveyId);
+    this.selectedSurvey = await this.getSurvey();
     this.requireApproval = this.selectedSurvey?.require_approval;
     this.color = this.selectedSurvey?.color;
     this.tasks = this.selectedSurvey?.tasks;
-
+    console.log(this.selectedSurvey);
     const fields: any = {};
     for (const task of this.tasks ?? []) {
       task.fields
@@ -387,8 +403,16 @@ export class PostEditPage {
   public setCalendar(event: any, key: any, type: string) {
     this.updateFormControl(key, dateHelper.setDate(event.detail.value, type));
   }
-
-  private async loadSurveyFormLocalDB(): Promise<any[]> {
+  private async loadSurveyFormLocalDB(): Promise<any> {
+    if (!this.selectedSurveyId) return null;
+    try {
+      const surveysFromDB: any[] = await this.dataBaseService.get(STORAGE_KEYS.SURVEYS);
+      return surveysFromDB.find((survey) => survey.id === this.selectedSurveyId) || null;
+    } catch (error: any) {
+      throw new Error(`Error loading surveys from local database: ${error.message}`);
+    }
+  }
+  private async loadSurveysFormLocalDB(): Promise<any[]> {
     try {
       const surveysFromDB: any[] = await this.dataBaseService.get(STORAGE_KEYS.SURVEYS);
       const filteredSurveys = surveysFromDB.filter((survey) => {

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
@@ -300,7 +300,6 @@ export class PostEditPage {
     this.requireApproval = this.selectedSurvey?.require_approval;
     this.color = this.selectedSurvey?.color;
     this.tasks = this.selectedSurvey?.tasks;
-    console.log(this.selectedSurvey);
     const fields: any = {};
     for (const task of this.tasks ?? []) {
       task.fields

--- a/apps/mobile-mzima-client/src/assets/locales/en.json
+++ b/apps/mobile-mzima-client/src/assets/locales/en.json
@@ -75,6 +75,8 @@
       "toc_text":"<p>These Terms of Service (the “Terms”) and our Privacy Policy apply to and govern your use of any websites owned or operated by Ushahidi Inc. (“Ushahidi”) that post a link to these Terms (such websites, the “Sites”), the Ushahidi services accessible via the Sites (including any cloud-based servers or platforms) and the Ushahidi mobile device applications (the “Apps”).</p><p>To make these Terms easier to read, the Sites, our services, platforms, and Apps are collectively called the “Services.” Please note that these Terms do not cover any of our products you download under an open source license. Additionally, these Terms may not apply if you have entered into a separate agreement with Ushahidi that governs your relationship with us, such as a separately-negotiated enterprise agreement.</p><h2>Agreement To Terms</h2><p>these Terms, do not use the Services. If you are accessing and using the Services on behalf of a company (such as your employer) or other legal entity, you represent and warrant that you have the authority to bind that company or other legal entity to these Terms.</p><p>In that case, “you” and “your” will refer to that company or other legal entity.</p>",
       "skip": "Skip",
       "loading":"Fetching Surveys...",
+      "loading_post":"Loading post",
+      "select_survey": "Select a survey",
       "emtpy_field_error": "This field cannot be empty",
       "info" : {
         "auth_not_online" : "Sorry. You're offline…please check your internet connection",


### PR DESCRIPTION
This PR 1. use ONLY-parameters for surveys and 2. only loads the connected survey when editing a post.

To test:
For filters:
- Select filters->Surveys
- [ ] The list should display Surveys
- [ ] The request to get the survey should use ONLY parameters 
- [ ] When selecting a filter, only posts matching the filter should appear
For adding/editing posts:
- [ ] When adding a post, the survey-list should appear as usual, but faster
- [ ] When clicking on a survey, there will be a little delay, because the whole survey is then loaded from the API
- [ ] When editing a post, only the survey that the post is connected to is loaded from the API

This PR fixes USH-1513 and USH-800
