### PR TITLE
[USH-1777] Images dont appear as required when previewing post images on mobile

### DIFF
--- a/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
+++ b/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
@@ -62,7 +62,7 @@ export class ImageUploaderComponent implements ControlValueAccessor {
     };
 
     // Set preview URL
-    this.previewUrl = objData.url; // Directly assign the URL
+    this.previewUrl = this.domSanitizer.bypassSecurityTrustUrl(objData.url); // Directly assign the URL
     console.log('Updated previewUrl:', this.previewUrl);
   }
 

--- a/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
+++ b/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
@@ -62,7 +62,7 @@ export class ImageUploaderComponent implements ControlValueAccessor {
     };
 
     // Set preview URL
-    this.previewUrl = this.domSanitizer.bypassSecurityTrustUrl(objData.url); // Directly assign the URL
+    this.previewUrl = objData.url; // Directly assign the URL
     console.log('Updated previewUrl:', this.previewUrl);
   }
 

--- a/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
+++ b/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
@@ -139,7 +139,6 @@ export class ImageUploaderComponent implements ControlValueAccessor {
         };
       }
       this.previewUrl = this.domSanitizer.bypassSecurityTrustUrl(this.photo.data);
-      console.log('previewUrl from photo.webPath:', this.previewUrl);
       this.upload = true;
     } catch (e) {
       console.log(e);
@@ -213,7 +212,6 @@ export class ImageUploaderComponent implements ControlValueAccessor {
     let params = {
       caption: this.captionControl.value,
       photo: this.photo,
-      previewUrl: this.previewUrl,
       id: this.id,
     };
     params = { ...params, ...action };

--- a/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
+++ b/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
@@ -47,15 +47,23 @@ export class ImageUploaderComponent implements ControlValueAccessor {
   domSanitizer: DomSanitizer;
 
   writeValue(obj: any): void {
-    if (obj) {
-      console.log('writeValue > obj', obj);
-      this.upload = false;
-      this.captionControl.patchValue(obj.caption);
-      this.id = obj.id;
-      this.photo = obj.photo;
-      if (typeof obj.photo === 'string') this.previewUrl = obj.photo;
-      else this.previewUrl = this.domSanitizer.bypassSecurityTrustUrl(obj.photo.data);
-    }
+    if (!obj) return;
+    console.log('writeValue > obj', obj);
+    const objData = Array.isArray(obj) ? obj[0] : obj;
+
+    this.upload = false;
+    this.captionControl.patchValue(objData.caption);
+    this.id = objData.id;
+
+    this.photo = {
+      name: this.fileName,
+      path: objData.url,
+      data: objData.url,
+    };
+
+    // Set preview URL
+    this.previewUrl = objData.url; // Directly assign the URL
+    console.log('Updated previewUrl:', this.previewUrl);
   }
 
   registerOnChange(fn: any): void {
@@ -131,6 +139,7 @@ export class ImageUploaderComponent implements ControlValueAccessor {
         };
       }
       this.previewUrl = this.domSanitizer.bypassSecurityTrustUrl(this.photo.data);
+      console.log('previewUrl from photo.webPath:', this.previewUrl);
       this.upload = true;
     } catch (e) {
       console.log(e);
@@ -204,6 +213,7 @@ export class ImageUploaderComponent implements ControlValueAccessor {
     let params = {
       caption: this.captionControl.value,
       photo: this.photo,
+      previewUrl: this.previewUrl,
       id: this.id,
     };
     params = { ...params, ...action };

--- a/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
+++ b/apps/mobile-mzima-client/src/app/post/components/image-uploader/image-uploader.component.ts
@@ -48,7 +48,6 @@ export class ImageUploaderComponent implements ControlValueAccessor {
 
   writeValue(obj: any): void {
     if (!obj) return;
-    console.log('writeValue > obj', obj);
     const objData = Array.isArray(obj) ? obj[0] : obj;
 
     this.upload = false;
@@ -63,7 +62,6 @@ export class ImageUploaderComponent implements ControlValueAccessor {
 
     // Set preview URL
     this.previewUrl = this.domSanitizer.bypassSecurityTrustUrl(objData.url); // Directly assign the URL
-    console.log('Updated previewUrl:', this.previewUrl);
   }
 
   registerOnChange(fn: any): void {

--- a/apps/mobile-mzima-client/src/app/post/components/post-content/post-content.component.html
+++ b/apps/mobile-mzima-client/src/app/post/components/post-content/post-content.component.html
@@ -62,11 +62,8 @@
 
         <ng-container *ngIf="field.input === 'upload'">
           <ng-container *ngIf="isConnection; else noConnection">
-            <div class="post__media">
-              <ion-img
-                class="post__media"
-                [src]="field.value.mediaSrc | prependUrl : backendUrl"
-              ></ion-img>
+            <div class="post__media" *ngFor="let media of field.value">
+              <ion-img class="post__media" [src]="media.url"></ion-img>
               <span class="post__media__caption">
                 {{ field.value.mediaCaption }}
               </span>

--- a/apps/mobile-mzima-client/src/app/post/helpers/upload-file-progress.ts
+++ b/apps/mobile-mzima-client/src/app/post/helpers/upload-file-progress.ts
@@ -1,5 +1,5 @@
 import { HttpEventType, HttpProgressEvent } from '@angular/common/http';
-import { Directory, Filesystem } from '@capacitor/filesystem';
+// import { Directory, Filesystem } from '@capacitor/filesystem';
 import { MediaService } from '@mzima-client/sdk';
 import { lastValueFrom, Observable, tap } from 'rxjs';
 
@@ -8,7 +8,7 @@ export class UploadFileProgressHelper {
 
   async uploadFileField(
     field: any,
-    { data, name, caption, path }: any,
+    { data, name, caption }: any,
     progressCallback: (progress: number) => void,
   ) {
     try {
@@ -34,10 +34,10 @@ export class UploadFileProgressHelper {
         field.value = { value: [event.body.result.id] };
       }
 
-      Filesystem.deleteFile({
-        directory: Directory.Data,
-        path: path,
-      });
+      // Filesystem.deleteFile({
+      //   directory: Directory.Data,
+      //   path: path,
+      // });
     } catch (error: any) {
       throw new Error(`Error uploading file: ${error.message}`);
     }

--- a/apps/mobile-mzima-client/src/app/post/helpers/upload-file-progress.ts
+++ b/apps/mobile-mzima-client/src/app/post/helpers/upload-file-progress.ts
@@ -1,5 +1,5 @@
 import { HttpEventType, HttpProgressEvent } from '@angular/common/http';
-// import { Directory, Filesystem } from '@capacitor/filesystem';
+import { Directory, Filesystem } from '@capacitor/filesystem';
 import { MediaService } from '@mzima-client/sdk';
 import { lastValueFrom, Observable, tap } from 'rxjs';
 
@@ -8,7 +8,7 @@ export class UploadFileProgressHelper {
 
   async uploadFileField(
     field: any,
-    { data, name, caption }: any,
+    { data, name, caption, path }: any,
     progressCallback: (progress: number) => void,
   ) {
     try {
@@ -34,10 +34,10 @@ export class UploadFileProgressHelper {
         field.value = { value: [event.body.result.id] };
       }
 
-      // Filesystem.deleteFile({
-      //   directory: Directory.Data,
-      //   path: path,
-      // });
+      Filesystem.deleteFile({
+        directory: Directory.Data,
+        path: path,
+      });
     } catch (error: any) {
       throw new Error(`Error uploading file: ${error.message}`);
     }

--- a/apps/mobile-mzima-client/src/app/post/helpers/upload-file-progress.ts
+++ b/apps/mobile-mzima-client/src/app/post/helpers/upload-file-progress.ts
@@ -34,14 +34,22 @@ export class UploadFileProgressHelper {
         field.value = { value: [event.body.result.id] };
       }
 
-      Filesystem.deleteFile({
+      await Filesystem.stat({
         directory: Directory.Data,
         path: path,
-      });
+      })
+        .then(async () => {
+          await Filesystem.deleteFile({
+            directory: Directory.Data,
+            path: path,
+          });
+        })
+        .catch(() => {
+          console.warn(`File not found to delete: ${path}`);
+        });
     } catch (error: any) {
       throw new Error(`Error uploading file: ${error.message}`);
     }
-
     return field;
   }
 }

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
@@ -830,7 +830,7 @@ export class PostEditPage {
       for (const content of postData.post_content) {
         for (const field of content.fields) {
           if (field.input === 'upload') {
-            field.value.value = null;
+            field.value.value = [];
           }
         }
       }

--- a/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
+++ b/apps/mobile-mzima-client/src/app/post/post-edit/post-edit.page.ts
@@ -634,13 +634,18 @@ export class PostEditPage {
                   caption: this.form.value[field.key]?.caption,
                   upload: this.form.value[field.key]?.upload,
                 };
+                value.value = {
+                  photo: this.form.value[field.key]?.photo,
+                  caption: this.form.value[field.key]?.caption,
+                };
               } else if (this.form.value[field.key]?.delete && this.form.value[field.key]?.id) {
                 this.fileToUpload = {
                   fileId: this.form.value[field.key]?.id,
                   delete: this.form.value[field.key]?.delete,
                 };
+                value.value = [];
               } else {
-                value.value = this.form.value[field.key]?.id || null;
+                value.value = this.form.value[field.key]?.id || [];
               }
             } else if (field.input === 'checkbox') {
               if (
@@ -771,21 +776,24 @@ export class PostEditPage {
           if (field?.file?.delete) {
             postData = await this.deleteFile(postData, field.file);
           } else if (field.value.value && typeof field.value.value !== 'number') {
-            const photo = {
-              data: field.value.value.photo.data,
-              name: field.value.value.photo.name,
-              caption: field.value.value.caption,
-              path: field.value.value.photo.path,
-            };
-            const fieldUpload = new UploadFileProgressHelper(this.mediaService).uploadFileField(
-              field,
-              photo,
-              (progress) =>
-                setTimeout(() => {
-                  this.uploadProgress$[field.id].next(progress);
-                }),
-            );
-            promises.push(fieldUpload);
+            const photoValue = field.value.value;
+            if (photoValue && photoValue.photo && photoValue.photo.data) {
+              const photo = {
+                data: photoValue.photo.data,
+                name: photoValue.photo.name,
+                caption: photoValue.caption,
+                path: photoValue.photo.path,
+              };
+              const fieldUpload = new UploadFileProgressHelper(this.mediaService).uploadFileField(
+                field,
+                photo,
+                (progress) =>
+                  setTimeout(() => {
+                    this.uploadProgress$[field.id].next(progress);
+                  }),
+              );
+              promises.push(fieldUpload);
+            }
           }
         }
       }


### PR DESCRIPTION
Since the backend now supports uploads/media types in arrays;
- I have updated the HTML file to iterate over media arrays as opposed to a single media object
- Removed the `prependUrl` pipe and replaced it with direct access to `media.url.`

Also other bugs present in this PR that have been fixed:

- [x] The console should be clear of any errors (especially the FileReader bug), establish how this is implemented in the rest of the code/ handle it gracefully instead
-   [x] Editing a post; Previously uploaded photo in a post is not being displayed before replacing the image
-   [x] Editing a post; Submitting the post afterwards with the new image doesn't work
- [x] If a user submits a post with an optional image field left empty, the submission fails.
- [x] If a user deletes an image in edit mode and submits the post, it fails.
- [ ] Introduced bug: (Images preview disappear during submission process in edit mode)