### PR TITLE
Adjustments to make sure translations with media-fields are saved

### DIFF
--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.ts
@@ -352,6 +352,7 @@ export class PostDetailsComponent extends BaseComponent implements OnChanges, On
     dialogRef.afterClosed().subscribe((response) => {
       if (response) {
         this.post = response.post;
+        this.getData(this.post);
         this.displayLanguage = response.displayLanguage.code;
       }
     });

--- a/apps/web-mzima-client/src/app/post/post-translate/post-translate.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-translate/post-translate.component.ts
@@ -64,9 +64,8 @@ export class PostTranslateComponent implements OnInit {
   saveTranslation() {
     this.translateForm.disable();
     this.post.post_content.forEach((task: any) => {
-      task.fields
-        .filter((field: any) => field.key in this.translateForm.controls)
-        .forEach((field: any) => {
+      task.fields.forEach((field: any) => {
+        if (field.key in this.translateForm.controls) {
           const translatedValue = this.translateForm.controls[field.key].value;
           field.value = field.value || {};
           field.value.translations = field.value.translations || {};
@@ -86,10 +85,22 @@ export class PostTranslateComponent implements OnInit {
               this.post.translations[this.activeLanguage.code] || {};
             this.post.translations[this.activeLanguage.code][field.type] = translatedValue;
           }
-        });
+        } else {
+          if (field.input === 'upload' || field.type === 'media') {
+            if (field.value) {
+              const values = { value: [] as any[] };
+              field.value.forEach((value: any) => {
+                values.value.push(value.value);
+              });
+              field.value = values;
+            }
+          }
+        }
+      });
     });
     this.post.enabled_languages = { default: 'en', available: this.enabledLanguages };
     delete this.post.completed_stages;
+    this.translateForm.enable();
 
     this.postsService.updateTranslations(this.post.id, this.post).subscribe({
       next: ({ result }) => {

--- a/apps/web-mzima-client/src/app/post/post-translate/post-translate.component.ts
+++ b/apps/web-mzima-client/src/app/post/post-translate/post-translate.component.ts
@@ -85,28 +85,21 @@ export class PostTranslateComponent implements OnInit {
               this.post.translations[this.activeLanguage.code] || {};
             this.post.translations[this.activeLanguage.code][field.type] = translatedValue;
           }
-        } else {
-          if (field.input === 'upload' || field.type === 'media') {
-            if (field.value) {
-              const values = { value: [] as any[] };
-              field.value.forEach((value: any) => {
-                values.value.push(value.value);
-              });
-              field.value = values;
-            }
+        } else if (field.input === 'upload' || field.type === 'media') {
+          if (field.value) {
+            field.value = { value: field.value.map((v: any) => v.value) };
           }
         }
       });
     });
+
     this.post.enabled_languages = { default: 'en', available: this.enabledLanguages };
     delete this.post.completed_stages;
-    this.translateForm.enable();
 
     this.postsService.updateTranslations(this.post.id, this.post).subscribe({
       next: ({ result }) => {
         this.postsService.unlockPost(this.post.id).subscribe();
         this.showMessage('Translation saved successfully', 'success');
-        this.postsService.unlockPost(this.post.id).subscribe();
         this.closeModal({ displayLanguage: this.activeLanguage, post: result });
       },
       error: ({ error }) => {


### PR DESCRIPTION
The format of media and old image fields had to be adjusted before the translations could be saved. 

To test:
- Translations should be saved successfully for posts with all kinds of fields, especially media-fields