### PR TITLE
[USH-1727] Author is always anonymous

### DIFF
--- a/libs/sdk/src/lib/helpers/api.ts
+++ b/libs/sdk/src/lib/helpers/api.ts
@@ -14,7 +14,8 @@ export const ONLY = {
   NAME_ID_COLOR: 'name,id,color',
   NAME_COLOR_PERMISSIONS: 'name,color,everyone_can_create,can_create',
   NAME_ID_DESCRIPTION: 'name,id,description',
-  NEEDED_POSTS_LIST_PROPERTIES: 'id,title,content,status,color,contact,locks,post_media,data_source_message_id,post_date',
+  NEEDED_POSTS_LIST_PROPERTIES:
+    'id,title,content,author_realname,status,color,contact,locks,post_media,data_source_message_id,post_date',
   TAG_ID_PARENTID_PARENT_SLUG: 'tag,id,parent_id,parent,slug',
   TAG_ID_PARENTID_PARENT_SLUG_CHILDREN: 'tag,id,parent_id,parent,slug,children',
   TAG_ID_PARENTID_CHILDREN: 'tag,id,parent_id,children',


### PR DESCRIPTION
Fix: 
- Added `author_realname` to query params for feed view posts (for when loggedIn)