### PR TITLE
[USH-1706] Onboarding guide stops progressing after 'filtering' modal

### DIFF
--- a/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.ts
@@ -57,12 +57,12 @@ export class OnboardingComponent implements AfterViewInit {
           this.router.navigate(['/settings']);
         }
 
-        // if (this.onboardingSteps[data.order].dynamic) {
-        //   setTimeout(() => {
-        //     this.customTourService.updateHighlightedElements();
-        //     this.isHidden = false;
-        //   }, 1000);
-        // }
+        if (this.onboardingSteps[data.order].dynamic) {
+          setTimeout(() => {
+            this.customTourService.updateHighlightedElements();
+            this.isHidden = false;
+          }, 1000);
+        }
       },
     });
 

--- a/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.ts
@@ -97,14 +97,14 @@ export class OnboardingComponent implements AfterViewInit {
       next: () => this.initOnboarding(),
     });
 
-    this.eventBusService.on(EventType.FeedPostsLoaded).subscribe({
-      next: () => {
-        setTimeout(() => {
-          this.customTourService.updateHighlightedElements();
-          this.isHidden = false;
-        }, 100);
-      },
-    });
+    // this.eventBusService.on(EventType.FeedPostsLoaded).subscribe({
+    //   next: () => {
+    //     setTimeout(() => {
+    //       this.customTourService.updateHighlightedElements();
+    //       this.isHidden = false;
+    //     }, 100);
+    //   },
+    // });
 
     this.sessionService.isFiltersVisible$.pipe(untilDestroyed(this)).subscribe({
       next: (isFiltersVisible) => {

--- a/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.ts
@@ -104,6 +104,7 @@ export class OnboardingComponent implements AfterViewInit {
     //       this.isHidden = false;
     //     }, 100);
     //   },
+    //
     // });
 
     this.sessionService.isFiltersVisible$.pipe(untilDestroyed(this)).subscribe({

--- a/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/onboarding/onboarding.component.ts
@@ -97,16 +97,6 @@ export class OnboardingComponent implements AfterViewInit {
       next: () => this.initOnboarding(),
     });
 
-    // this.eventBusService.on(EventType.FeedPostsLoaded).subscribe({
-    //   next: () => {
-    //     setTimeout(() => {
-    //       this.customTourService.updateHighlightedElements();
-    //       this.isHidden = false;
-    //     }, 100);
-    //   },
-    //
-    // });
-
     this.sessionService.isFiltersVisible$.pipe(untilDestroyed(this)).subscribe({
       next: (isFiltersVisible) => {
         setTimeout(() => {


### PR DESCRIPTION
**Issue Description:**
The onboarding flow stops progressing after displaying the 'Filtering' guide. Following this, a persistent dark overlay appears, preventing any further interaction with the system. The overlay cannot be dismissed unless the user refreshes the page to regain access.

**Approach;**
I uncommented the code that delays the highlight update using setTimeout to ensure the DOM is fully rendered before proceeding. This snippet initially checks if the step is dynamic eg. 'sorting' requires the feed view to display so as to highlight the button