### PR TITLE
[USH-1681] Show confirmation when one navigates from editing a survey or a post

### DIFF
--- a/apps/web-mzima-client/src/app/core/guards/deactivate-settings-route.guard.ts
+++ b/apps/web-mzima-client/src/app/core/guards/deactivate-settings-route.guard.ts
@@ -6,7 +6,6 @@ import { Observable } from 'rxjs';
 
 export interface IDeactivateGuard {
   changesMade: boolean | null;
-  browserBackButtonClicked: boolean;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -17,7 +16,7 @@ export class DeactivateGuardService implements CanDeactivate<IDeactivateGuard> {
   ) {}
 
   canDeactivate(component: IDeactivateGuard): boolean | Promise<boolean> | Observable<boolean> {
-    if (component.changesMade || (component.changesMade && component.browserBackButtonClicked)) {
+    if (component.changesMade) {
       const confirmModalResult = this.openConfirmModal().then((confirmed: boolean) => confirmed);
       return confirmModalResult;
     } else {

--- a/apps/web-mzima-client/src/app/core/guards/deactivate-settings-route.guard.ts
+++ b/apps/web-mzima-client/src/app/core/guards/deactivate-settings-route.guard.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { ConfirmModalService } from '@services';
+import { Observable } from 'rxjs';
+
+export interface IDeactivateGuard {
+  changesMade: boolean | null;
+  browserBackButtonClicked: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DeactivateGuardService implements CanDeactivate<IDeactivateGuard> {
+  constructor(
+    private confirmModalService: ConfirmModalService,
+    private translate: TranslateService,
+  ) {}
+
+  canDeactivate(component: IDeactivateGuard): boolean | Promise<boolean> | Observable<boolean> {
+    if (component.changesMade || (component.changesMade && component.browserBackButtonClicked)) {
+      const confirmModalResult = this.openConfirmModal().then((confirmed: boolean) => confirmed);
+      return confirmModalResult;
+    } else {
+      return true;
+    }
+  }
+
+  async openConfirmModal() {
+    const confirmed = await this.confirmModalService.open({
+      title: this.translate.instant('notify.default.discard_changes'),
+      description: this.translate.instant('notify.default.survey_has_not_been_saved'),
+      confirmButtonText: this.translate.instant('notify.survey.discard_changes'),
+      cancelButtonText: this.translate.instant('notify.survey.back_to_editing'),
+      isConfirmNotDestructive: false,
+      isCancelDestructive: false,
+    });
+    return confirmed;
+  }
+}

--- a/apps/web-mzima-client/src/app/settings/settings.module.ts
+++ b/apps/web-mzima-client/src/app/settings/settings.module.ts
@@ -12,6 +12,7 @@ import { SettingsComponent } from './settings/settings.component';
 import { FileUploaderComponent } from './components';
 import { SettingsLayoutComponent } from './settings-layout.component';
 import { MzimaUiModule } from '@mzima-client/mzima-ui';
+import { DeactivateGuardService } from '../core/guards/deactivate-settings-route.guard';
 
 @NgModule({
   declarations: [SettingsComponent, FileUploaderComponent, SettingsLayoutComponent],
@@ -26,6 +27,7 @@ import { MzimaUiModule } from '@mzima-client/mzima-ui';
     MatRippleModule,
     MzimaUiModule,
   ],
+  providers: [DeactivateGuardService],
   exports: [FileUploaderComponent],
 })
 export class SettingsModule {}

--- a/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.html
+++ b/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.html
@@ -144,7 +144,7 @@
   <mzima-client-button
     fill="outline"
     color="secondary"
-    (buttonClick)="openConfirmModal()"
+    (buttonClick)="navigateBack()"
     [data-qa]="'btn-cancel-survey-item'"
   >
     {{ 'app.cancel' | translate }}

--- a/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common';
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, HostListener, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -55,6 +55,7 @@ export class SurveyItemComponent extends BaseComponent implements OnInit {
   public errorTaskField = false;
   public submitted = false;
   isDefaultLanguageSelected = true;
+  public browserBackButtonClicked: boolean;
 
   constructor(
     protected override sessionService: SessionService,
@@ -344,25 +345,13 @@ export class SurveyItemComponent extends BaseComponent implements OnInit {
     }
   }
 
-  public async openConfirmModal() {
-    if (this.hasChanges()) {
-      const confirmed = await this.confirmModalService.open({
-        title: this.translate.instant('notify.default.discard_changes'),
-        description: this.translate.instant('notify.default.survey_has_not_been_saved'),
-        cancelButtonText: this.translate.instant('notify.survey.discard_changes'),
-        confirmButtonText: this.translate.instant('notify.survey.save_changes'),
-        isCancelDestructive: true,
-        isConfirmNotDestructive: true,
-      });
+  @HostListener('window:beforeunload', ['$event']) unloadNotification($event: any): void {
+    if (this.changesMade)
+      $event.returnValue = 'Form has changed! - Just to let browser popup show up';
+  }
 
-      if (confirmed) {
-        this.save();
-      } else {
-        this.navigateBack();
-      }
-    } else {
-      this.navigateBack();
-    }
+  @HostListener('window:popstate', ['$event']) onPopState() {
+    this.browserBackButtonClicked = true;
   }
 
   navigateBack() {

--- a/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/survey-item/survey-item.component.ts
@@ -55,7 +55,6 @@ export class SurveyItemComponent extends BaseComponent implements OnInit {
   public errorTaskField = false;
   public submitted = false;
   isDefaultLanguageSelected = true;
-  public browserBackButtonClicked: boolean;
 
   constructor(
     protected override sessionService: SessionService,
@@ -348,10 +347,6 @@ export class SurveyItemComponent extends BaseComponent implements OnInit {
   @HostListener('window:beforeunload', ['$event']) unloadNotification($event: any): void {
     if (this.changesMade)
       $event.returnValue = 'Form has changed! - Just to let browser popup show up';
-  }
-
-  @HostListener('window:popstate', ['$event']) onPopState() {
-    this.browserBackButtonClicked = true;
   }
 
   navigateBack() {

--- a/apps/web-mzima-client/src/app/settings/surveys/surveys-routing.module.ts
+++ b/apps/web-mzima-client/src/app/settings/surveys/surveys-routing.module.ts
@@ -3,13 +3,20 @@ import { RouterModule, Routes } from '@angular/router';
 import { SurveyItemComponent } from './survey-item/survey-item.component';
 
 import { SurveysComponent } from './surveys.component';
+import { DeactivateGuardService } from '../../core/guards/deactivate-settings-route.guard';
 
 const routes: Routes = [
   { path: '', component: SurveysComponent },
-  { path: 'create', component: SurveyItemComponent, data: { breadcrumb: 'survey.create_survey' } },
+  {
+    path: 'create',
+    component: SurveyItemComponent,
+    canDeactivate: [DeactivateGuardService],
+    data: { breadcrumb: 'survey.create_survey' },
+  },
   {
     path: 'update/:id',
     component: SurveyItemComponent,
+    canDeactivate: [DeactivateGuardService],
     data: { breadcrumb: 'survey.update_survey' },
   },
 ];

--- a/apps/web-mzima-client/src/assets/locales/en.json
+++ b/apps/web-mzima-client/src/assets/locales/en.json
@@ -2061,6 +2061,7 @@
       "destroy_confirm_desc_end": "You can <a href=\"settings/data-import\">download and import</a> all your data before deleting.",
       "discard_changes": "Discard changes",
       "save_changes": "Save Changes",
+      "back_to_editing": "Back to editing",
       "invalid_characters": "Please remove invalid characters (e.g. +, $, ^, =)",
       "translations_missing": "You need to add translations for all names, and ensure checkboxes and radios do not have duplicates. Check that you have translated the survey-names for all added languages and that your checkbox and radio button values are unique (within each language)."
     },


### PR DESCRIPTION
#### Fixes
- Angular confirm modal trigger on browser back button
- Angular confirm modal trigger on (sidebar and settings) router links click
- Default browser confirm modal

#### Other things to note
- `no changes made` snack bar popup if cancel button is clicked when there's no changes made to the form
- `canDeactivate` guard triggers all confirm modal activities, except for the cancel button
- `canDeactivate` guard also uses save information while processing routing