### PR TITLE
[USH-1733] Floating action buttons in the map view are slightly offset in iOS app

### DIFF
--- a/apps/mobile-mzima-client/src/app/map/map.page.scss
+++ b/apps/mobile-mzima-client/src/app/map/map.page.scss
@@ -24,7 +24,7 @@
   position: fixed;
 }
 .button-group {
-  bottom: 90px;
+  bottom: calc(90px + env(safe-area-inset-bottom, 0));
   position: fixed;
   right: var(--ion-padding);
   z-index: 1000;


### PR DESCRIPTION
Implementing the `safe area insets` in the CSS file to allow for proper alignment