### PR TITLE
Displaying map when editing/viewing posts

### DIFF
--- a/apps/web-mzima-client/src/app/map/map.component.ts
+++ b/apps/web-mzima-client/src/app/map/map.component.ts
@@ -78,25 +78,26 @@ export class MapComponent extends MainViewComponent implements OnInit {
   }
 
   initBaseLayers() {
-    const baseLayers = mapHelper
-      .getOpenLayersMapConfig()
-      .filter((layer) => layer.visible)
-      .map(
-        (layer) =>
-          new TileLayer({
-            title: layer.name,
-            type: 'base',
-            visible: this.mapConfig.default_view?.baselayer === layer.code,
-            source: new XYZ({
-              url: layer.url,
-              maxZoom: 'maxZoom' in layer.layerOptions ? layer.layerOptions.maxZoom : undefined,
-            }),
-          } as BaseLayerOptions),
-      );
+    const baseLayers = mapHelper.getOpenLayersMapConfig().filter((layer) => layer.visible);
+    const visibleLayer =
+      baseLayers.find((layer) => layer.code === this.mapConfig.default_view?.baselayer)?.code ||
+      'streets';
+    const selectableLayers = baseLayers.map(
+      (layer) =>
+        new TileLayer({
+          title: layer.name,
+          type: 'base',
+          visible: visibleLayer === layer.code,
+          source: new XYZ({
+            url: layer.url,
+            maxZoom: 'maxZoom' in layer.layerOptions ? layer.layerOptions.maxZoom : undefined,
+          }),
+        } as BaseLayerOptions),
+    );
 
     this.baseMaps = new LayerGroup({
       title: 'Base Maps',
-      layers: baseLayers,
+      layers: selectableLayers,
     } as GroupLayerOptions);
   }
 

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.html
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.html
@@ -1,4 +1,4 @@
-<div class="map-holder">
+<!-- <div class="map-holder">
   <div
     leaflet
     class="map"
@@ -12,11 +12,43 @@
   <button type="button" class="btn-current-location" (click)="getCurrentLocation()">
     <mat-icon class="btn-current-location_icon" svgIcon="current-location"></mat-icon>
   </button>
+</div> -->
+<div id="ol-map" class="map-container">
+  <div class="form-row search" [data-qa]="'location-search'">
+    <mat-form-field appearance="outline">
+      <input
+        id="search-input"  
+        matInput
+        (keyup)="query$.next($event)"
+        placeholder="Search for addresses, placenames, or coordinates..."
+      />
+      <mzima-client-button
+      matPrefix
+      fill="clear"
+      color="secondary"
+      [iconOnly]="true"
+      *ngIf="locations.length === 0"
+    >
+      <mat-icon icon svgIcon="search-small"></mat-icon>
+    </mzima-client-button>
+    <ul id="search-results" class="search-results">
+      <li *ngFor="let location of locations" (click)="selectLocation(location)">
+        {{ location.display_name }}
+      </li>
+    </ul>
+    </mat-form-field>
+  </div>
 </div>
+
+
 
 <span class="instructions">
   {{ 'post.location.you_can_search_or_click' | translate }}
 </span>
+
+
+
+
 <div *ngIf="location">
   <div class="form-row">
     <mat-label

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.html
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.html
@@ -1,49 +1,42 @@
 <div class="form-row search" [data-qa]="'location-search'">
-<mat-form-field appearance="outline">
-  <input
-    id="search-input"  
-    matInput
-    (keyup)="query$.next($event)"
-    placeholder="{{ 'post.location.search_address' | translate }}"
-    [data-qa]="'query-location'"
-/>
+  <mat-form-field appearance="outline">
+    <input
+      id="search-input"  
+      matInput
+      (keyup)="query$.next($event)"
+      placeholder="{{ 'post.location.search_address' | translate }}"
+      [data-qa]="'query-location'"
+  />
 
-<mzima-client-button 
-[iconOnly]="true" 
-fill="clear" 
-matSuffix 
-color="secondary">
-  <mat-icon icon svgIcon="search-small"></mat-icon>
-</mzima-client-button>
-</mat-form-field>
+  <mzima-client-button 
+  [iconOnly]="true" 
+  fill="clear" 
+  matSuffix 
+  color="secondary">
+    <mat-icon icon svgIcon="search-small"></mat-icon>
+  </mzima-client-button>
+  </mat-form-field>
 
-<ul
-class="geocoder-list"
-*ngIf="locations && locations.length > 0"
-[data-qa]="'geocoder-list'"
->
-<li
-  class="geocoder-list__item"
-  *ngFor="let location of locations"
-  (click)="selectLocation(location)"
-  [data-qa]="'geocoder-list-item'"
->
-  {{ location.display_name }}
-</li>
-</ul>
+  <ul
+  class="geocoder-list"
+  *ngIf="locations && locations.length > 0"
+  [data-qa]="'geocoder-list'"
+  >
+  <li
+    class="geocoder-list__item"
+    *ngFor="let location of locations"
+    (click)="selectLocation(location)"
+    [data-qa]="'geocoder-list-item'"
+  >
+    {{ location.display_name }}
+  </li>
+  </ul>
 </div>  
 <div id="ol-map" class="map-container"></div>
-
-
-
-
 
 <span class="instructions">
   {{ 'post.location.you_can_search_or_click' | translate }}
 </span>
-
-
-
 
 <div *ngIf="location">
   <div class="form-row">

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.html
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.html
@@ -1,44 +1,40 @@
-<!-- <div class="map-holder">
-  <div
-    leaflet
-    class="map"
-    *ngIf="mapReady"
-    [leafletLayers]="mapLayers"
-    [leafletOptions]="leafletOptions"
-    [leafletFitBounds]="mapFitToBounds"
-    (leafletMapReady)="onMapReady($event)"
-    [leafletFitBoundsOptions]="fitBoundsOptions"
-  ></div>
-  <button type="button" class="btn-current-location" (click)="getCurrentLocation()">
-    <mat-icon class="btn-current-location_icon" svgIcon="current-location"></mat-icon>
-  </button>
-</div> -->
-<div id="ol-map" class="map-container">
-  <div class="form-row search" [data-qa]="'location-search'">
-    <mat-form-field appearance="outline">
-      <input
-        id="search-input"  
-        matInput
-        (keyup)="query$.next($event)"
-        placeholder="Search for addresses, placenames, or coordinates..."
-      />
-      <mzima-client-button
-      matPrefix
-      fill="clear"
-      color="secondary"
-      [iconOnly]="true"
-      *ngIf="locations.length === 0"
-    >
-      <mat-icon icon svgIcon="search-small"></mat-icon>
-    </mzima-client-button>
-    <ul id="search-results" class="search-results">
-      <li *ngFor="let location of locations" (click)="selectLocation(location)">
-        {{ location.display_name }}
-      </li>
-    </ul>
-    </mat-form-field>
-  </div>
-</div>
+<div class="form-row search" [data-qa]="'location-search'">
+<mat-form-field appearance="outline">
+  <input
+    id="search-input"  
+    matInput
+    (keyup)="query$.next($event)"
+    placeholder="{{ 'post.location.search_address' | translate }}"
+    [data-qa]="'query-location'"
+/>
+
+<mzima-client-button 
+[iconOnly]="true" 
+fill="clear" 
+matSuffix 
+color="secondary">
+  <mat-icon icon svgIcon="search-small"></mat-icon>
+</mzima-client-button>
+</mat-form-field>
+
+<ul
+class="geocoder-list"
+*ngIf="locations && locations.length > 0"
+[data-qa]="'geocoder-list'"
+>
+<li
+  class="geocoder-list__item"
+  *ngFor="let location of locations"
+  (click)="selectLocation(location)"
+  [data-qa]="'geocoder-list-item'"
+>
+  {{ location.display_name }}
+</li>
+</ul>
+</div>  
+<div id="ol-map" class="map-container"></div>
+
+
 
 
 

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.scss
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.scss
@@ -13,14 +13,7 @@
   margin-bottom: 8px;
   margin-top:8px;
 }
-::ng-deep {
-  .ol-zoom {
-    top: 418px;
-    @include breakpoint-max($mobile) {
-      top: 190px;
-    }
-}
-}
+
 
 #geocode-input,
 #geocode-button {
@@ -35,7 +28,6 @@
 .geocoder-list {
   list-style: none;
   margin-top: 0;
-  //background: var(--color-neutral-20);
   border: 1px solid var(--color-neutral-60);
   padding: 10px;
   top: -5px;

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.scss
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.scss
@@ -1,103 +1,28 @@
-.map-holder {
-  min-height: 240px;
-  position: relative;
-  margin-bottom: 16px;
+@import 'helpers';
 
-  &:before {
-    content: '';
-    display: block;
-    padding-top: 60%;
+#ol-map {
+  height: 468px;
+  @include breakpoint-max($mobile) {
+    height: 240px;
   }
-
-  .map {
-    top: 0;
-    left: 0;
-    z-index: 25;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-  }
+  
 }
-
-.instructions {
-  display: block;
-  font-style: italic;
-  margin-bottom: 8px;
-}
-
-.btn-current-location {
-  bottom: 80px;
-  left: 10px;
-  width: 33px;
-  height: 33px;
-  z-index: 50;
-  position: absolute;
-  background-color: #fff;
-  padding: 2px;
-  border: 2px solid rgba(0, 0, 0, 0.2);
-  border-radius: 4px;
-  cursor: pointer;
-
-  &_icon {
-    font-size: 24px;
-  }
-}
-
-.location-error {
-  color: var(--color-accent);
-
-  &::ng-deep {
-    .mat-form-field-outline-thick {
-      .mat-form-field-outline-end {
-        border-color: transparent;
-      }
-    }
-  }
-
-  & input {
-    border: 1px solid var(--color-accent);
-  }
-}
-
 ::ng-deep {
-  .leaflet-top.leaflet-left {
-    width: 100%;
-  }
-
-  .leaflet-touch .leaflet-control-geocoder {
-    top: 16px;
-    left: 16px;
-    padding: 7px;
-    right: 16px;
-    z-index: 50;
-    position: absolute;
-    border-radius: 4px;
-    box-shadow: 0 0 2px rgb(0 0 0 / 12%), 0 2px 2px rgb(0 0 0 / 24%);
-    margin: 0;
-    border: none;
-  }
-
-  .leaflet-control-geocoder-form {
-    width: calc(100% - 30px);
-
-    input {
-      width: 100%;
+  .ol-zoom {
+    top: 418px;
+    @include breakpoint-max($mobile) {
+      top: 190px;
     }
-  }
+}
+}
 
-  .leaflet-control-geocoder-alternatives {
-    width: 100%;
+#geocode-input,
+#geocode-button {
+  font-size: 16px;
+  margin: 0 2px 0 0;
+  padding: 4px 8px;
+}
 
-    li {
-      display: flex;
-      position: relative;
-      align-items: center;
-      justify-content: flex-start;
-      overflow: hidden;
-      padding: 5px 16px;
-      user-select: none;
-      cursor: pointer;
-      min-height: 48px;
-    }
-  }
+#geocode-input {
+  width: 300px;
 }

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.scss
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.scss
@@ -5,7 +5,13 @@
   @include breakpoint-max($mobile) {
     height: 240px;
   }
-  
+}
+
+.instructions {
+  display: block;
+  font-style: italic;
+  margin-bottom: 8px;
+  margin-top:8px;
 }
 ::ng-deep {
   .ol-zoom {
@@ -25,4 +31,26 @@
 
 #geocode-input {
   width: 300px;
+}
+.geocoder-list {
+  list-style: none;
+  margin-top: 0;
+  //background: var(--color-neutral-20);
+  border: 1px solid var(--color-neutral-60);
+  padding: 10px;
+  top: -5px;
+  display: block;
+  position: inherit;
+  border-radius: 5px;
+
+  &__item {
+    cursor: pointer;
+    &:not(:last-child) {
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--color-neutral-60);
+    }
+    &:not(:first-child) {
+      padding-top: 10px;
+    }
+  }
 }

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
@@ -1,11 +1,4 @@
-import {
-  AfterViewInit,
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { mapHelper } from '@helpers';
 import { MapConfigInterface } from '@models';
 import { TranslateService } from '@ngx-translate/core';
@@ -32,7 +25,7 @@ import 'leaflet.markercluster';
   templateUrl: './location-select.component.html',
   styleUrls: ['./location-select.component.scss'],
 })
-export class LocationSelectComponent implements OnInit, AfterViewInit {
+export class LocationSelectComponent implements OnInit {
   @Input() public zoom: number;
   @Input() public location: any;
   @Input() public required: boolean;
@@ -54,10 +47,7 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
   public query$: Subject<any> = new Subject<any>();
   private markerLayer: VectorLayer;
 
-  constructor(
-    private sessionService: SessionService,
-    private translate: TranslateService,
-  ) {
+  constructor(private sessionService: SessionService, private translate: TranslateService) {
     this.query$
       .pipe(
         debounceTime(250),
@@ -100,10 +90,9 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
       const geolocation = toLonLat(coordinate);
       this.location = { lat: geolocation[1], lng: geolocation[0] };
       this.setMarker();
+      this.changeCoords();
     });
   }
-
-  ngAfterViewInit(): void {}
 
   public searchLocation(query: string) {
     fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${query}`)
@@ -143,7 +132,7 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
       }),
     });
     this.map.addLayer(this.markerLayer);
-}
+  }
 
   private getMapConfigurations(): MapConfigInterface {
     return this.sessionService.getMapConfigurations();

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
@@ -94,7 +94,9 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
       layers: [currentLayer],
       target: 'ol-map',
     });
-    this.setMarker();
+    if (this.isEditPost) {
+      this.setMarker();
+    }
     this.map.on('click', (evt) => {
       const coordinate = evt.coordinate;
       const geolocation = toLonLat(coordinate);
@@ -119,7 +121,8 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
 
   public selectLocation(location: any) {
     this.location = { lat: location.lat, lng: location.lon };
-    this.setMarker(fromLonLat(this.location.lng, this.location.lat));
+    this.locations = [];
+    this.setMarker(fromLonLat([this.location.lng, this.location.lat]));
     this.locations = [];
     this.changeCoords();
   }
@@ -151,24 +154,6 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
   }
   private getMapConfigurations(): MapConfigInterface {
     return this.sessionService.getMapConfigurations();
-  }
-
-  public onMapReady(map: Map) {}
-
-  private addMarker() {
-    // this.checkErrors();
-    // if (this.mapMarker) {
-    //   this.map.removeLayer(this.mapMarker);
-    // }
-    // this.mapMarker = marker(this.location, {
-    //   draggable: true,
-    //   icon: pointIcon(this.color, this.type === 'web' ? 'default' : this.type),
-    // }).addTo(this.map);
-    // this.mapMarker.on('dragend', (e) => {
-    //   this.location = e.target.getLatLng();
-    //   this.checkErrors();
-    //   this.cdr.detectChanges();
-    // });
   }
 
   private changeCoords(error = false) {

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
@@ -94,6 +94,7 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
       layers: [currentLayer],
       target: 'ol-map',
     });
+    this.setMarker();
   }
 
   ngAfterViewInit(): void {}
@@ -113,12 +114,18 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
   public selectLocation(location: any) {
     if (this.markerLayer) this.map.removeLayer(this.markerLayer);
     this.location = { lat: location.lat, lng: location.lon };
+    this.setMarker();
+    this.locations = [];
+    this.changeCoords();
+  }
+
+  private setMarker() {
     const view = new View({
-      center: fromLonLat([location.lon, location.lat]),
+      center: fromLonLat([this.location.lng, this.location.lat]),
       zoom: this.mapConfig.default_view?.zoom || 10,
     });
     const marker = new Feature({
-      geometry: new Point(fromLonLat([location.lon, location.lat])),
+      geometry: new Point(fromLonLat([this.location.lng, this.location.lat])),
     });
 
     this.markerLayer = new VectorLayer({
@@ -134,8 +141,6 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
     });
     this.map.addLayer(this.markerLayer);
     this.map.setView(view);
-    this.locations = [];
-    this.changeCoords();
   }
   private getMapConfigurations(): MapConfigInterface {
     return this.sessionService.getMapConfigurations();

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
@@ -15,7 +15,7 @@ import Map from 'ol/Map';
 import TileLayer from 'ol/layer/Tile';
 import XYZ from 'ol/source/XYZ';
 import View from 'ol/View';
-import { fromLonLat } from 'ol/proj';
+import { fromLonLat, toLonLat } from 'ol/proj';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import Feature from 'ol/Feature';
@@ -95,6 +95,12 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
       target: 'ol-map',
     });
     this.setMarker();
+    this.map.on('click', (evt) => {
+      const coordinate = evt.coordinate;
+      const geolocation = toLonLat(coordinate);
+      this.location = { lat: geolocation[1], lng: geolocation[0] };
+      this.setMarker([0, 0]);
+    });
   }
 
   ngAfterViewInit(): void {}
@@ -112,16 +118,17 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
   }
 
   public selectLocation(location: any) {
-    if (this.markerLayer) this.map.removeLayer(this.markerLayer);
     this.location = { lat: location.lat, lng: location.lon };
-    this.setMarker();
+    this.setMarker(fromLonLat(this.location.lng, this.location.lat));
     this.locations = [];
     this.changeCoords();
   }
 
-  private setMarker() {
+  private setMarker(center?: any) {
+    if (this.markerLayer) this.map.removeLayer(this.markerLayer);
+    if (!center) center = [0, 0];
     const view = new View({
-      center: fromLonLat([this.location.lng, this.location.lat]),
+      center: center,
       zoom: this.mapConfig.default_view?.zoom || 10,
     });
     const marker = new Feature({

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
@@ -1,6 +1,5 @@
 import {
   AfterViewInit,
-  ChangeDetectorRef,
   Component,
   EventEmitter,
   Input,
@@ -57,7 +56,6 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
 
   constructor(
     private sessionService: SessionService,
-    private cdr: ChangeDetectorRef,
     private translate: TranslateService,
   ) {
     this.query$
@@ -101,7 +99,7 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
       const coordinate = evt.coordinate;
       const geolocation = toLonLat(coordinate);
       this.location = { lat: geolocation[1], lng: geolocation[0] };
-      this.setMarker([0, 0]);
+      this.setMarker();
     });
   }
 
@@ -122,18 +120,13 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
   public selectLocation(location: any) {
     this.location = { lat: location.lat, lng: location.lon };
     this.locations = [];
-    this.setMarker(fromLonLat([this.location.lng, this.location.lat]));
+    this.setMarker();
     this.locations = [];
     this.changeCoords();
   }
 
-  private setMarker(center?: any) {
+  private setMarker() {
     if (this.markerLayer) this.map.removeLayer(this.markerLayer);
-    if (!center) center = [0, 0];
-    const view = new View({
-      center: center,
-      zoom: this.mapConfig.default_view?.zoom || 10,
-    });
     const marker = new Feature({
       geometry: new Point(fromLonLat([this.location.lng, this.location.lat])),
     });
@@ -150,15 +143,14 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
       }),
     });
     this.map.addLayer(this.markerLayer);
-    this.map.setView(view);
-  }
+}
+
   private getMapConfigurations(): MapConfigInterface {
     return this.sessionService.getMapConfigurations();
   }
 
   private changeCoords(error = false) {
     this.locationChange.emit({ location: this.location, error });
-    this.cdr.detectChanges();
   }
 
   public checkErrors() {
@@ -170,18 +162,6 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
     }
 
     this.changeCoords(this.emptyFieldLat || this.emptyFieldLng);
-  }
-
-  public getCurrentLocation() {
-    // navigator.geolocation.getCurrentPosition((position) => {
-    //   const {
-    //     coords: { latitude, longitude },
-    //   } = position;
-    //   this.location.lat = latitude;
-    //   this.location.lng = longitude;
-    //   this.addMarker();
-    //   this.map.setView([latitude, longitude], 12);
-    // });
   }
 
   public onFocusOut() {

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
@@ -11,23 +11,21 @@ import { mapHelper } from '@helpers';
 import { MapConfigInterface } from '@models';
 import { TranslateService } from '@ngx-translate/core';
 import { SessionService } from '@services';
-import {
-  control,
-  FitBoundsOptions,
-  LatLngBounds,
-  LatLngLiteral,
-  Map,
-  MapOptions,
-  marker,
-  Marker,
-  MarkerClusterGroupOptions,
-  tileLayer,
-} from 'leaflet';
-import 'leaflet.markercluster';
-import { pointIcon } from '../../core/helpers/map';
-import Geocoder from 'leaflet-control-geocoder';
-import { fromEvent, filter, debounceTime, distinctUntilChanged, tap } from 'rxjs';
+import Map from 'ol/Map';
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
+import View from 'ol/View';
+import { fromLonLat } from 'ol/proj';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
+import Style from 'ol/style/Style';
+import { distinctUntilChanged, tap, Subject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Point } from 'ol/geom';
+import Icon from 'ol/style/Icon';
+import 'leaflet.markercluster';
 
 @UntilDestroy()
 @Component({
@@ -36,7 +34,6 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
   styleUrls: ['./location-select.component.scss'],
 })
 export class LocationSelectComponent implements OnInit, AfterViewInit {
-  @Input() public center: LatLngLiteral;
   @Input() public zoom: number;
   @Input() public location: any;
   @Input() public required: boolean;
@@ -44,6 +41,7 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
   @Input() public type = 'default';
   @Input() public isEditPost: boolean = false;
   @Output() locationChange = new EventEmitter();
+  public searchTerm: string = '';
   public emptyFieldLat = false;
   public emptyFieldLng = false;
   public noSpecialCharactersLat = false;
@@ -52,121 +50,113 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
   public mapLayers: any[] = [];
   public mapReady = false;
   public mapConfig: MapConfigInterface;
-  public markerClusterOptions: MarkerClusterGroupOptions = {
-    animate: true,
-    maxClusterRadius: 50,
-  };
-  public mapFitToBounds: LatLngBounds;
-  public fitBoundsOptions: FitBoundsOptions = {
-    animate: true,
-  };
-  public mapMarker: Marker;
-  public leafletOptions: MapOptions;
   public disabled = false;
-  public geocoderControl: any;
+  public locations: any[] = [];
+  public query$: Subject<any> = new Subject<any>();
+  private markerLayer: VectorLayer;
 
   constructor(
     private sessionService: SessionService,
     private cdr: ChangeDetectorRef,
     private translate: TranslateService,
-  ) {}
-
-  ngOnInit(): void {
-    this.mapConfig = this.getMapConfigurations();
-
-    if (!this.isEditPost && !this.location.lat) {
-      this.location.lat = this.mapConfig.default_view!.lat;
-      this.location.lng = this.mapConfig.default_view!.lon;
-    }
-
-    const currentLayer =
-      mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
-
-    this.leafletOptions = {
-      scrollWheelZoom: true,
-      zoomControl: false,
-      worldCopyJump: true,
-      layers: [tileLayer(currentLayer.url, currentLayer.layerOptions)],
-      center: [
-        this.location?.lat || this.mapConfig.default_view!.lat,
-        this.location?.lng || this.mapConfig.default_view!.lon,
-      ],
-      zoom: this.mapConfig.default_view!.zoom || this.zoom,
-    };
-    this.markerClusterOptions.maxClusterRadius = this.mapConfig.cluster_radius;
-
-    this.mapReady = true;
-  }
-
-  ngAfterViewInit() {
-    // change tracking for search when entering text in geocoder search input (and debounce to reduce geocoding requests sent)
-    const geocoderInputElement = this.geocoderControl.getContainer().querySelector('input');
-    geocoderInputElement.setAttribute('data-qa', 'location-search');
-    fromEvent(geocoderInputElement, 'input')
+  ) {
+    this.query$
       .pipe(
-        filter(Boolean),
-        debounceTime(600),
+        debounceTime(250),
         distinctUntilChanged(),
-        tap(() => {
-          this.geocoderControl.options.placeholder = geocoderInputElement.value;
-          this.geocoderControl._input.value = geocoderInputElement.value;
-          this.geocoderControl._geocode();
-        }),
+        tap(({ target: { value } }) => this.searchLocation(value)),
         untilDestroyed(this),
       )
       .subscribe();
   }
 
+  ngOnInit(): void {
+    this.mapConfig = this.sessionService.getMapConfigurations();
+    if (!this.isEditPost && !this.location.lat) {
+      this.location.lat = this.mapConfig.default_view!.lat;
+      this.location.lng = this.mapConfig.default_view!.lon;
+    }
+    const baseLayer = mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
+    const currentLayer = new TileLayer({
+      visible: true,
+      source: new XYZ({
+        url: baseLayer.url,
+        maxZoom: 'maxZoom' in baseLayer.layerOptions ? baseLayer.layerOptions.maxZoom : undefined,
+      }),
+    });
+    const view = new View({
+      center: fromLonLat([this.location.lng, this.location.lat]),
+      zoom: this.mapConfig.default_view?.zoom || 2,
+    });
+
+    this.map = new Map({
+      view: view,
+      layers: [currentLayer],
+      target: 'ol-map',
+    });
+  }
+
+  ngAfterViewInit(): void {}
+
+  public searchLocation(query: string) {
+    fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${query}`)
+      .then((response) => response.json())
+      .then((data) => {
+        this.locations = data.length > 0 ? data : [];
+      })
+      .catch((error) => {
+        console.error('Error fetching location data:', error);
+        this.locations = [];
+      });
+  }
+
+  public selectLocation(location: any) {
+    if (this.markerLayer) this.map.removeLayer(this.markerLayer);
+    this.location = { lat: location.lat, lng: location.lon };
+    const view = new View({
+      center: fromLonLat([location.lon, location.lat]),
+      zoom: this.mapConfig.default_view?.zoom || 10,
+    });
+    const marker = new Feature({
+      geometry: new Point(fromLonLat([location.lon, location.lat])),
+    });
+
+    this.markerLayer = new VectorLayer({
+      source: new VectorSource({
+        features: [marker],
+      }),
+      style: new Style({
+        image: new Icon({
+          anchor: [0.5, 1],
+          src: mapHelper.imageIcon('default'),
+        }),
+      }),
+    });
+    this.map.addLayer(this.markerLayer);
+    this.map.setView(view);
+    this.locations = [];
+    this.changeCoords();
+  }
   private getMapConfigurations(): MapConfigInterface {
     return this.sessionService.getMapConfigurations();
   }
 
-  public onMapReady(map: Map) {
-    // Initialize geocoder
-    this.geocoderControl = new Geocoder({
-      defaultMarkGeocode: false,
-      position: 'topleft',
-      collapsed: false,
-      placeholder: this.translate.instant('post.location.search_address'),
-      errorMessage: this.translate.instant('post.location.nothing_found'),
-    });
-
-    this.map = map;
-    control.zoom({ position: 'bottomleft' }).addTo(this.map);
-    this.map.panTo(this.location);
-    this.geocoderControl.addTo(this.map);
-
-    this.addMarker();
-
-    this.map.on('click', (e) => {
-      this.location = e.latlng.wrap();
-      this.addMarker();
-      this.cdr.detectChanges();
-    });
-
-    // Listen event markgeocode from geocoder
-    this.geocoderControl.on('markgeocode', (e: any) => {
-      this.location = e.geocode.center;
-      this.addMarker();
-      this.map.fitBounds(e.geocode.bbox);
-    });
-  }
+  public onMapReady(map: Map) {}
 
   private addMarker() {
-    this.checkErrors();
-    if (this.mapMarker) {
-      this.map.removeLayer(this.mapMarker);
-    }
-    this.mapMarker = marker(this.location, {
-      draggable: true,
-      icon: pointIcon(this.color, this.type === 'web' ? 'default' : this.type),
-    }).addTo(this.map);
-
-    this.mapMarker.on('dragend', (e) => {
-      this.location = e.target.getLatLng();
-      this.checkErrors();
-      this.cdr.detectChanges();
-    });
+    // this.checkErrors();
+    // if (this.mapMarker) {
+    //   this.map.removeLayer(this.mapMarker);
+    // }
+    // this.mapMarker = marker(this.location, {
+    //   draggable: true,
+    //   icon: pointIcon(this.color, this.type === 'web' ? 'default' : this.type),
+    // }).addTo(this.map);
+    // this.mapMarker.on('dragend', (e) => {
+    //   this.location = e.target.getLatLng();
+    //   this.checkErrors();
+    //   this.cdr.detectChanges();
+    // });
   }
 
   private changeCoords(error = false) {
@@ -186,15 +176,15 @@ export class LocationSelectComponent implements OnInit, AfterViewInit {
   }
 
   public getCurrentLocation() {
-    navigator.geolocation.getCurrentPosition((position) => {
-      const {
-        coords: { latitude, longitude },
-      } = position;
-      this.location.lat = latitude;
-      this.location.lng = longitude;
-      this.addMarker();
-      this.map.setView([latitude, longitude], 12);
-    });
+    // navigator.geolocation.getCurrentPosition((position) => {
+    //   const {
+    //     coords: { latitude, longitude },
+    //   } = position;
+    //   this.location.lat = latitude;
+    //   this.location.lng = longitude;
+    //   this.addMarker();
+    //   this.map.setView([latitude, longitude], 12);
+    // });
   }
 
   public onFocusOut() {

--- a/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
+++ b/apps/web-mzima-client/src/app/post/location-select/location-select.component.ts
@@ -64,34 +64,40 @@ export class LocationSelectComponent implements OnInit {
       this.location.lat = this.mapConfig.default_view!.lat;
       this.location.lng = this.mapConfig.default_view!.lon;
     }
-    const baseLayer = mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
-    const currentLayer = new TileLayer({
-      visible: true,
-      source: new XYZ({
-        url: baseLayer.url,
-        maxZoom: 'maxZoom' in baseLayer.layerOptions ? baseLayer.layerOptions.maxZoom : undefined,
-      }),
-    });
-    const view = new View({
-      center: fromLonLat([this.location.lng, this.location.lat]),
-      zoom: this.mapConfig.default_view?.zoom || 2,
-    });
 
-    this.map = new Map({
-      view: view,
-      layers: [currentLayer],
-      target: 'ol-map',
-    });
-    if (this.isEditPost) {
-      this.setMarker();
+    const baseLayers = mapHelper.getOpenLayersMapConfig().filter((layer) => layer.visible);
+    const visibleLayer =
+      baseLayers.find((layer) => layer.code === this.mapConfig.default_view?.baselayer) ||
+      baseLayers.find((layer) => layer.code === 'streets');
+
+    if (visibleLayer) {
+      this.map = new Map({
+        view: new View({
+          center: fromLonLat([this.location.lng, this.location.lat]),
+          zoom: this.mapConfig.default_view?.zoom || 2,
+        }),
+        layers: [
+          new TileLayer({
+            visible: true,
+            source: new XYZ({
+              url: visibleLayer.url,
+            }),
+          }),
+        ],
+        target: 'ol-map',
+      });
+
+      if (this.isEditPost) {
+        this.setMarker();
+      }
+
+      this.map.on('click', (evt) => {
+        const [lng, lat] = toLonLat(evt.coordinate);
+        this.location = { lat, lng };
+        this.setMarker();
+        this.changeCoords();
+      });
     }
-    this.map.on('click', (evt) => {
-      const coordinate = evt.coordinate;
-      const geolocation = toLonLat(coordinate);
-      this.location = { lat: geolocation[1], lng: geolocation[0] };
-      this.setMarker();
-      this.changeCoords();
-    });
   }
 
   public searchLocation(query: string) {

--- a/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
+++ b/apps/web-mzima-client/src/app/post/post-details/post-details.component.html
@@ -98,7 +98,7 @@
                 <app-map-with-marker
                   class="map"
                   [marker]="field.value.value"
-                  [color]="color || 'var(--color-neutral-100)'"
+                  [color]="post.color || 'var(--color-neutral-100)'"
                   [type]="post.source?.toLowerCase() || 'default'"
                   tabindex="-1"
                   data-qa="postLocationMap"

--- a/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.html
+++ b/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.html
@@ -1,13 +1,1 @@
-<div class="map-holder">
-  <div
-    leaflet
-    class="map"
-    tabindex="-1"
-    *ngIf="mapReady"
-    [leafletLayers]="mapLayers"
-    [leafletOptions]="leafletOptions"
-    [leafletFitBounds]="mapFitToBounds"
-    (leafletMapReady)="onMapReady($event)"
-    [leafletFitBoundsOptions]="fitBoundsOptions"
-  ></div>
-</div>
+<div class="map-holder"><div id="ol-map" class="map-container"></div></div>

--- a/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.scss
+++ b/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.scss
@@ -1,18 +1,9 @@
-.map-holder {
-  max-height: 450px;
-  position: relative;
+@import 'helpers';
 
-  &:before {
-    content: '';
-    display: block;
-    padding-top: 66.6666%;
-  }
-}
-
-.map {
-  top: 0;
-  left: 0;
+#ol-map {
+  height: 450px;
   width: 100%;
-  height: 100%;
-  position: absolute;
+  @include breakpoint-max($mobile) {
+    height: 240px;
+  }
 }

--- a/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, AfterViewInit } from '@angular/core';
+import { Component, Input, OnDestroy, AfterViewInit } from '@angular/core';
 import { mapHelper } from '@helpers';
 import { MapConfigInterface } from '@models';
 import Map from 'ol/Map';
@@ -20,7 +20,7 @@ import { UntilDestroy } from '@ngneat/until-destroy';
   templateUrl: './map-with-marker.component.html',
   styleUrls: ['./map-with-marker.component.scss'],
 })
-export class MapWithMarkerComponent implements OnInit, OnDestroy, AfterViewInit {
+export class MapWithMarkerComponent implements OnDestroy, AfterViewInit {
   @Input() public marker: { lat: number; lon: number };
   @Input() public color = 'var(--color-neutral-100)';
   @Input() public type = 'default';
@@ -30,45 +30,49 @@ export class MapWithMarkerComponent implements OnInit, OnDestroy, AfterViewInit 
   private markerLayer: VectorLayer;
 
   constructor(private sessionService: SessionService) {}
-  ngOnInit(): void {}
+
   ngAfterViewInit() {
-
     this.mapConfig = this.sessionService.getMapConfigurations();
-    const baseLayer = mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
-    const currentLayer = new TileLayer({
-      visible: true,
-      source: new XYZ({
-        url: baseLayer.url,
-        maxZoom: 'maxZoom' in baseLayer.layerOptions ? baseLayer.layerOptions.maxZoom : undefined,
-      }),
-    });
-    const view = new View({
-      center: fromLonLat([this.marker.lon, this.marker.lat]),
-      zoom: this.mapConfig.default_view?.zoom || 2,
-    });
+    const baseLayers = mapHelper.getOpenLayersMapConfig().filter((layer) => layer.visible);
+    const visibleLayer =
+      baseLayers.find((layer) => layer.code === this.mapConfig.default_view?.baselayer) ||
+      baseLayers.find((layer) => layer.code === 'streets');
 
-    this.map = new Map({
-      view: view,
-      layers: [currentLayer],
-      target: 'ol-map',
-    });
-
-    const marker = new Feature({
-      geometry: new Point(fromLonLat([this.marker.lon, this.marker.lat])),
-    });
-
-    this.markerLayer = new VectorLayer({
-      source: new VectorSource({
-        features: [marker],
-      }),
-      style: new Style({
-        image: new Icon({
-          anchor: [0.5, 1],
-          src: mapHelper.imageIcon(this.color),
+    if (visibleLayer) {
+      const currentLayer = new TileLayer({
+        visible: true,
+        source: new XYZ({
+          url: visibleLayer.url,
         }),
-      }),
-    });
-    this.map.addLayer(this.markerLayer);
+      });
+      const view = new View({
+        center: fromLonLat([this.marker.lon, this.marker.lat]),
+        zoom: this.mapConfig.default_view?.zoom || 2,
+      });
+
+      this.map = new Map({
+        view: view,
+        layers: [currentLayer],
+        target: 'ol-map',
+      });
+
+      const marker = new Feature({
+        geometry: new Point(fromLonLat([this.marker.lon, this.marker.lat])),
+      });
+
+      this.markerLayer = new VectorLayer({
+        source: new VectorSource({
+          features: [marker],
+        }),
+        style: new Style({
+          image: new Icon({
+            anchor: [0.5, 1],
+            src: mapHelper.imageIcon(this.color),
+          }),
+        }),
+      });
+      this.map.addLayer(this.markerLayer);
+    }
   }
   ngOnDestroy(): void {
     this.map.dispose();

--- a/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.ts
@@ -1,16 +1,17 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { mapHelper } from '@helpers';
 import { MapConfigInterface } from '@models';
-import {
-  control,
-  FitBoundsOptions,
-  LatLngBounds,
-  Map,
-  MapOptions,
-  tileLayer,
-  marker,
-} from 'leaflet';
-import { pointIcon } from '../../../core/helpers/map';
+import Map from 'ol/Map';
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
+import View from 'ol/View';
+import { fromLonLat } from 'ol/proj';
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import Style from 'ol/style/Style';
+import Icon from 'ol/style/Icon';
 import { SessionService } from '../../../core/services/session.service';
 
 @Component({
@@ -23,46 +24,47 @@ export class MapWithMarkerComponent implements OnInit {
   @Input() public color = 'var(--color-neutral-100)';
   @Input() public type = 'default';
 
-  public mapReady = false;
   public mapConfig: MapConfigInterface;
-  public leafletOptions: MapOptions;
-  public mapFitToBounds: LatLngBounds;
-  public fitBoundsOptions: FitBoundsOptions = {
-    animate: true,
-  };
-  public mapLayers: any[] = [];
+  private map: Map;
+  private markerLayer: VectorLayer;
 
   constructor(private sessionService: SessionService) {}
-
   ngOnInit(): void {
     this.mapConfig = this.sessionService.getMapConfigurations();
+    const baseLayer = mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
+    const currentLayer = new TileLayer({
+      visible: true,
+      source: new XYZ({
+        url: baseLayer.url,
+        maxZoom: 'maxZoom' in baseLayer.layerOptions ? baseLayer.layerOptions.maxZoom : undefined,
+      }),
+    });
+    const view = new View({
+      center: fromLonLat([this.marker.lon, this.marker.lat]),
+      zoom: this.mapConfig.default_view?.zoom || 2,
+    });
 
-    const currentLayer =
-      mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
+    this.map = new Map({
+      view: view,
+      layers: [currentLayer],
+      target: 'ol-map',
+    });
 
-    this.leafletOptions = {
-      scrollWheelZoom: true,
-      zoomControl: false,
-      layers: [tileLayer(currentLayer.url, currentLayer.layerOptions)],
-      center: [this.marker.lat, this.marker.lon],
-      zoom: this.mapConfig.default_view!.zoom,
-    };
+    const marker = new Feature({
+      geometry: new Point(fromLonLat([this.marker.lon, this.marker.lat])),
+    });
 
-    const mapMarker = marker(
-      {
-        lat: this.marker.lat,
-        lng: this.marker.lon,
-      },
-      {
-        icon: pointIcon(this.color, this.type === 'web' ? 'default' : this.type),
-      },
-    );
-    this.mapLayers.push(mapMarker);
-
-    this.mapReady = true;
-  }
-
-  public onMapReady(map: Map) {
-    control.zoom({ position: 'bottomleft' }).addTo(map);
+    this.markerLayer = new VectorLayer({
+      source: new VectorSource({
+        features: [marker],
+      }),
+      style: new Style({
+        image: new Icon({
+          anchor: [0.5, 1],
+          src: mapHelper.imageIcon(this.color),
+        }),
+      }),
+    });
+    this.map.addLayer(this.markerLayer);
   }
 }

--- a/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.ts
+++ b/apps/web-mzima-client/src/app/shared/components/map-with-marker/map-with-marker.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, AfterViewInit } from '@angular/core';
 import { mapHelper } from '@helpers';
 import { MapConfigInterface } from '@models';
 import Map from 'ol/Map';
@@ -13,13 +13,14 @@ import VectorSource from 'ol/source/Vector';
 import Style from 'ol/style/Style';
 import Icon from 'ol/style/Icon';
 import { SessionService } from '../../../core/services/session.service';
-
+import { UntilDestroy } from '@ngneat/until-destroy';
+@UntilDestroy()
 @Component({
   selector: 'app-map-with-marker',
   templateUrl: './map-with-marker.component.html',
   styleUrls: ['./map-with-marker.component.scss'],
 })
-export class MapWithMarkerComponent implements OnInit {
+export class MapWithMarkerComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() public marker: { lat: number; lon: number };
   @Input() public color = 'var(--color-neutral-100)';
   @Input() public type = 'default';
@@ -29,7 +30,9 @@ export class MapWithMarkerComponent implements OnInit {
   private markerLayer: VectorLayer;
 
   constructor(private sessionService: SessionService) {}
-  ngOnInit(): void {
+  ngOnInit(): void {}
+  ngAfterViewInit() {
+
     this.mapConfig = this.sessionService.getMapConfigurations();
     const baseLayer = mapHelper.getMapLayers().baselayers[this.mapConfig.default_view!.baselayer];
     const currentLayer = new TileLayer({
@@ -66,5 +69,8 @@ export class MapWithMarkerComponent implements OnInit {
       }),
     });
     this.map.addLayer(this.markerLayer);
+  }
+  ngOnDestroy(): void {
+    this.map.dispose();
   }
 }


### PR DESCRIPTION
This PR is exchanging Leaflet with OpenLayers when creating, editing and viewing a post:
To test:
1. Add a post to a survey with location:
- [x] Make sure the map is displayed with the selected basemap
- [x] Search for a location, the selected location displays with a pin on the map
- [x] Click on the map, make sure the pin is put in the clicked position
- [x] lat/long fields are updated properly
2. Save the post and open the post from data-view
- [x] The post is shown with the map
- [x] The pin is located on the right place
3. Edit the post
- [ ] Make sure the map is displayed with the selected basemap
- [x] Search for a location, the selected location displays with a pin on the map
- [x] Click on the map, make sure the pin is put in the clicked position
- [x] lat/long fields are updated properly


Note: There is a mismatch when looking at posts on the post-details modal. I have created a new ticket for that because it is likely not connected to openLayers but to something with how the post-modal is handled (needs to be worked on before map is released though!). New ticket: https://linear.app/ushahidi/issue/USH-1808/show-map-when-viewing-post-on-smaller-screens-and-on-map-modal